### PR TITLE
Fix diagram type grouping across toolbar and editor flows

### DIFF
--- a/frontend/src/components/command/CommandPalette.tsx
+++ b/frontend/src/components/command/CommandPalette.tsx
@@ -1,13 +1,10 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useEphemeralStore } from '../../stores/ephemeralStore'
-import { useSessionStore, type DiagramView } from '../../stores/sessionStore'
-import { useCollabStore } from '../../stores/collabStore'
-import { collabLoadExample } from '../../hooks/useCollabTabs'
+import { useSessionStore } from '../../stores/sessionStore'
 import { useGenerate } from '../../hooks/useGenerate'
-import { api } from '../../api/client'
-import type { ExampleCategory } from '../../api/types'
-import { GENERATE_TARGET_GROUPS } from '../../generation/targets'
-import { getViewForExampleCategory } from '../../constants/diagram'
+import { useExamples } from '../../hooks/useExamples'
+import { GENERATE_ONLY_TARGET_GROUPS } from '../../generation/targets'
+import { DIAGRAM_VIEW_ICON, VIEW_MODE_GROUPS } from '../../constants/diagram'
 import {
   LayoutGrid, Workflow, GitBranch, Network,
   Code, Layers, Maximize2, Minimize2,
@@ -25,13 +22,6 @@ import {
   CommandSeparator,
 } from '@/components/ui/command'
 
-const DIAGRAM_VIEWS: { value: DiagramView; label: string; icon: React.ReactNode }[] = [
-  { value: 'class', label: 'Class Diagram', icon: <LayoutGrid /> },
-  { value: 'state', label: 'State Diagram', icon: <Workflow /> },
-  { value: 'feature', label: 'Feature Diagram', icon: <GitBranch /> },
-  { value: 'structure', label: 'Structure Diagram', icon: <Network /> },
-]
-
 const CATEGORY_ICONS: Record<string, React.ReactNode> = {
   'Class Diagrams': <LayoutGrid />,
   'State Machines': <Workflow />,
@@ -45,25 +35,16 @@ export function CommandPalette() {
     setDiagramOnly, diagramOnly, toggleOutputPanel,
     setRenderMode, renderMode, commandPaletteInitialPage,
   } = useEphemeralStore()
-  const { setViewMode } = useSessionStore()
-  const localLoadExample = useSessionStore((s) => s.loadExample)
-  const isCollaborating = useCollabStore((s) => s.isCollaborating)
+  const setViewMode = useSessionStore((s) => s.setViewMode)
+  const viewMode = useSessionStore((s) => s.viewMode)
+  const umpleModel = useSessionStore((s) => s.umpleModel)
   const generate = useGenerate()
+  const { categories, loadExample, loading } = useExamples()
 
-  const [categories, setCategories] = useState<ExampleCategory[]>([])
-  const [loadingExamples, setLoadingExamples] = useState(false)
   const [pages, setPages] = useState<string[]>([])
   const [search, setSearch] = useState('')
 
   const page = pages[pages.length - 1]
-
-  // Load categories on first open
-  useEffect(() => {
-    if (commandPaletteOpen && categories.length === 0) {
-      setLoadingExamples(true)
-      api.listExamples().then(setCategories).catch(() => {}).finally(() => setLoadingExamples(false))
-    }
-  }, [commandPaletteOpen, categories.length])
 
   // Reset state when palette closes
   useEffect(() => {
@@ -121,27 +102,11 @@ export function CommandPalette() {
     generate(language)
   }, [closeCommandPalette, generate])
 
-  const handleLoadExample = useCallback(async (name: string, category: string) => {
-    closeCommandPalette()
-    try {
-      const res = await api.getExample(name)
-      if (isCollaborating) {
-        collabLoadExample(res.name, res.code, res.modelId)
-      } else {
-        localLoadExample(res.name, res.code, res.modelId)
-      }
-      const view = getViewForExampleCategory(category)
-      if (view) {
-        setViewMode(view)
-      }
-      useEphemeralStore.getState().setRightPanelView('diagram')
-    } catch { /* ignore */ }
-  }, [closeCommandPalette, localLoadExample, isCollaborating, setViewMode])
-
   const currentCategory = useMemo(
     () => page && page !== 'examples' ? categories.find((c) => c.name === page) : undefined,
     [categories, page],
   )
+  const canToggleRenderer = viewMode === 'class' && !!umpleModel?.umpleClasses?.length
 
   const breadcrumb = pages.map((p) => (p === 'examples' ? 'Examples' : p)).join(' \u203A ')
 
@@ -185,24 +150,28 @@ export function CommandPalette() {
         {/* Root page */}
         {!page && (
           <>
-            <CommandGroup heading="Diagram">
-              {DIAGRAM_VIEWS.map((dt) => (
-                <CommandItem
-                  key={dt.value}
-                  onSelect={() => {
-                    setViewMode(dt.value)
-                    useEphemeralStore.getState().setRightPanelView('diagram')
-                    closeCommandPalette()
-                  }}
-                  data-testid={`command-item-diagram-${dt.value}`}
-                >
-                  {dt.icon}
-                  {dt.label}
-                </CommandItem>
-              ))}
-            </CommandGroup>
+            {VIEW_MODE_GROUPS.map((group) => (
+              <CommandGroup key={group.label} heading={group.label}>
+                {group.modes.map((mode) => (
+                  <CommandItem
+                    key={mode.value}
+                    onSelect={() => {
+                      setViewMode(mode.value)
+                      useEphemeralStore.getState().setRightPanelView('diagram')
+                      closeCommandPalette()
+                    }}
+                    data-testid={`command-item-diagram-${mode.value}`}
+                  >
+                    <DIAGRAM_VIEW_ICON />
+                    {mode.longLabel ?? mode.label}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
 
-            {GENERATE_TARGET_GROUPS.map((group) => (
+            <CommandSeparator />
+
+            {GENERATE_ONLY_TARGET_GROUPS.map((group) => (
               <CommandGroup key={group.label} heading={group.label}>
                 {group.targets.map((target) => (
                   <CommandItem
@@ -219,20 +188,24 @@ export function CommandPalette() {
 
             <CommandSeparator />
             <CommandGroup heading="View">
-              <CommandItem
-                onSelect={() => {
-                  setRenderMode(renderMode === 'editable' ? 'graphviz' : 'editable')
-                  closeCommandPalette()
-                }}
-              >
-                <Layers />
-                Switch to {renderMode === 'editable' ? 'Graphviz' : 'Editable'} Rendering
-              </CommandItem>
+              {canToggleRenderer && (
+                <CommandItem
+                  onSelect={() => {
+                    setRenderMode(renderMode === 'editable' ? 'graphviz' : 'editable')
+                    closeCommandPalette()
+                  }}
+                  data-testid="command-item-view-renderer"
+                >
+                  <Layers />
+                  Switch to {renderMode === 'editable' ? 'Graphviz' : 'Editable'} Rendering
+                </CommandItem>
+              )}
               <CommandItem
                 onSelect={() => {
                   setDiagramOnly(!diagramOnly)
                   closeCommandPalette()
                 }}
+                data-testid="command-item-view-diagram-only"
               >
                 {diagramOnly ? <Minimize2 /> : <Maximize2 />}
                 {diagramOnly ? 'Exit Diagram Only Mode' : 'Diagram Only Mode'}
@@ -242,6 +215,7 @@ export function CommandPalette() {
                   toggleOutputPanel()
                   closeCommandPalette()
                 }}
+                data-testid="command-item-view-output-panel"
               >
                 <Terminal />
                 Toggle Output Panel
@@ -251,7 +225,7 @@ export function CommandPalette() {
 
             <CommandSeparator />
             <CommandGroup heading="Examples">
-              {loadingExamples ? (
+              {loading ? (
                 <div className="py-2 text-center text-xs text-muted-foreground">Loading examples...</div>
               ) : categories.length > 0 ? (
                 <CommandItem
@@ -292,11 +266,14 @@ export function CommandPalette() {
             {currentCategory.examples.map((ex) => (
                 <CommandItem
                   key={ex.name}
-                  onSelect={() => handleLoadExample(ex.name, currentCategory.name)}
+                  onSelect={() => {
+                    closeCommandPalette()
+                    loadExample(ex.name, currentCategory.name)
+                  }}
                   data-testid={`command-item-example-${ex.name}`}
                 >
                   <FileCode />
-                  {ex.label}
+                  {ex.label || ex.name}
                 </CommandItem>
               ))}
           </CommandGroup>

--- a/frontend/src/components/editor/ExecutionPanel.tsx
+++ b/frontend/src/components/editor/ExecutionPanel.tsx
@@ -231,7 +231,7 @@ export function OutputPanel() {
   }, [executionOutput, executionErrors])
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col" data-testid="output-panel">
       {/* Header */}
       <div className="flex h-[38px] shrink-0 items-center justify-between border-b border-border px-3">
         <div className="flex items-center gap-2">

--- a/frontend/src/components/layout/AppToolbar.tsx
+++ b/frontend/src/components/layout/AppToolbar.tsx
@@ -4,7 +4,7 @@ import { useSessionStore, type DiagramView } from '../../stores/sessionStore'
 import { useCompile } from '../../hooks/useExecute'
 import { useGenerate } from '../../hooks/useGenerate'
 import { useExamples } from '../../hooks/useExamples'
-import { GENERATE_TARGET_GROUPS } from '../../generation/targets'
+import { GENERATE_ONLY_TARGET_GROUPS } from '../../generation/targets'
 import { AiConfigForm } from '@/components/sidebar/AiConfigForm'
 import { useTaskStore } from '../../stores/taskStore'
 import { ToolbarDivider } from '@/components/diagram/CanvasToolbar'
@@ -26,7 +26,7 @@ import {
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { Tip } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { VIEW_MODE_GROUPS, ALL_VIEW_MODES } from '../../constants/diagram'
+import { VIEW_MODE_GROUPS, getViewModeOption } from '../../constants/diagram'
 
 const pillBase = 'flex items-center bg-surface-0 rounded-lg border border-border shadow-sm px-1 py-1'
 const toolbarBtn = 'flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors cursor-pointer'
@@ -114,7 +114,7 @@ export function AppToolbar() {
                   <DropdownMenuSubContent className="w-56 max-h-72">
                     {cat.examples.map((ex) => (
                       <DropdownMenuItem key={ex.name} onSelect={() => loadExample(ex.name, cat.name)}>
-                        {ex.label}
+                        {ex.label || ex.name}
                       </DropdownMenuItem>
                     ))}
                   </DropdownMenuSubContent>
@@ -156,7 +156,7 @@ export function AppToolbar() {
               className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-ink-muted rounded-md hover:text-ink hover:bg-surface-2 transition-colors cursor-pointer outline-none"
               aria-label="Diagram view"
             >
-              <span className="truncate">{ALL_VIEW_MODES.find((m) => m.value === viewMode)?.label ?? 'Class'}</span>
+              <span className="truncate">{getViewModeOption(viewMode)?.label ?? 'Class'}</span>
               <ChevronDown className="size-3 shrink-0" />
             </DropdownMenuTrigger>
           </Tip>
@@ -196,7 +196,7 @@ export function AppToolbar() {
             </DropdownMenuTrigger>
           </Tip>
           <DropdownMenuContent align="end" className="w-52 max-h-80">
-            {GENERATE_TARGET_GROUPS.map((group, gi) => (
+            {GENERATE_ONLY_TARGET_GROUPS.map((group, gi) => (
               <DropdownMenuGroup key={group.label}>
                 {gi > 0 && <DropdownMenuSeparator />}
                 <DropdownMenuLabel className="text-xxs">{group.label}</DropdownMenuLabel>

--- a/frontend/src/components/layout/AppToolbar.tsx
+++ b/frontend/src/components/layout/AppToolbar.tsx
@@ -26,7 +26,7 @@ import {
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { Tip } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { VIEW_MODE_GROUPS, ALL_VIEW_MODES, PINNED_VIEW_MODES } from '../../constants/diagram'
+import { VIEW_MODE_GROUPS, ALL_VIEW_MODES } from '../../constants/diagram'
 
 const pillBase = 'flex items-center bg-surface-0 rounded-lg border border-border shadow-sm px-1 py-1'
 const toolbarBtn = 'flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors cursor-pointer'
@@ -162,20 +162,11 @@ export function AppToolbar() {
           </Tip>
           <DropdownMenuContent align="start" className="w-48">
             <DropdownMenuRadioGroup value={viewMode} onValueChange={(v) => setViewMode(v as DiagramView)}>
-              {PINNED_VIEW_MODES.map((pv) => {
-                const m = ALL_VIEW_MODES.find((v) => v.value === pv)
-                if (!m) return null
-                return (
-                  <DropdownMenuRadioItem key={m.value} value={m.value} data-testid={`diagram-view-${m.value}`}>
-                    {m.label}
-                  </DropdownMenuRadioItem>
-                )
-              })}
-              {VIEW_MODE_GROUPS.map((group) => (
+              {VIEW_MODE_GROUPS.map((group, index) => (
                 <DropdownMenuGroup key={group.label}>
-                  <DropdownMenuSeparator />
+                  {index > 0 && <DropdownMenuSeparator />}
                   <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
-                  {group.modes.filter((m) => !PINNED_VIEW_MODES.includes(m.value)).map((m) => (
+                  {group.modes.map((m) => (
                     <DropdownMenuRadioItem key={m.value} value={m.value} data-testid={`diagram-view-${m.value}`}>
                       {m.label}
                     </DropdownMenuRadioItem>

--- a/frontend/src/components/layout/CanvasBanner.tsx
+++ b/frontend/src/components/layout/CanvasBanner.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useEphemeralStore } from '../../stores/ephemeralStore'
 import { useGenerate } from '../../hooks/useGenerate'
-import { GENERATE_TARGET_GROUPS, getGenerateTarget } from '../../generation/targets'
+import { GENERATE_ONLY_TARGET_GROUPS, getGenerateTarget } from '../../generation/targets'
 import { ChevronDown, Maximize2, Minimize2 } from 'lucide-react'
 import {
   DropdownMenu,
@@ -90,7 +90,7 @@ export function CanvasBanner() {
                 </DropdownMenuTrigger>
               </Tip>
               <DropdownMenuContent align="start" className="w-52 max-h-64">
-                {GENERATE_TARGET_GROUPS.map((group, gi) => (
+                {GENERATE_ONLY_TARGET_GROUPS.map((group, gi) => (
                   <DropdownMenuGroup key={group.label}>
                     {gi > 0 && <DropdownMenuSeparator />}
                     <DropdownMenuLabel className="text-xxs">{group.label}</DropdownMenuLabel>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -5,8 +5,8 @@ import { usePreferencesStore, type GvLayoutAlgorithm } from '../../stores/prefer
 import { useExamples } from '../../hooks/useExamples'
 import { useExecute } from '../../hooks/useExecute'
 import { useGenerate } from '../../hooks/useGenerate'
-import { GENERATE_TARGETS, GENERATE_TARGET_GROUPS, getGenerateTarget } from '../../generation/targets'
-import { LAYOUT_OPTIONS, VIEW_MODE_GROUPS, getViewForExampleCategory } from '../../constants/diagram'
+import { GENERATE_ONLY_TARGETS, GENERATE_ONLY_TARGET_GROUPS, getGenerateTarget } from '../../generation/targets'
+import { LAYOUT_OPTIONS, VIEW_MODE_GROUPS, getViewForExampleCategory, getLayoutOption } from '../../constants/diagram'
 import { Combobox } from '@/components/ui/combobox'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
@@ -188,12 +188,12 @@ function ToolsGroup() {
   const showLayout = VIEW_OUTPUT_KIND[viewMode] !== 'html'
 
   const selectedTarget = useMemo(
-    () => getGenerateTarget(targetId) ?? GENERATE_TARGETS[0],
+    () => getGenerateTarget(targetId) ?? GENERATE_ONLY_TARGETS[0],
     [targetId],
   )
 
   const generateGroups = useMemo(
-    () => GENERATE_TARGET_GROUPS.map((g) => ({
+    () => GENERATE_ONLY_TARGET_GROUPS.map((g) => ({
       label: g.label,
       options: g.targets.map((t) => ({ value: t.id, label: t.label })),
     })),
@@ -204,7 +204,7 @@ function ToolsGroup() {
     () => allCategories
       .filter((cat) => (getViewForExampleCategory(cat.name) ?? 'class') === viewMode)
       .flatMap((cat) => cat.examples)
-      .map((ex) => ({ value: ex.name, label: ex.label })),
+      .map((ex) => ({ value: ex.name, label: ex.label || ex.name })),
     [allCategories, viewMode]
   )
 
@@ -283,8 +283,8 @@ function ToolsGroup() {
                 variant="secondary"
                 size="xs"
                 className="text-xs"
-                title={selectedTarget.executable ? 'Execute generated code' : 'Execution is only supported for Java and Python'}
-              >
+              title={selectedTarget.executable ? 'Execute generated code' : 'Execution is only supported for Java and Python'}
+            >
                 {running ? (
                   <Loader2 className="size-3 animate-spin" />
                 ) : (
@@ -302,7 +302,7 @@ function ToolsGroup() {
             <SubLabel>Layout Algorithm</SubLabel>
             <Select value={layoutAlgorithm} onValueChange={(v) => setLayoutAlgorithm(v as GvLayoutAlgorithm)}>
               <SelectTrigger>
-                <SelectValue />
+                <SelectValue>{getLayoutOption(layoutAlgorithm)?.label}</SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {LAYOUT_OPTIONS.map((opt) => (

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -6,9 +6,9 @@ import { useExamples } from '../../hooks/useExamples'
 import { useExecute } from '../../hooks/useExecute'
 import { useGenerate } from '../../hooks/useGenerate'
 import { GENERATE_TARGETS, GENERATE_TARGET_GROUPS, getGenerateTarget } from '../../generation/targets'
-import { LAYOUT_OPTIONS, ALL_VIEW_MODES, PINNED_VIEW_MODES, getViewForExampleCategory } from '../../constants/diagram'
+import { LAYOUT_OPTIONS, VIEW_MODE_GROUPS, getViewForExampleCategory } from '../../constants/diagram'
 import { Combobox } from '@/components/ui/combobox'
-import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import {
@@ -225,20 +225,16 @@ function ToolsGroup() {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {PINNED_VIEW_MODES.map((pv) => {
-                  const m = ALL_VIEW_MODES.find((v) => v.value === pv)
-                  if (!m) return null
-                  return (
-                    <SelectItem key={m.value} value={m.value}>
-                      {m.longLabel ?? m.label}
-                    </SelectItem>
-                  )
-                })}
-                <SelectSeparator />
-                {ALL_VIEW_MODES.filter((m) => !PINNED_VIEW_MODES.includes(m.value)).map((m) => (
-                  <SelectItem key={m.value} value={m.value}>
-                    {m.longLabel ?? m.label}
-                  </SelectItem>
+                {VIEW_MODE_GROUPS.map((group, index) => (
+                  <SelectGroup key={group.label}>
+                    {index > 0 && <SelectSeparator />}
+                    <SelectLabel>{group.label}</SelectLabel>
+                    {group.modes.map((m) => (
+                      <SelectItem key={m.value} value={m.value}>
+                        {m.longLabel ?? m.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
                 ))}
               </SelectContent>
             </Select>

--- a/frontend/src/constants/diagram.ts
+++ b/frontend/src/constants/diagram.ts
@@ -13,41 +13,45 @@ export function getViewForExampleCategory(category: string): DiagramView | null 
   return EXAMPLE_CATEGORY_TO_VIEW[category] ?? null
 }
 
-/** Grouped diagram view modes for dropdowns and sidebar */
+/** Grouped diagram view modes following the legacy UmpleOnline live-view menu.
+ *  Editable class view is controlled separately by render mode, so it is not listed here.
+ */
 export const VIEW_MODE_GROUPS: {
   label: string
   modes: { value: DiagramView; label: string; longLabel?: string }[]
 }[] = [
   {
-    label: 'Structure',
+    label: 'Class Views',
     modes: [
       { value: 'class', label: 'Class', longLabel: 'Class Diagram' },
       { value: 'erd', label: 'Entity Relationship', longLabel: 'Entity Relationship Diagram' },
-      { value: 'feature', label: 'Feature', longLabel: 'Feature Diagram' },
-      { value: 'structure', label: 'Structure', longLabel: 'Composite Structure Diagram' },
+      { value: 'crud', label: 'CRUD UI', longLabel: 'CRUD UI' },
     ],
   },
   {
-    label: 'Behavior',
+    label: 'State Views',
     modes: [
       { value: 'state', label: 'State', longLabel: 'State Machine Diagram' },
-      { value: 'eventSequence', label: 'Event Sequence', longLabel: 'Event Sequence Diagram' },
       { value: 'stateTables', label: 'State Tables', longLabel: 'State Tables Diagram' },
     ],
   },
   {
-    label: 'Other',
+    label: 'Special Views',
+    modes: [
+      { value: 'structure', label: 'Structure', longLabel: 'Composite Structure Diagram' },
+      { value: 'feature', label: 'Feature', longLabel: 'Feature Diagram' },
+    ],
+  },
+  {
+    label: 'Instance Views',
     modes: [
       { value: 'instance', label: 'Instance', longLabel: 'Instance Diagram' },
-      { value: 'crud', label: 'CRUD UI', longLabel: 'CRUD UI' },
+      { value: 'eventSequence', label: 'Event Sequence', longLabel: 'Event Sequence Diagram' },
     ],
   },
 ]
 
 export const ALL_VIEW_MODES = VIEW_MODE_GROUPS.flatMap((g) => g.modes)
-
-/** Pinned diagram types shown at the top of dropdowns for quick access */
-export const PINNED_VIEW_MODES: DiagramView[] = ['class', 'state']
 
 /** Display preference toggles per diagram view */
 export const DISPLAY_TOGGLES: Record<DiagramView, { key: DisplayPrefKey; label: string }[]> = {

--- a/frontend/src/constants/diagram.ts
+++ b/frontend/src/constants/diagram.ts
@@ -1,89 +1,284 @@
-import type { DiagramView } from '../stores/sessionStore'
-import type { DisplayPrefKey } from '../stores/preferencesStore'
+import { LayoutGrid } from 'lucide-react'
 
-export const EXAMPLE_CATEGORY_TO_VIEW: Partial<Record<string, DiagramView>> = {
-  'Class Diagrams': 'class',
-  'State Machines': 'state',
-  'Composite Structure': 'structure',
-  'Feature Diagrams': 'feature',
-  'Entity Relationships': 'erd',
+export type DiagramView =
+  | 'class'
+  | 'state'
+  | 'feature'
+  | 'structure'
+  | 'erd'
+  | 'instance'
+  | 'eventSequence'
+  | 'stateTables'
+  | 'crud'
+
+export type DiagramOutputKind = 'gv' | 'html' | 'component'
+
+export type DisplayPrefKey =
+  | 'showAttributes'
+  | 'showMethods'
+  | 'showTraits'
+  | 'showActions'
+  | 'showTransitionLabels'
+  | 'showGuards'
+  | 'showGuardLabels'
+  | 'showNaturalLanguage'
+  | 'showFeatureDependency'
+
+export interface DiagramDisplayToggle {
+  key: DisplayPrefKey
+  label: string
+  enabledSuboption?: string
+  disabledSuboption?: string
+}
+
+export interface DiagramViewMode {
+  value: DiagramView
+  label: string
+  longLabel: string
+  outputKind: DiagramOutputKind
+  diagramType?: string
+  exampleCategories?: string[]
+  legacyDiagramTypes?: string[]
+  displayToggles?: DiagramDisplayToggle[]
+}
+
+export interface DiagramViewGroup {
+  label: string
+  modes: DiagramViewMode[]
+}
+
+export interface LayoutOption {
+  value: 'dot' | 'sfdp' | 'circo' | 'neato' | 'fdp' | 'twopi'
+  label: string
+  suboption?: string
+}
+
+export const LAYOUT_OPTIONS = [
+  { value: 'dot', label: 'Dot (default)' },
+  { value: 'sfdp', label: 'SFDP', suboption: 'gvsfdp' },
+  { value: 'circo', label: 'Circo', suboption: 'gvcirco' },
+  { value: 'neato', label: 'Neato', suboption: 'gvneato' },
+  { value: 'fdp', label: 'FDP', suboption: 'gvfdp' },
+  { value: 'twopi', label: 'Twopi', suboption: 'gvtwopi' },
+] as const satisfies readonly LayoutOption[]
+
+export type GvLayoutAlgorithm = (typeof LAYOUT_OPTIONS)[number]['value']
+
+export interface DiagramDisplayPrefs {
+  showAttributes: boolean
+  showMethods: boolean
+  showTraits: boolean
+  showActions: boolean
+  showTransitionLabels: boolean
+  showGuards: boolean
+  showGuardLabels: boolean
+  showNaturalLanguage: boolean
+  showFeatureDependency: boolean
+  layoutAlgorithm: GvLayoutAlgorithm
+}
+
+const CLASS_TOGGLES: DiagramDisplayToggle[] = [
+  { key: 'showAttributes', label: 'Attributes', disabledSuboption: 'hideattributes' },
+  { key: 'showMethods', label: 'Methods', enabledSuboption: 'showmethods' },
+  { key: 'showTraits', label: 'Traits' },
+]
+
+const STATE_TOGGLES: DiagramDisplayToggle[] = [
+  { key: 'showActions', label: 'Actions', disabledSuboption: 'hideactions' },
+  { key: 'showTransitionLabels', label: 'Transition Labels', enabledSuboption: 'showtransitionlabels' },
+  { key: 'showGuards', label: 'Guards', disabledSuboption: 'hideguards' },
+  { key: 'showGuardLabels', label: 'Guard Labels', enabledSuboption: 'showguardlabels' },
+  { key: 'showNaturalLanguage', label: 'Natural Language', disabledSuboption: 'hidenaturallanguage' },
+]
+
+const FEATURE_TOGGLES: DiagramDisplayToggle[] = [
+  { key: 'showFeatureDependency', label: 'Feature Dependency', enabledSuboption: 'showFeatureDependency' },
+]
+
+/** Grouped diagram view modes following the legacy UmpleOnline live-view menu.
+ *  Editable class view is controlled separately by render mode, so it is not listed here.
+ */
+export const VIEW_MODE_GROUPS: DiagramViewGroup[] = [
+  {
+    label: 'Class Views',
+    modes: [
+      {
+        value: 'class',
+        label: 'Class',
+        longLabel: 'Class Diagram',
+        outputKind: 'gv',
+        diagramType: 'GvClassDiagram',
+        exampleCategories: ['Class Diagrams'],
+        legacyDiagramTypes: ['GvClass', 'class'],
+        displayToggles: CLASS_TOGGLES,
+      },
+      {
+        value: 'erd',
+        label: 'Entity Relationship',
+        longLabel: 'Entity Relationship Diagram',
+        outputKind: 'gv',
+        diagramType: 'GvEntityRelationshipDiagram',
+        exampleCategories: ['Entity Relationships'],
+        legacyDiagramTypes: ['erd'],
+      },
+      {
+        value: 'crud',
+        label: 'CRUD UI',
+        longLabel: 'CRUD UI',
+        outputKind: 'component',
+      },
+    ],
+  },
+  {
+    label: 'State Views',
+    modes: [
+      {
+        value: 'state',
+        label: 'State',
+        longLabel: 'State Machine Diagram',
+        outputKind: 'gv',
+        diagramType: 'GvStateDiagram',
+        exampleCategories: ['State Machines'],
+        legacyDiagramTypes: ['state'],
+        displayToggles: STATE_TOGGLES,
+      },
+      {
+        value: 'stateTables',
+        label: 'State Tables',
+        longLabel: 'State Tables Diagram',
+        outputKind: 'html',
+        diagramType: 'StateTables',
+      },
+    ],
+  },
+  {
+    label: 'Special Views',
+    modes: [
+      {
+        value: 'structure',
+        label: 'Structure',
+        longLabel: 'Composite Structure Diagram',
+        outputKind: 'html',
+        diagramType: 'StructureDiagram',
+        exampleCategories: ['Composite Structure'],
+        legacyDiagramTypes: ['structure'],
+      },
+      {
+        value: 'feature',
+        label: 'Feature',
+        longLabel: 'Feature Diagram',
+        outputKind: 'gv',
+        diagramType: 'GvFeatureDiagram',
+        exampleCategories: ['Feature Diagrams'],
+        legacyDiagramTypes: ['feature'],
+        displayToggles: FEATURE_TOGGLES,
+      },
+    ],
+  },
+  {
+    label: 'Instance Views',
+    modes: [
+      {
+        value: 'instance',
+        label: 'Instance',
+        longLabel: 'Instance Diagram',
+        outputKind: 'gv',
+        diagramType: 'InstanceDiagram',
+      },
+      {
+        value: 'eventSequence',
+        label: 'Event Sequence',
+        longLabel: 'Event Sequence Diagram',
+        outputKind: 'html',
+        diagramType: 'EventSequence',
+      },
+    ],
+  },
+]
+
+export const DIAGRAM_VIEW_ICON = LayoutGrid
+
+export const ALL_VIEW_MODES = VIEW_MODE_GROUPS.flatMap((group) => group.modes)
+
+const VIEW_MODE_BY_VALUE = new Map(ALL_VIEW_MODES.map((mode) => [mode.value, mode]))
+const LAYOUT_OPTION_BY_VALUE = new Map(LAYOUT_OPTIONS.map((option) => [option.value, option]))
+
+export const VIEW_OUTPUT_KIND = Object.fromEntries(
+  ALL_VIEW_MODES.map((mode) => [mode.value, mode.outputKind] as const)
+) as Record<DiagramView, DiagramOutputKind>
+
+export const DISPLAY_TOGGLES = Object.fromEntries(
+  ALL_VIEW_MODES.map((mode) => [mode.value, mode.displayToggles ?? []] as const)
+) as Record<DiagramView, DiagramDisplayToggle[]>
+
+export const DISPLAY_PREF_DEFAULTS: Record<DisplayPrefKey, boolean> = {
+  showAttributes: true,
+  showMethods: false,
+  showTraits: false,
+  showActions: true,
+  showTransitionLabels: false,
+  showGuards: true,
+  showGuardLabels: false,
+  showNaturalLanguage: true,
+  showFeatureDependency: false,
+}
+
+export const DISPLAY_PREF_KEYS = Object.keys(DISPLAY_PREF_DEFAULTS) as DisplayPrefKey[]
+
+export const EXAMPLE_CATEGORY_TO_VIEW = Object.fromEntries(
+  ALL_VIEW_MODES.flatMap((mode) =>
+    (mode.exampleCategories ?? []).map((category) => [category, mode.value] as const)
+  )
+) as Partial<Record<string, DiagramView>>
+
+const LEGACY_DIAGRAM_TYPE_TO_VIEW = Object.fromEntries(
+  ALL_VIEW_MODES.flatMap((mode) =>
+    (mode.legacyDiagramTypes ?? []).map((legacyType) => [legacyType, mode.value] as const)
+  )
+) as Partial<Record<string, DiagramView>>
+
+export function getViewModeOption(view: DiagramView): DiagramViewMode | null {
+  return VIEW_MODE_BY_VALUE.get(view) ?? null
 }
 
 export function getViewForExampleCategory(category: string): DiagramView | null {
   return EXAMPLE_CATEGORY_TO_VIEW[category] ?? null
 }
 
-/** Grouped diagram view modes following the legacy UmpleOnline live-view menu.
- *  Editable class view is controlled separately by render mode, so it is not listed here.
- */
-export const VIEW_MODE_GROUPS: {
-  label: string
-  modes: { value: DiagramView; label: string; longLabel?: string }[]
-}[] = [
-  {
-    label: 'Class Views',
-    modes: [
-      { value: 'class', label: 'Class', longLabel: 'Class Diagram' },
-      { value: 'erd', label: 'Entity Relationship', longLabel: 'Entity Relationship Diagram' },
-      { value: 'crud', label: 'CRUD UI', longLabel: 'CRUD UI' },
-    ],
-  },
-  {
-    label: 'State Views',
-    modes: [
-      { value: 'state', label: 'State', longLabel: 'State Machine Diagram' },
-      { value: 'stateTables', label: 'State Tables', longLabel: 'State Tables Diagram' },
-    ],
-  },
-  {
-    label: 'Special Views',
-    modes: [
-      { value: 'structure', label: 'Structure', longLabel: 'Composite Structure Diagram' },
-      { value: 'feature', label: 'Feature', longLabel: 'Feature Diagram' },
-    ],
-  },
-  {
-    label: 'Instance Views',
-    modes: [
-      { value: 'instance', label: 'Instance', longLabel: 'Instance Diagram' },
-      { value: 'eventSequence', label: 'Event Sequence', longLabel: 'Event Sequence Diagram' },
-    ],
-  },
-]
-
-export const ALL_VIEW_MODES = VIEW_MODE_GROUPS.flatMap((g) => g.modes)
-
-/** Display preference toggles per diagram view */
-export const DISPLAY_TOGGLES: Record<DiagramView, { key: DisplayPrefKey; label: string }[]> = {
-  class: [
-    { key: 'showAttributes', label: 'Attributes' },
-    { key: 'showMethods', label: 'Methods' },
-    { key: 'showTraits', label: 'Traits' },
-  ],
-  state: [
-    { key: 'showActions', label: 'Actions' },
-    { key: 'showTransitionLabels', label: 'Transition Labels' },
-    { key: 'showGuards', label: 'Guards' },
-    { key: 'showGuardLabels', label: 'Guard Labels' },
-    { key: 'showNaturalLanguage', label: 'Natural Language' },
-  ],
-  feature: [
-    { key: 'showFeatureDependency', label: 'Feature Dependency' },
-  ],
-  structure: [],
-  erd: [],
-  instance: [],
-  eventSequence: [],
-  stateTables: [],
-  crud: [],
+export function getViewForLegacyDiagramType(diagramType: string): DiagramView | null {
+  return LEGACY_DIAGRAM_TYPE_TO_VIEW[diagramType] ?? null
 }
 
-/** Layout algorithm options for Graphviz */
-export const LAYOUT_OPTIONS = [
-  { value: 'dot', label: 'Dot (default)' },
-  { value: 'sfdp', label: 'SFDP' },
-  { value: 'circo', label: 'Circo' },
-  { value: 'neato', label: 'Neato' },
-  { value: 'fdp', label: 'FDP' },
-  { value: 'twopi', label: 'Twopi' },
-]
+export function getLayoutOption(algo: GvLayoutAlgorithm): LayoutOption | null {
+  return LAYOUT_OPTION_BY_VALUE.get(algo) ?? null
+}
+
+export function buildSuboptions(
+  prefs: DiagramDisplayPrefs,
+  viewMode: DiagramView,
+  isDark: boolean,
+): string[] {
+  const opts: string[] = []
+  const view = getViewModeOption(viewMode)
+
+  for (const toggle of view?.displayToggles ?? []) {
+    const enabled = prefs[toggle.key]
+    if (toggle.enabledSuboption && enabled) opts.push(toggle.enabledSuboption)
+    if (toggle.disabledSuboption && !enabled) opts.push(toggle.disabledSuboption)
+  }
+
+  const layoutOption = getLayoutOption(prefs.layoutAlgorithm)
+  if (layoutOption?.suboption) {
+    opts.push(layoutOption.suboption)
+  }
+
+  if (isDark) opts.push('gvdark')
+
+  return opts
+}
+
+/** Returns the effective backend diagram type, accounting for the Traits toggle. */
+export function getEffectiveDiagramType(viewMode: DiagramView, showTraits: boolean): string {
+  if (viewMode === 'class' && showTraits) return 'GvClassTraitDiagram'
+  return getViewModeOption(viewMode)?.diagramType ?? 'GvClassDiagram'
+}

--- a/frontend/src/generation/targets.ts
+++ b/frontend/src/generation/targets.ts
@@ -87,6 +87,13 @@ export const GENERATE_TARGET_GROUPS: GenerateTargetGroup[] = [
 ]
 
 export const GENERATE_TARGETS: GenerateTarget[] = GENERATE_TARGET_GROUPS.flatMap((g) => g.targets)
+export const GENERATE_ONLY_TARGET_GROUPS: GenerateTargetGroup[] = GENERATE_TARGET_GROUPS
+  .map((group) => ({
+    ...group,
+    targets: group.targets.filter((target) => target.action === 'generate'),
+  }))
+  .filter((group) => group.targets.length > 0)
+export const GENERATE_ONLY_TARGETS: GenerateTarget[] = GENERATE_ONLY_TARGET_GROUPS.flatMap((g) => g.targets)
 
 const TARGETS_BY_ID = new Map(GENERATE_TARGETS.map((target) => [target.id, target]))
 

--- a/frontend/src/hooks/useExamples.ts
+++ b/frontend/src/hooks/useExamples.ts
@@ -13,12 +13,14 @@ let fetchPromise: Promise<ExampleCategory[]> | null = null
 
 export function useExamples() {
   const [allCategories, setAllCategories] = useState<ExampleCategory[]>(cachedCategories ?? [])
+  const [loading, setLoading] = useState(cachedCategories === null)
   const localLoadExample = useSessionStore((s) => s.loadExample)
   const isCollaborating = useCollabStore((s) => s.isCollaborating)
 
   useEffect(() => {
     if (cachedCategories) {
       setAllCategories(cachedCategories)
+      setLoading(false)
       return
     }
     if (!fetchPromise) {
@@ -27,7 +29,12 @@ export function useExamples() {
         .then((cats) => { cachedCategories = cats })
         .catch(() => { fetchPromise = null })
     }
-    fetchPromise.then(setAllCategories).catch(() => {})
+    fetchPromise
+      .then((cats) => {
+        setAllCategories(cats)
+        setLoading(false)
+      })
+      .catch(() => setLoading(false))
   }, [])
 
   const categories = useMemo(
@@ -51,5 +58,5 @@ export function useExamples() {
     } catch { /* ignore */ }
   }, [localLoadExample, isCollaborating])
 
-  return { categories, loadExample }
+  return { categories, loadExample, loading }
 }

--- a/frontend/src/hooks/useModelFromURL.ts
+++ b/frontend/src/hooks/useModelFromURL.ts
@@ -1,9 +1,9 @@
 import { useEffect, useRef } from 'react'
-import { useSessionStore, type DiagramView } from '../stores/sessionStore'
+import { useSessionStore } from '../stores/sessionStore'
 import { useCollabStore } from '../stores/collabStore'
 import { useEphemeralStore } from '../stores/ephemeralStore'
 import { isTemporaryModel } from '../lib/modelId'
-import { getViewForExampleCategory } from '../constants/diagram'
+import { getViewForExampleCategory, getViewForLegacyDiagramType } from '../constants/diagram'
 import { getGenerateTarget } from '../generation/targets'
 import { api } from '../api/client'
 
@@ -23,16 +23,6 @@ const initialReadOnly = initialParams.has('readOnly')
 
 /** ?generateDefault= param. */
 const initialGenerateDefault = initialParams.get('generateDefault')
-
-/** Map legacy ?diagramtype= values to new view modes. */
-const DIAGRAM_TYPE_MAP: Record<string, DiagramView> = {
-  GvClass: 'class',
-  class: 'class',
-  state: 'state',
-  feature: 'feature',
-  structure: 'structure',
-  erd: 'erd',
-}
 
 /**
  * Read the persisted modelId from sessionStorage (Zustand hydrates async, so
@@ -88,7 +78,7 @@ export function useModelFromURL() {
   useEffect(() => {
     // ?diagramtype=
     if (initialDiagramType) {
-      const mapped = DIAGRAM_TYPE_MAP[initialDiagramType]
+      const mapped = getViewForLegacyDiagramType(initialDiagramType)
       if (mapped) useSessionStore.getState().setViewMode(mapped)
     }
 

--- a/frontend/src/stores/preferencesStore.ts
+++ b/frontend/src/stores/preferencesStore.ts
@@ -1,5 +1,15 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
+import {
+  DISPLAY_PREF_DEFAULTS,
+  DISPLAY_PREF_KEYS,
+  type DisplayPrefKey,
+  type DiagramDisplayPrefs,
+  type DiagramView,
+  type GvLayoutAlgorithm,
+  buildSuboptions,
+  getEffectiveDiagramType,
+} from '../constants/diagram'
 
 // ── AI Config types ──
 
@@ -31,14 +41,7 @@ export function createDefaultProviderConfigs(): Record<AiProvider, ProviderConfi
   ) as Record<AiProvider, ProviderConfig>
 }
 
-// ── Diagram display pref types ──
-
-export type GvLayoutAlgorithm = 'dot' | 'sfdp' | 'circo' | 'neato' | 'fdp' | 'twopi'
-
-export type DisplayPrefKey =
-  | 'showAttributes' | 'showMethods' | 'showTraits'
-  | 'showActions' | 'showTransitionLabels' | 'showGuards' | 'showGuardLabels' | 'showNaturalLanguage'
-  | 'showFeatureDependency'
+export type { DisplayPrefKey, GvLayoutAlgorithm } from '../constants/diagram'
 
 // ── Store ──
 
@@ -93,15 +96,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       toggleSidebar: () => set((s) => ({ showSidebar: !s.showSidebar })),
 
       // Diagram display preferences (match Umple compiler defaults)
-      showAttributes: true,
-      showMethods: false,
-      showTraits: false,
-      showActions: true,
-      showTransitionLabels: false,
-      showGuards: true,
-      showGuardLabels: false,
-      showNaturalLanguage: true,
-      showFeatureDependency: false,
+      ...DISPLAY_PREF_DEFAULTS,
       layoutAlgorithm: 'dot',
       toggleDisplayPref: (key) => set((s) => ({ [key]: !s[key] })),
       setLayoutAlgorithm: (layoutAlgorithm) => set({ layoutAlgorithm }),
@@ -140,11 +135,13 @@ export const usePreferencesStore = create<PreferencesState>()(
         // schemas (e.g. serialized action names stored as null) would
         // otherwise shadow the real store actions after the spread.
         const DATA_KEYS = [
-          'theme', 'hasSeenWelcome', 'showSidebar',
-          'showAttributes', 'showMethods', 'showTraits',
-          'showActions', 'showTransitionLabels', 'showGuards', 'showGuardLabels', 'showNaturalLanguage',
-          'showFeatureDependency', 'layoutAlgorithm',
-          'activeProvider', 'configs',
+          'theme',
+          'hasSeenWelcome',
+          'showSidebar',
+          ...DISPLAY_PREF_KEYS,
+          'layoutAlgorithm',
+          'activeProvider',
+          'configs',
         ] as const
         const safe: Record<string, unknown> = {}
         for (const k of DATA_KEYS) {
@@ -160,15 +157,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         theme: state.theme,
         hasSeenWelcome: state.hasSeenWelcome,
         showSidebar: state.showSidebar,
-        showAttributes: state.showAttributes,
-        showMethods: state.showMethods,
-        showTraits: state.showTraits,
-        showActions: state.showActions,
-        showTransitionLabels: state.showTransitionLabels,
-        showGuards: state.showGuards,
-        showGuardLabels: state.showGuardLabels,
-        showNaturalLanguage: state.showNaturalLanguage,
-        showFeatureDependency: state.showFeatureDependency,
+        ...Object.fromEntries(DISPLAY_PREF_KEYS.map((key) => [key, state[key]])),
         layoutAlgorithm: state.layoutAlgorithm,
         activeProvider: state.activeProvider,
         configs: state.configs,
@@ -181,58 +170,28 @@ export const usePreferencesStore = create<PreferencesState>()(
  *  Use as an effect dependency to trigger diagram refresh on pref changes. */
 export function selectSuboptionsKey(s: PreferencesState): string {
   return JSON.stringify([
-    s.showAttributes, s.showMethods, s.showTraits,
-    s.showActions, s.showTransitionLabels, s.showGuards, s.showGuardLabels, s.showNaturalLanguage,
-    s.showFeatureDependency, s.layoutAlgorithm,
+    ...DISPLAY_PREF_KEYS.map((key) => s[key]),
+    s.layoutAlgorithm,
   ])
 }
 
-/** Builds the suboptions array to send to the backend based on display preferences. */
-export function buildSuboptions(
-  prefs: Pick<PreferencesState,
-    'showAttributes' | 'showMethods' | 'showTraits' |
-    'showActions' | 'showTransitionLabels' | 'showGuards' | 'showGuardLabels' | 'showNaturalLanguage' |
-    'showFeatureDependency' | 'layoutAlgorithm'
-  >,
-  viewMode: string,
-  isDark: boolean,
-): string[] {
-  const opts: string[] = []
+export { buildSuboptions, getEffectiveDiagramType }
 
-  if (viewMode === 'class') {
-    if (!prefs.showAttributes) opts.push('hideattributes')
-    if (prefs.showMethods) opts.push('showmethods')
-  } else if (viewMode === 'state') {
-    if (!prefs.showActions) opts.push('hideactions')
-    if (prefs.showTransitionLabels) opts.push('showtransitionlabels')
-    if (!prefs.showGuards) opts.push('hideguards')
-    if (prefs.showGuardLabels) opts.push('showguardlabels')
-    if (!prefs.showNaturalLanguage) opts.push('hidenaturallanguage')
-  } else if (viewMode === 'feature') {
-    if (prefs.showFeatureDependency) opts.push('showFeatureDependency')
+export function selectDiagramDisplayPrefs(
+  s: Pick<PreferencesState, keyof DiagramDisplayPrefs>
+): DiagramDisplayPrefs {
+  return {
+    showAttributes: s.showAttributes,
+    showMethods: s.showMethods,
+    showTraits: s.showTraits,
+    showActions: s.showActions,
+    showTransitionLabels: s.showTransitionLabels,
+    showGuards: s.showGuards,
+    showGuardLabels: s.showGuardLabels,
+    showNaturalLanguage: s.showNaturalLanguage,
+    showFeatureDependency: s.showFeatureDependency,
+    layoutAlgorithm: s.layoutAlgorithm,
   }
-
-  if (prefs.layoutAlgorithm !== 'dot') {
-    opts.push('gv' + prefs.layoutAlgorithm)
-  }
-
-  if (isDark) opts.push('gvdark')
-
-  return opts
 }
 
-/** Returns the effective diagram type, accounting for the Traits toggle. */
-export function getEffectiveDiagramType(viewMode: string, showTraits: boolean): string {
-  const VIEW_TO_GV_TYPE: Record<string, string> = {
-    class: 'GvClassDiagram',
-    state: 'GvStateDiagram',
-    feature: 'GvFeatureDiagram',
-    structure: 'StructureDiagram',
-    erd: 'GvEntityRelationshipDiagram',
-    instance: 'InstanceDiagram',
-    eventSequence: 'EventSequence',
-    stateTables: 'StateTables',
-  }
-  if (viewMode === 'class' && showTraits) return 'GvClassTraitDiagram'
-  return VIEW_TO_GV_TYPE[viewMode] ?? 'GvClassDiagram'
-}
+export type { DiagramDisplayPrefs, DiagramView } from '../constants/diagram'

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -2,20 +2,14 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import type { Node, Edge } from '@xyflow/react'
 import type { UmpleModel, GvLayout, StoredLayoutMetadata, ApiTab } from '../api/types'
+import { VIEW_OUTPUT_KIND } from '../constants/diagram'
+import type { DiagramView } from '../constants/diagram'
 import { useEphemeralStore } from './ephemeralStore'
 import { ensureUmpExt } from '../lib/umpFile'
 
 // ── Diagram types ──
-
-export type DiagramView = 'class' | 'state' | 'feature' | 'structure' | 'erd' | 'instance' | 'eventSequence' | 'stateTables' | 'crud'
-
-/** Classifies each view by its backend output kind */
-export const VIEW_OUTPUT_KIND: Record<DiagramView, 'gv' | 'html' | 'component'> = {
-  class: 'gv', state: 'gv', feature: 'gv', structure: 'html',
-  erd: 'gv', instance: 'gv',
-  eventSequence: 'html', stateTables: 'html',
-  crud: 'component',
-}
+export type { DiagramView } from '../constants/diagram'
+export { VIEW_OUTPUT_KIND } from '../constants/diagram'
 
 interface DiagramElements {
   nodes: Node[]

--- a/frontend/tests/e2e/app-smoke.spec.ts
+++ b/frontend/tests/e2e/app-smoke.spec.ts
@@ -114,7 +114,7 @@ test('uses the selected diagram type for the first diagram request', async ({ pa
   await expect.poll(() => diagramTypes[diagramTypes.length - 1]).toBe('GvStateDiagram')
 })
 
-test('grouped dropdown renders all 8 diagram types with group labels', async ({ page }) => {
+test('grouped dropdown renders legacy diagram view groups', async ({ page }) => {
   await page.route('**/api/diagram', async (route) => {
     await route.fulfill({ json: { svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>' } })
   })
@@ -127,15 +127,17 @@ test('grouped dropdown renders all 8 diagram types with group labels', async ({ 
 
   // Verify group labels exist (scoped to label slots to avoid matching radio items)
   const labels = page.locator('[data-slot="dropdown-menu-label"]')
-  await expect(labels.filter({ hasText: 'Structure' })).toBeVisible()
-  await expect(labels.filter({ hasText: 'Behavior' })).toBeVisible()
-  await expect(labels.filter({ hasText: 'Other' })).toBeVisible()
+  await expect(labels.filter({ hasText: 'Class Views' })).toBeVisible()
+  await expect(labels.filter({ hasText: 'State Views' })).toBeVisible()
+  await expect(labels.filter({ hasText: 'Special Views' })).toBeVisible()
+  await expect(labels.filter({ hasText: 'Instance Views' })).toBeVisible()
+  await expect(page.locator('[data-slot="dropdown-menu-radio-group"] > [data-slot="dropdown-menu-radio-item"]')).toHaveCount(0)
 
-  // Verify all 8 diagram types are present
+  // Verify all exposed diagram types are present
   for (const id of [
     'diagram-view-class', 'diagram-view-erd', 'diagram-view-feature', 'diagram-view-structure',
     'diagram-view-state', 'diagram-view-eventSequence', 'diagram-view-stateTables',
-    'diagram-view-instance',
+    'diagram-view-instance', 'diagram-view-crud',
   ]) {
     await expect(page.getByTestId(id)).toBeVisible()
   }

--- a/frontend/tests/e2e/app-smoke.spec.ts
+++ b/frontend/tests/e2e/app-smoke.spec.ts
@@ -143,6 +143,72 @@ test('grouped dropdown renders legacy diagram view groups', async ({ page }) => 
   }
 })
 
+test('command palette lists all supported diagram commands and diagram commands work', async ({ page }) => {
+  const diagramTypes: string[] = []
+
+  await page.route('**/api/diagram', async (route) => {
+    const body = route.request().postDataJSON() as { diagramType?: string }
+    if (body.diagramType) diagramTypes.push(body.diagramType)
+    await route.fulfill({ json: { svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>' } })
+  })
+
+  await page.goto('/')
+  await expect(page.getByTestId('app-shell')).toBeVisible()
+
+  await page.keyboard.press('Control+k')
+  await page.getByTestId('command-item-examples-browse').click()
+  await page.getByTestId('command-item-category-Samples').click()
+  await page.getByTestId('command-item-example-Banking').click()
+  await expect(page.getByTestId('class-node-Account')).toBeVisible({ timeout: 10_000 })
+
+  await page.keyboard.press('Control+k')
+  await expect(page.getByTestId('command-palette')).toBeVisible()
+
+  for (const id of [
+    'command-item-diagram-class', 'command-item-diagram-erd', 'command-item-diagram-crud',
+    'command-item-diagram-state', 'command-item-diagram-stateTables',
+    'command-item-diagram-structure', 'command-item-diagram-feature',
+    'command-item-diagram-instance', 'command-item-diagram-eventSequence',
+  ]) {
+    await expect(page.getByTestId(id)).toBeVisible()
+  }
+
+  await expect(page.getByTestId('command-item-gen-Java')).toBeVisible()
+  await expect(page.getByTestId('command-item-gen-stateDiagram')).toHaveCount(0)
+  await expect(page.getByTestId('command-item-gen-featureDiagram')).toHaveCount(0)
+
+  await page.getByTestId('command-item-diagram-erd').click()
+  await expect.poll(() => diagramTypes[diagramTypes.length - 1]).toBe('GvEntityRelationshipDiagram')
+})
+
+test('command palette view commands toggle renderer, output panel, and diagram-only mode', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByTestId('app-shell')).toBeVisible()
+
+  await page.keyboard.press('Control+k')
+  await page.getByTestId('command-item-examples-browse').click()
+  await page.getByTestId('command-item-category-Samples').click()
+  await page.getByTestId('command-item-example-Banking').click()
+  await expect(page.getByTestId('class-node-Account')).toBeVisible({ timeout: 10_000 })
+
+  await page.keyboard.press('Control+k')
+  const initialRendererLabel = await page.getByTestId('command-item-view-renderer').textContent()
+  await page.getByTestId('command-item-view-renderer').click()
+
+  await page.keyboard.press('Control+k')
+  if (initialRendererLabel?.includes('Editable')) {
+    await expect(page.getByTestId('command-item-view-renderer')).toContainText('Graphviz')
+  } else {
+    await expect(page.getByTestId('command-item-view-renderer')).toContainText('Editable')
+  }
+  await page.getByTestId('command-item-view-output-panel').click()
+  await expect(page.getByTestId('output-panel')).toBeVisible()
+
+  await page.keyboard.press('Control+k')
+  await page.getByTestId('command-item-view-diagram-only').click()
+  await expect(page.getByTestId('editor-panel')).toHaveCount(0)
+})
+
 test('ERD selection sends GvEntityRelationshipDiagram to backend', async ({ page }) => {
   const diagramTypes: string[] = []
 


### PR DESCRIPTION
## Summary
- Group diagram types consistently across the toolbar, command palette, and example/model selectors
- Update execution, banner, sidebar, and session state handling to match the new grouping behavior
- Adjust smoke coverage to reflect the updated UI flow

## Testing
- Not run (not requested)