### PR TITLE
refactor: simplify generate tests and DRY Dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.23-alpine AS builder
 WORKDIR /app
 COPY go.mod ./
 RUN go mod download || true
@@ -6,14 +6,17 @@ COPY . .
 RUN go mod tidy && CGO_ENABLED=0 go build -o /server ./cmd/server
 
 FROM eclipse-temurin:17-jdk-alpine
+
+ARG GLIBC_VERSION=2.35-r1
+
 RUN apk add --no-cache graphviz python3
 
 # TXL (required for Python code generation) is a glibc binary.
 # Install glibc compatibility layer for Alpine.
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
- && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk \
- && apk add --no-cache --force-overwrite glibc-2.35-r1.apk \
- && rm glibc-2.35-r1.apk \
+ && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
+ && apk add --no-cache --force-overwrite glibc-${GLIBC_VERSION}.apk \
+ && rm glibc-${GLIBC_VERSION}.apk \
  && mkdir -p /lib64 \
  && ln -sf /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 WORKDIR /app

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,14 +1,16 @@
 FROM golang:1.23-alpine
 
+ARG GLIBC_VERSION=2.35-r1
+
 RUN apk add --no-cache graphviz openjdk17-jdk python3
 
 # TXL (required for Python code generation) is a glibc binary.
 # Install glibc compatibility layer for Alpine and create the /lib64 symlink
 # that the dynamic linker path (hardcoded in the ELF binary) expects.
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
- && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk \
- && apk add --no-cache --force-overwrite glibc-2.35-r1.apk \
- && rm glibc-2.35-r1.apk \
+ && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
+ && apk add --no-cache --force-overwrite glibc-${GLIBC_VERSION}.apk \
+ && rm glibc-${GLIBC_VERSION}.apk \
  && mkdir -p /lib64 \
  && ln -sf /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 

--- a/frontend/tests/e2e/live-generate.spec.ts
+++ b/frontend/tests/e2e/live-generate.spec.ts
@@ -7,7 +7,8 @@
  * Requires `make dev` running, then: `PLAYWRIGHT_LIVE_BACKEND=1 bun run test:e2e`
  */
 import { expect, test, type Page } from '@playwright/test'
-import { GENERATE_TARGETS, type GenerateTarget } from '../../src/generation/targets'
+import { GENERATE_TARGETS, resolveGenerateRequestLanguage } from '../../src/generation/targets'
+import type { GenerateResponse } from '../../src/api/types'
 
 test.skip(
   !process.env.PLAYWRIGHT_LIVE_BACKEND,
@@ -52,11 +53,8 @@ const GENERATE_ACTION_TARGETS = GENERATE_TARGETS.filter(
  * text (or HTML) must contain to confirm the generator produced real content.
  */
 const OUTPUT_EXPECTATIONS: Record<string, {
-  /** Patterns the output text must contain (case-insensitive substring match). */
   outputContains?: string[]
-  /** Expected response kind. */
   kind?: 'text' | 'html' | 'iframe'
-  /** If true, expect downloads array to be non-empty. */
   hasDownloads?: boolean
 }> = {
   Java:                        { outputContains: ['class Student', 'getName', 'getCourses'], kind: 'text' },
@@ -91,22 +89,11 @@ const OUTPUT_EXPECTATIONS: Record<string, {
 
 /* ── Helpers ── */
 
-interface GenerateApiResponse {
-  output: string
-  language: string
-  errors?: string
-  modelId?: string
-  kind?: string
-  html?: string
-  iframeUrl?: string
-  downloads?: { label: string; url: string; filename?: string }[]
-}
-
 async function generateViaApi(
   request: Page['request'],
   baseURL: string,
   language: string,
-): Promise<GenerateApiResponse> {
+): Promise<GenerateResponse> {
   const res = await request.post(`${baseURL}/api/generate`, {
     data: { code: UMPLE_MODEL, language },
   })
@@ -118,7 +105,12 @@ async function setEditorCode(page: Page, code: string) {
   const editor = page.locator('.cm-content')
   await editor.click()
   await page.keyboard.press('Control+a')
-  await page.keyboard.type(code, { delay: 0 })
+  await page.evaluate((text) => {
+    const view = (document.querySelector('.cm-editor') as any)?.cmView?.view
+    if (view) {
+      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } })
+    }
+  }, code)
 }
 
 async function compileAndWait(page: Page) {
@@ -130,11 +122,6 @@ async function compileAndWait(page: Page) {
   await compilePromise
 }
 
-function resolveLanguage(target: GenerateTarget): string {
-  if (target.id === 'Mermaid') return 'Mermaid.class'
-  return target.requestLanguage ?? target.id
-}
-
 /* ── Tests ── */
 
 test.describe('Live backend — code generation targets', () => {
@@ -143,21 +130,24 @@ test.describe('Live backend — code generation targets', () => {
   test.beforeAll(async ({ request, baseURL }) => {
     const health = await request.get(`${baseURL}/api/health`)
     expect(health.ok()).toBeTruthy()
+
+    // Verify every generate-action target has an entry in OUTPUT_EXPECTATIONS
+    const missing = GENERATE_ACTION_TARGETS
+      .filter((t) => !(t.id in OUTPUT_EXPECTATIONS))
+      .map((t) => t.id)
+    expect(missing, 'Missing OUTPUT_EXPECTATIONS entries').toEqual([])
   })
 
-  test('every generate target produces output via API', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.getByTestId('app-shell')).toBeVisible()
-
+  test('every generate target produces output via API', async ({ request, baseURL }) => {
     const failures: string[] = []
     let passed = 0
 
     for (const target of GENERATE_ACTION_TARGETS) {
-      const language = resolveLanguage(target)
+      const language = resolveGenerateRequestLanguage(target, 'class')
       const label = `${target.id} (${language})`
 
       try {
-        const res = await generateViaApi(page.request, page.url().replace(/\/$/, ''), language)
+        const res = await generateViaApi(request, baseURL!, language)
         const hasOutput = !!(res.output || res.html || res.iframeUrl)
 
         if (!hasOutput && !res.errors) {
@@ -175,7 +165,6 @@ test.describe('Live backend — code generation targets', () => {
         if (expectations) {
           const contentIssues: string[] = []
 
-          // Check output kind
           if (expectations.kind) {
             const actualKind = res.kind ?? (res.iframeUrl ? 'iframe' : res.html ? 'html' : 'text')
             if (actualKind !== expectations.kind) {
@@ -183,7 +172,6 @@ test.describe('Live backend — code generation targets', () => {
             }
           }
 
-          // Check output text contains expected patterns
           if (expectations.outputContains) {
             const text = (res.output || '').toLowerCase()
             for (const pattern of expectations.outputContains) {
@@ -193,7 +181,6 @@ test.describe('Live backend — code generation targets', () => {
             }
           }
 
-          // Check downloads
           if (expectations.hasDownloads && (!res.downloads || res.downloads.length === 0)) {
             contentIssues.push('expected downloads but got none')
           }
@@ -210,7 +197,6 @@ test.describe('Live backend — code generation targets', () => {
       }
     }
 
-    // Report
     const total = passed + failures.length
     if (failures.length > 0) {
       const detail = failures.map((f) => `  • ${f}`).join('\n')
@@ -220,11 +206,8 @@ test.describe('Live backend — code generation targets', () => {
     }
   })
 
-  test('Mermaid state variant generates state diagram syntax', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.getByTestId('app-shell')).toBeVisible()
-
-    const res = await generateViaApi(page.request, page.url().replace(/\/$/, ''), 'Mermaid.state')
+  test('Mermaid state variant generates state diagram syntax', async ({ request, baseURL }) => {
+    const res = await generateViaApi(request, baseURL!, 'Mermaid.state')
     expect(res.output.toLowerCase()).toContain('statediagram')
     expect(res.output).toContain('Active')
     expect(res.output).toContain('Graduated')
@@ -249,22 +232,15 @@ test.describe('Live backend — code generation targets', () => {
     await expect(page.locator('[data-testid="diagram-canvas"]')).toBeVisible()
   })
 
-  test('empty code returns an error, not a crash', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.getByTestId('app-shell')).toBeVisible()
-
-    const res = await page.request.post(`${page.url().replace(/\/$/, '')}/api/generate`, {
+  test('empty code returns an error, not a crash', async ({ request, baseURL }) => {
+    const res = await request.post(`${baseURL}/api/generate`, {
       data: { code: '', language: 'Java' },
     })
-    // Backend should reject with 400
     expect(res.status()).toBe(400)
   })
 
-  test('invalid language returns an error', async ({ page }) => {
-    await page.goto('/')
-    await expect(page.getByTestId('app-shell')).toBeVisible()
-
-    const res = await page.request.post(`${page.url().replace(/\/$/, '')}/api/generate`, {
+  test('invalid language returns an error', async ({ request, baseURL }) => {
+    const res = await request.post(`${baseURL}/api/generate`, {
       data: { code: UMPLE_MODEL, language: 'NonExistentLanguage' },
     })
     expect(res.status()).toBe(400)


### PR DESCRIPTION
## Summary
- Replace duplicate types/functions in test with imports from production code
- Use Playwright `request` fixture for API-only tests (2x overall speedup)
- Use `page.evaluate` for CodeMirror input instead of char-by-char `keyboard.type`
- Extract `GLIBC_VERSION` build ARG in both Dockerfiles
- Align prod Dockerfile Go version to 1.23

## Test plan
- [x] All 5 live-generate tests pass (35.8s, down from 1.2m)
- [x] TypeScript typecheck passes