### PR TITLE
fix(backend): install TXL for Python generation and add e2e tests

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,6 +7,15 @@ RUN go mod tidy && CGO_ENABLED=0 go build -o /server ./cmd/server
 
 FROM eclipse-temurin:17-jdk-alpine
 RUN apk add --no-cache graphviz python3
+
+# TXL (required for Python code generation) is a glibc binary.
+# Install glibc compatibility layer for Alpine.
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+ && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk \
+ && apk add --no-cache --force-overwrite glibc-2.35-r1.apk \
+ && rm glibc-2.35-r1.apk \
+ && mkdir -p /lib64 \
+ && ln -sf /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 WORKDIR /app
 COPY --from=builder /server /app/server
 RUN mkdir -p /data/models /examples

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,6 +1,17 @@
 FROM golang:1.23-alpine
 
 RUN apk add --no-cache graphviz openjdk17-jdk python3
+
+# TXL (required for Python code generation) is a glibc binary.
+# Install glibc compatibility layer for Alpine and create the /lib64 symlink
+# that the dynamic linker path (hardcoded in the ELF binary) expects.
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+ && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk \
+ && apk add --no-cache --force-overwrite glibc-2.35-r1.apk \
+ && rm glibc-2.35-r1.apk \
+ && mkdir -p /lib64 \
+ && ln -sf /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
 RUN go install github.com/air-verse/air@v1.61.7
 
 WORKDIR /app

--- a/backend/internal/api/handlers/generate.go
+++ b/backend/internal/api/handlers/generate.go
@@ -414,6 +414,8 @@ func languageExtensions(lang string) []string {
 		return []string{".uml", ".notation", ".di", ".project"}
 	case "Scxml":
 		return []string{".scxml"}
+	case "Mermaid":
+		return []string{".mermaid"}
 	default:
 		return nil
 	}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,6 +6,8 @@ services:
       - ./data/models:/data/models
       - ./jars:/jars:ro
       - ./examples:/examples:ro
+      - /usr/local/bin/txl:/usr/local/bin/txl:ro
+      - /usr/local/lib/txl:/usr/local/lib/txl:ro
     environment:
       - UMPLE_JAR=/jars/umple.jar
       - MODEL_STORE_PATH=/data/models

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - ./data/models:/data/models
       - ./jars:/jars:ro
       - ./examples:/examples:ro
+      - /usr/local/bin/txl:/usr/local/bin/txl:ro
+      - /usr/local/lib/txl:/usr/local/lib/txl:ro
     environment:
       - UMPLE_JAR=/jars/umple.jar
       - MODEL_STORE_PATH=/data/models

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:live": "PLAYWRIGHT_LIVE_BACKEND=1 playwright test tests/e2e/live-backend.spec.ts",
+    "test:e2e:live": "PLAYWRIGHT_LIVE_BACKEND=1 playwright test tests/e2e/live-backend.spec.ts tests/e2e/live-generate.spec.ts",
     "test:e2e:install": "playwright install chromium",
     "test:e2e:typecheck": "tsc -p tsconfig.playwright.json --noEmit"
   },

--- a/frontend/tests/e2e/live-generate.spec.ts
+++ b/frontend/tests/e2e/live-generate.spec.ts
@@ -1,0 +1,272 @@
+/**
+ * Live Backend E2E Tests — Code Generation
+ *
+ * Tests every generation target against the real backend to verify
+ * that each language produces meaningful output.
+ *
+ * Requires `make dev` running, then: `PLAYWRIGHT_LIVE_BACKEND=1 bun run test:e2e`
+ */
+import { expect, test, type Page } from '@playwright/test'
+import { GENERATE_TARGETS, type GenerateTarget } from '../../src/generation/targets'
+
+test.skip(
+  !process.env.PLAYWRIGHT_LIVE_BACKEND,
+  'Set PLAYWRIGHT_LIVE_BACKEND=1 to run against the real backend stack.',
+)
+
+/* ── Test data ── */
+
+/** Umple model with classes, attributes, associations, and a state machine. */
+const UMPLE_MODEL = `class Student {
+  name;
+  Integer id;
+  status {
+    Active {
+      graduate -> Graduated;
+      suspend -> Suspended;
+    }
+    Suspended {
+      reinstate -> Active;
+    }
+    Graduated {}
+  }
+}
+
+class Course {
+  title;
+  Integer credits;
+}
+
+association {
+  * Student -- * Course;
+}
+`
+
+/** Generation targets that use the 'generate' action (not 'diagram'). */
+const GENERATE_ACTION_TARGETS = GENERATE_TARGETS.filter(
+  (t) => t.action === 'generate',
+)
+
+/**
+ * Per-language output expectations. Each entry specifies patterns the output
+ * text (or HTML) must contain to confirm the generator produced real content.
+ */
+const OUTPUT_EXPECTATIONS: Record<string, {
+  /** Patterns the output text must contain (case-insensitive substring match). */
+  outputContains?: string[]
+  /** Expected response kind. */
+  kind?: 'text' | 'html' | 'iframe'
+  /** If true, expect downloads array to be non-empty. */
+  hasDownloads?: boolean
+}> = {
+  Java:                        { outputContains: ['class Student', 'getName', 'getCourses'], kind: 'text' },
+  javadoc:                     { kind: 'iframe', hasDownloads: true },
+  Php:                         { outputContains: ['class Student', 'getName'], kind: 'text' },
+  Python:                      { outputContains: ['class Student', 'getName'], kind: 'text' },
+  RTCpp:                       { outputContains: ['Student'], kind: 'text' },
+  Ruby:                        { outputContains: ['class Student', 'name'], kind: 'text' },
+  Alloy:                       { outputContains: ['sig Student'], kind: 'text' },
+  NuSMV:                       { outputContains: ['MODULE'], kind: 'text' },
+  Ecore:                       { outputContains: ['Student'], kind: 'text' },
+  TextUml:                     { outputContains: ['Student'], kind: 'text' },
+  Scxml:                       { outputContains: ['scxml'], kind: 'text' },
+  Papyrus:                     { hasDownloads: true },
+  Yuml:                        { kind: 'html' },
+  Mermaid:                     { outputContains: ['Student'], kind: 'text' },
+  Json:                        { outputContains: ['Student', 'name'], kind: 'text' },
+  Sql:                         { outputContains: ['CREATE TABLE', 'Student'], kind: 'text' },
+  SimpleMetrics:               { kind: 'html' },
+  PlainRequirementsDoc:        { kind: 'html' },
+  CodeAnalysis:                { kind: 'html' },
+  USE:                         { outputContains: ['Student'], kind: 'text' },
+  UmpleSelf:                   { outputContains: ['Student'], kind: 'text' },
+  UmpleAnnotaiveToComposition: { kind: 'text' },
+  Cpp:                         { outputContains: ['Student'], kind: 'text' },
+  SimpleCpp:                   { outputContains: ['Student'], kind: 'text' },
+  Umlet:                       { outputContains: ['Student'], kind: 'text' },
+  // SimulateJava generator is not available in the current umple.jar build.
+  // The backend returns output="nothing" with an error. We just verify the API responds.
+  SimulateJava:                { kind: 'text' },
+}
+
+/* ── Helpers ── */
+
+interface GenerateApiResponse {
+  output: string
+  language: string
+  errors?: string
+  modelId?: string
+  kind?: string
+  html?: string
+  iframeUrl?: string
+  downloads?: { label: string; url: string; filename?: string }[]
+}
+
+async function generateViaApi(
+  request: Page['request'],
+  baseURL: string,
+  language: string,
+): Promise<GenerateApiResponse> {
+  const res = await request.post(`${baseURL}/api/generate`, {
+    data: { code: UMPLE_MODEL, language },
+  })
+  expect(res.ok(), `POST /api/generate (${language}) returned ${res.status()}`).toBeTruthy()
+  return res.json()
+}
+
+async function setEditorCode(page: Page, code: string) {
+  const editor = page.locator('.cm-content')
+  await editor.click()
+  await page.keyboard.press('Control+a')
+  await page.keyboard.type(code, { delay: 0 })
+}
+
+async function compileAndWait(page: Page) {
+  const compilePromise = page.waitForResponse(
+    (res) => res.url().includes('/api/compile') && res.status() === 200,
+    { timeout: 30_000 },
+  )
+  await page.getByTestId('compile-button').click()
+  await compilePromise
+}
+
+function resolveLanguage(target: GenerateTarget): string {
+  if (target.id === 'Mermaid') return 'Mermaid.class'
+  return target.requestLanguage ?? target.id
+}
+
+/* ── Tests ── */
+
+test.describe('Live backend — code generation targets', () => {
+  test.setTimeout(300_000) // 5 min budget
+
+  test.beforeAll(async ({ request, baseURL }) => {
+    const health = await request.get(`${baseURL}/api/health`)
+    expect(health.ok()).toBeTruthy()
+  })
+
+  test('every generate target produces output via API', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('app-shell')).toBeVisible()
+
+    const failures: string[] = []
+    let passed = 0
+
+    for (const target of GENERATE_ACTION_TARGETS) {
+      const language = resolveLanguage(target)
+      const label = `${target.id} (${language})`
+
+      try {
+        const res = await generateViaApi(page.request, page.url().replace(/\/$/, ''), language)
+        const hasOutput = !!(res.output || res.html || res.iframeUrl)
+
+        if (!hasOutput && !res.errors) {
+          failures.push(`${label} — no output and no errors`)
+          continue
+        }
+
+        if (!hasOutput) {
+          failures.push(`${label} — only errors: ${res.errors?.slice(0, 200)}`)
+          continue
+        }
+
+        // Validate per-language expectations
+        const expectations = OUTPUT_EXPECTATIONS[target.id]
+        if (expectations) {
+          const contentIssues: string[] = []
+
+          // Check output kind
+          if (expectations.kind) {
+            const actualKind = res.kind ?? (res.iframeUrl ? 'iframe' : res.html ? 'html' : 'text')
+            if (actualKind !== expectations.kind) {
+              contentIssues.push(`expected kind=${expectations.kind}, got ${actualKind}`)
+            }
+          }
+
+          // Check output text contains expected patterns
+          if (expectations.outputContains) {
+            const text = (res.output || '').toLowerCase()
+            for (const pattern of expectations.outputContains) {
+              if (!text.includes(pattern.toLowerCase())) {
+                contentIssues.push(`output missing "${pattern}"`)
+              }
+            }
+          }
+
+          // Check downloads
+          if (expectations.hasDownloads && (!res.downloads || res.downloads.length === 0)) {
+            contentIssues.push('expected downloads but got none')
+          }
+
+          if (contentIssues.length > 0) {
+            failures.push(`${label} — ${contentIssues.join('; ')}`)
+            continue
+          }
+        }
+
+        passed++
+      } catch (err) {
+        failures.push(`${label} — ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
+
+    // Report
+    const total = passed + failures.length
+    if (failures.length > 0) {
+      const detail = failures.map((f) => `  • ${f}`).join('\n')
+      expect
+        .soft(failures.length, `${passed}/${total} passed:\n${detail}`)
+        .toBe(0)
+    }
+  })
+
+  test('Mermaid state variant generates state diagram syntax', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('app-shell')).toBeVisible()
+
+    const res = await generateViaApi(page.request, page.url().replace(/\/$/, ''), 'Mermaid.state')
+    expect(res.output.toLowerCase()).toContain('statediagram')
+    expect(res.output).toContain('Active')
+    expect(res.output).toContain('Graduated')
+  })
+
+  test('generate via UI flow shows output in right panel', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('app-shell')).toBeVisible()
+
+    await setEditorCode(page, UMPLE_MODEL)
+    await compileAndWait(page)
+
+    // Generate Java via command palette
+    await page.keyboard.press('Control+k')
+    await expect(page.getByTestId('command-palette')).toBeVisible()
+    await page.getByTestId('command-item-gen-Java').click()
+
+    // Wait for generated code to appear (CodeMirror in the generated panel)
+    await expect(page.locator('.cm-content').last()).toBeVisible({ timeout: 30_000 })
+
+    // Verify the panel is showing generated output
+    await expect(page.locator('[data-testid="diagram-canvas"]')).toBeVisible()
+  })
+
+  test('empty code returns an error, not a crash', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('app-shell')).toBeVisible()
+
+    const res = await page.request.post(`${page.url().replace(/\/$/, '')}/api/generate`, {
+      data: { code: '', language: 'Java' },
+    })
+    // Backend should reject with 400
+    expect(res.status()).toBe(400)
+  })
+
+  test('invalid language returns an error', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('app-shell')).toBeVisible()
+
+    const res = await page.request.post(`${page.url().replace(/\/$/, '')}/api/generate`, {
+      data: { code: UMPLE_MODEL, language: 'NonExistentLanguage' },
+    })
+    expect(res.status()).toBe(400)
+  })
+})


### PR DESCRIPTION
## Summary
- Install glibc compatibility layer in Alpine Docker containers so the TXL binary (required for Python code generation) can run
- Mount host TXL binary and lib into dev/prod containers via docker-compose volumes
- Add missing Mermaid file extension mapping in `generate.go` so downloads work
- Add comprehensive Playwright live-backend test suite (`live-generate.spec.ts`) covering all 26 code generation targets with per-language output validation

## Test plan
- [x] `PLAYWRIGHT_LIVE_BACKEND=1 bun run test:e2e` — all 5 generate tests pass
- [ ] Verify Python generation works in the UI (type Umple code → Generate → Python)
- [ ] Verify Mermaid generation now includes download ZIP link
- [ ] Rebuild prod containers and verify TXL is available