### PR TITLE
Update large dropdown pickers to searchable comboboxes

### DIFF
--- a/frontend/src/components/layout/AppToolbar.tsx
+++ b/frontend/src/components/layout/AppToolbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useEphemeralStore } from '../../stores/ephemeralStore'
 import { useSessionStore, type DiagramView } from '../../stores/sessionStore'
 import { useCompile } from '../../hooks/useExecute'
@@ -9,24 +9,17 @@ import { AiConfigForm } from '@/components/sidebar/AiConfigForm'
 import { useTaskStore } from '../../stores/taskStore'
 import { ToolbarDivider } from '@/components/diagram/CanvasToolbar'
 import { Hammer, Loader2, Check, ChevronDown, Code, Sparkles, ClipboardList, Plus, Search, BookOpen } from 'lucide-react'
+import { Combobox, type ComboboxGroup } from '@/components/ui/combobox'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuGroup,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubTrigger,
-  DropdownMenuSubContent,
 } from '@/components/ui/dropdown-menu'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { Tip } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { VIEW_MODE_GROUPS, getViewModeOption } from '../../constants/diagram'
+import { VIEW_MODE_GROUPS } from '../../constants/diagram'
 
 const pillBase = 'flex items-center bg-surface-0 rounded-lg border border-border shadow-sm px-1 py-1'
 const toolbarBtn = 'flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors cursor-pointer'
@@ -40,7 +33,45 @@ export function AppToolbar() {
   const viewMode = useSessionStore((s) => s.viewMode)
   const setViewMode = useSessionStore((s) => s.setViewMode)
   const handleGenerate = useGenerate()
-  const { categories: exampleCategories, loadExample } = useExamples()
+  const { categories: exampleCategories, loadExample, loading: loadingExamples } = useExamples()
+
+  const viewModeGroups = useMemo<ComboboxGroup[]>(
+    () => VIEW_MODE_GROUPS.map((group) => ({
+      label: group.label,
+      options: group.modes.map((mode) => ({
+        value: mode.value,
+        label: mode.longLabel ?? mode.label,
+        triggerLabel: mode.label,
+        testId: `diagram-view-${mode.value}`,
+        keywords: [mode.label, mode.longLabel, group.label].filter(Boolean) as string[],
+      })),
+    })),
+    [],
+  )
+
+  const exampleGroups = useMemo<ComboboxGroup[]>(
+    () => exampleCategories.map((category) => ({
+      label: category.name,
+      options: category.examples.map((example) => ({
+        value: JSON.stringify({ name: example.name, category: category.name }),
+        label: example.label || example.name,
+        keywords: [example.name, category.name],
+      })),
+    })),
+    [exampleCategories],
+  )
+
+  const generateGroups = useMemo<ComboboxGroup[]>(
+    () => GENERATE_ONLY_TARGET_GROUPS.map((group) => ({
+      label: group.label,
+      options: group.targets.map((target) => ({
+        value: target.id,
+        label: target.label,
+        keywords: [target.id, group.label],
+      })),
+    })),
+    [],
+  )
 
   // Compile success micro-interaction
   const prevCompilingRef = useRef(compiling)
@@ -94,35 +125,28 @@ export function AppToolbar() {
 
         <ToolbarDivider />
 
-        <DropdownMenu>
-          <Tip content="Load example" side="bottom">
-            <DropdownMenuTrigger asChild>
-              <button className={toolbarBtn} aria-label="Examples">
-                <BookOpen className="size-3.5" />
-                Examples
-                <ChevronDown className="size-3 shrink-0" />
-              </button>
-            </DropdownMenuTrigger>
-          </Tip>
-          <DropdownMenuContent align="start" className="w-48">
-            {exampleCategories.length === 0 ? (
-              <DropdownMenuItem disabled>Loading examples...</DropdownMenuItem>
-            ) : (
-              exampleCategories.map((cat) => (
-                <DropdownMenuSub key={cat.name}>
-                  <DropdownMenuSubTrigger>{cat.name}</DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent className="w-56 max-h-72">
-                    {cat.examples.map((ex) => (
-                      <DropdownMenuItem key={ex.name} onSelect={() => loadExample(ex.name, cat.name)}>
-                        {ex.label || ex.name}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
-              ))
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <Combobox
+          groups={exampleGroups}
+          onSelect={(selection) => {
+            const parsed = JSON.parse(selection) as { name: string; category: string }
+            void loadExample(parsed.name, parsed.category)
+          }}
+          placeholder="Examples"
+          searchPlaceholder="Search examples..."
+          emptyText={loadingExamples ? 'Loading examples...' : 'No examples.'}
+          disabled={loadingExamples && exampleGroups.length === 0}
+          className={cn(toolbarBtn, 'w-auto h-auto border-0 bg-transparent px-1.5 py-0.5 focus:border-transparent focus:ring-0')}
+          contentClassName="w-64 min-w-[16rem]"
+          listClassName="max-h-72"
+          triggerChildren={(
+            <>
+              <BookOpen className="size-3.5" />
+              Examples
+              <ChevronDown className="size-3 shrink-0" />
+            </>
+          )}
+          ariaLabel="Examples"
+        />
       </div>
 
       <div className={cn(pillBase, 'gap-0.5')}>
@@ -149,43 +173,33 @@ export function AppToolbar() {
           </button>
         </Tip>
 
-        <DropdownMenu>
-          <Tip content="Diagram view" side="bottom">
-            <DropdownMenuTrigger
-              data-tour="diagram-view"
-              className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-ink-muted rounded-md hover:text-ink hover:bg-surface-2 transition-colors cursor-pointer outline-none"
-              aria-label="Diagram view"
-            >
-              <span className="truncate">{getViewModeOption(viewMode)?.label ?? 'Class'}</span>
-              <ChevronDown className="size-3 shrink-0" />
-            </DropdownMenuTrigger>
-          </Tip>
-          <DropdownMenuContent align="start" className="w-48">
-            <DropdownMenuRadioGroup value={viewMode} onValueChange={(v) => setViewMode(v as DiagramView)}>
-              {VIEW_MODE_GROUPS.map((group, index) => (
-                <DropdownMenuGroup key={group.label}>
-                  {index > 0 && <DropdownMenuSeparator />}
-                  <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
-                  {group.modes.map((m) => (
-                    <DropdownMenuRadioItem key={m.value} value={m.value} data-testid={`diagram-view-${m.value}`}>
-                      {m.label}
-                    </DropdownMenuRadioItem>
-                  ))}
-                </DropdownMenuGroup>
-              ))}
-            </DropdownMenuRadioGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <Combobox
+          groups={viewModeGroups}
+          value={viewMode}
+          onSelect={(value) => setViewMode(value as DiagramView)}
+          searchPlaceholder="Search views..."
+          className="w-auto h-auto border-0 bg-transparent px-2 py-1 font-medium text-ink-muted hover:text-ink hover:bg-surface-2 focus:border-transparent focus:ring-0"
+          contentClassName="w-64 min-w-[16rem]"
+          listClassName="max-h-80"
+          ariaLabel="Diagram view"
+          data-tour="diagram-view"
+        />
 
         <ToolbarDivider />
 
-        <DropdownMenu>
-          <Tip content="Generate code" side="bottom">
-            <DropdownMenuTrigger
-              className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-ink-muted rounded-md hover:text-ink hover:bg-surface-2 transition-colors cursor-pointer outline-none disabled:cursor-not-allowed disabled:opacity-70"
-              aria-label="Generate"
-              disabled={generatingCode}
-            >
+        <Combobox
+          groups={generateGroups}
+          onSelect={(targetId) => {
+            void handleGenerate(targetId)
+          }}
+          placeholder="Generate"
+          searchPlaceholder="Search targets..."
+          disabled={generatingCode}
+          className="w-auto h-auto border-0 bg-transparent px-2 py-1 font-medium text-ink-muted hover:text-ink hover:bg-surface-2 focus:border-transparent focus:ring-0"
+          contentClassName="w-72 min-w-[18rem]"
+          listClassName="max-h-80"
+          triggerChildren={(
+            <>
               {generatingCode ? (
                 <Loader2 className="size-3.5 shrink-0 animate-spin" />
               ) : (
@@ -193,25 +207,10 @@ export function AppToolbar() {
               )}
               <span className="truncate">{generatingCode ? 'Generating...' : 'Generate'}</span>
               <ChevronDown className="size-3 shrink-0" />
-            </DropdownMenuTrigger>
-          </Tip>
-          <DropdownMenuContent align="end" className="w-52 max-h-80">
-            {GENERATE_ONLY_TARGET_GROUPS.map((group, gi) => (
-              <DropdownMenuGroup key={group.label}>
-                {gi > 0 && <DropdownMenuSeparator />}
-                <DropdownMenuLabel className="text-xxs">{group.label}</DropdownMenuLabel>
-                {group.targets.map((target) => (
-                  <DropdownMenuItem
-                    key={target.id}
-                    onSelect={() => handleGenerate(target.id)}
-                  >
-                    {target.label}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuGroup>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
+            </>
+          )}
+          ariaLabel="Generate"
+        />
       </div>
 
       <div className={cn(pillBase, 'absolute right-3 top-1/2 -translate-y-1/2')}>

--- a/frontend/src/components/layout/CanvasBanner.tsx
+++ b/frontend/src/components/layout/CanvasBanner.tsx
@@ -1,17 +1,9 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useEphemeralStore } from '../../stores/ephemeralStore'
 import { useGenerate } from '../../hooks/useGenerate'
 import { GENERATE_ONLY_TARGET_GROUPS, getGenerateTarget } from '../../generation/targets'
 import { ChevronDown, Maximize2, Minimize2 } from 'lucide-react'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  DropdownMenuGroup,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-} from '@/components/ui/dropdown-menu'
+import { Combobox, type ComboboxGroup } from '@/components/ui/combobox'
 import { Tip } from '@/components/ui/tooltip'
 import { lineTabClasses } from '@/components/ui/line-tab'
 import { cn } from '@/lib/utils'
@@ -25,6 +17,17 @@ export function CanvasBanner() {
   const generatingCode = useEphemeralStore((s) => s.generatingCode)
   const generationRequested = useEphemeralStore((s) => s.generationRequested)
   const handleGenerate = useGenerate()
+  const generateGroups = useMemo<ComboboxGroup[]>(
+    () => GENERATE_ONLY_TARGET_GROUPS.map((group) => ({
+      label: group.label,
+      options: group.targets.map((target) => ({
+        value: target.id,
+        label: target.label,
+        keywords: [target.id, group.label],
+      })),
+    })),
+    [],
+  )
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -80,33 +83,19 @@ export function CanvasBanner() {
                 <span className="truncate">{getGenerateTarget(generatedTargetId)?.label ?? generatedTargetId}</span>
               </button>
             </Tip>
-            <DropdownMenu>
-              <Tip content="Change language" side="bottom">
-                <DropdownMenuTrigger
-                  className="px-1 py-0.5 text-xs transition-colors cursor-pointer outline-none text-ink-faint hover:text-ink-muted"
-                  aria-label="Change language"
-                >
-                  <ChevronDown className="size-3" />
-                </DropdownMenuTrigger>
-              </Tip>
-              <DropdownMenuContent align="start" className="w-52 max-h-64">
-                {GENERATE_ONLY_TARGET_GROUPS.map((group, gi) => (
-                  <DropdownMenuGroup key={group.label}>
-                    {gi > 0 && <DropdownMenuSeparator />}
-                    <DropdownMenuLabel className="text-xxs">{group.label}</DropdownMenuLabel>
-                    {group.targets.map((target) => (
-                      <DropdownMenuItem
-                        key={target.id}
-                        onSelect={() => handleGenerate(target.id)}
-                        className={`text-xs ${target.id === generatedTargetId ? 'bg-brand-light text-brand font-semibold' : ''}`}
-                      >
-                        {target.label}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuGroup>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <Combobox
+              groups={generateGroups}
+              value={generatedTargetId}
+              onSelect={(targetId) => {
+                void handleGenerate(targetId)
+              }}
+              searchPlaceholder="Search targets..."
+              className="h-auto w-auto border-0 bg-transparent px-1 py-0.5 text-xs text-ink-faint hover:text-ink-muted focus:border-transparent focus:ring-0"
+              contentClassName="w-72 min-w-[18rem]"
+              listClassName="max-h-72"
+              triggerChildren={<ChevronDown className="size-3" />}
+              ariaLabel="Change language"
+            />
           </div>
         )}
       </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -7,8 +7,8 @@ import { useExecute } from '../../hooks/useExecute'
 import { useGenerate } from '../../hooks/useGenerate'
 import { GENERATE_ONLY_TARGETS, GENERATE_ONLY_TARGET_GROUPS, getGenerateTarget } from '../../generation/targets'
 import { LAYOUT_OPTIONS, VIEW_MODE_GROUPS, getViewForExampleCategory, getLayoutOption } from '../../constants/diagram'
-import { Combobox } from '@/components/ui/combobox'
-import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Combobox, type ComboboxGroup } from '@/components/ui/combobox'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import {
@@ -180,7 +180,7 @@ function ToolsGroup() {
   const { execute } = useExecute()
   const running = useEphemeralStore((s) => s.executing)
   const generate = useGenerate()
-  const { categories: allCategories, loadExample } = useExamples()
+  const { categories: allCategories, loadExample, loading: loadingExamples } = useExamples()
   const targetId = useSessionStore((s) => s.generateTargetId)
   const setTargetId = useSessionStore((s) => s.setGenerateTargetId)
   const selectedExample = useSessionStore((s) => s.selectedExample)
@@ -198,6 +198,18 @@ function ToolsGroup() {
       options: g.targets.map((t) => ({ value: t.id, label: t.label })),
     })),
     []
+  )
+
+  const viewModeGroups = useMemo<ComboboxGroup[]>(
+    () => VIEW_MODE_GROUPS.map((group) => ({
+      label: group.label,
+      options: group.modes.map((mode) => ({
+        value: mode.value,
+        label: mode.longLabel ?? mode.label,
+        keywords: [mode.label, mode.longLabel, group.label].filter(Boolean) as string[],
+      })),
+    })),
+    [],
   )
 
   const exampleOptions = useMemo(
@@ -220,31 +232,22 @@ function ToolsGroup() {
         <div data-tour="examples">
           <SubLabel>Examples</SubLabel>
           <div className="space-y-1.5">
-            <Select value={viewMode} onValueChange={(v) => setViewMode(v as typeof viewMode)}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {VIEW_MODE_GROUPS.map((group, index) => (
-                  <SelectGroup key={group.label}>
-                    {index > 0 && <SelectSeparator />}
-                    <SelectLabel>{group.label}</SelectLabel>
-                    {group.modes.map((m) => (
-                      <SelectItem key={m.value} value={m.value}>
-                        {m.longLabel ?? m.label}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              groups={viewModeGroups}
+              value={viewMode}
+              onSelect={(value) => setViewMode(value as typeof viewMode)}
+              placeholder="Select view..."
+              searchPlaceholder="Search views..."
+            />
             <Combobox
               key={viewMode}
               options={exampleOptions}
               value={selectedExample ?? undefined}
               onSelect={loadExample}
-              placeholder={exampleOptions.length > 0 ? 'Load an example...' : 'No examples'}
+              placeholder={loadingExamples ? 'Loading examples...' : exampleOptions.length > 0 ? 'Load an example...' : 'No examples'}
               searchPlaceholder="Search examples..."
+              emptyText={loadingExamples ? 'Loading examples...' : 'No results.'}
+              disabled={loadingExamples && exampleOptions.length === 0}
             />
           </div>
         </div>

--- a/frontend/src/components/onboarding/OnboardingTour.tsx
+++ b/frontend/src/components/onboarding/OnboardingTour.tsx
@@ -38,7 +38,7 @@ const TOUR_STEPS: TourStep[] = [
   {
     target: '[data-tour="diagram-view"]',
     title: 'Switch to State Machine',
-    description: 'Click this dropdown and select "State" to switch the diagram view.',
+    description: 'Open this view picker and select "State" to switch the diagram view.',
     placement: 'bottom',
     icon: MousePointerClick,
     interactive: true,
@@ -47,7 +47,7 @@ const TOUR_STEPS: TourStep[] = [
   {
     target: '[data-tour="examples"]',
     title: 'Pick a state machine example',
-    description: 'Choose any example from the dropdown to load a state machine model.',
+    description: 'Choose any example from the picker to load a state machine model.',
     placement: 'right',
     icon: MousePointerClick,
     interactive: true,
@@ -68,7 +68,7 @@ const TOUR_STEPS: TourStep[] = [
   {
     target: '[data-tour="generate"]',
     title: 'Generate Python code',
-    description: 'Select "Python" from the language dropdown, then click Generate to produce working code from your model.',
+    description: 'Select "Python" from the target picker, then click Generate to produce working code from your model.',
     placement: 'right',
     icon: MousePointerClick,
     interactive: true,

--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { CheckIcon, ChevronDownIcon, SearchIcon } from 'lucide-react'
+import { type ReactNode, useState } from 'react'
+import { CheckIcon, ChevronDownIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
@@ -7,6 +7,9 @@ import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, Command
 export interface ComboboxOption {
   value: string
   label: string
+  triggerLabel?: string
+  testId?: string
+  keywords?: string[]
 }
 
 export interface ComboboxGroup {
@@ -26,7 +29,14 @@ interface ComboboxProps {
   emptyText?: string
   /** Show search input. Defaults to true. */
   searchable?: boolean
+  disabled?: boolean
+  ariaLabel?: string
   className?: string
+  contentClassName?: string
+  listClassName?: string
+  triggerChildren?: ReactNode
+  'data-testid'?: string
+  'data-tour'?: string
 }
 
 export function Combobox({
@@ -38,7 +48,14 @@ export function Combobox({
   searchPlaceholder = 'Search...',
   emptyText = 'No results.',
   searchable = true,
+  disabled = false,
+  ariaLabel,
   className,
+  contentClassName,
+  listClassName,
+  triggerChildren,
+  'data-testid': dataTestId,
+  'data-tour': dataTour,
 }: ComboboxProps) {
   const [open, setOpen] = useState(false)
 
@@ -48,11 +65,13 @@ export function Combobox({
   const renderItem = (option: ComboboxOption) => (
     <CommandItem
       key={option.value}
-      value={option.label}
+      value={[option.label, option.keywords?.join(' '), option.value].filter(Boolean).join(' ')}
+      keywords={option.keywords}
       onSelect={() => {
         onSelect(option.value)
         setOpen(false)
       }}
+      data-testid={option.testId}
       className="gap-1.5 px-2 py-1 text-xs"
     >
       <CheckIcon className={cn('size-3 shrink-0', option.value === value ? 'opacity-100' : 'opacity-0')} />
@@ -61,28 +80,39 @@ export function Combobox({
   )
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger
-        className={cn(
-          'flex w-full items-center justify-between gap-1 rounded-md border border-surface-2 bg-surface-0 h-8 px-2.5 py-1.5 text-xs text-ink outline-none hover:bg-surface-1 focus:border-brand focus:ring-1 focus:ring-brand transition-colors cursor-pointer',
-          !selected && 'text-ink-muted',
-          className
-        )}
-      >
-        <span className="truncate">{selected?.label ?? placeholder}</span>
-        <ChevronDownIcon className="size-3 shrink-0 text-ink-faint" />
+    <Popover open={open} onOpenChange={(nextOpen) => !disabled && setOpen(nextOpen)}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          disabled={disabled}
+          data-testid={dataTestId}
+          data-tour={dataTour}
+          className={cn(
+            'flex w-full items-center justify-between gap-1 rounded-md border border-surface-2 bg-surface-0 h-8 px-2.5 py-1.5 text-xs text-ink outline-none hover:bg-surface-1 focus:border-brand focus:ring-1 focus:ring-brand transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-70',
+            !selected && !triggerChildren && 'text-ink-muted',
+            className
+          )}
+        >
+          {triggerChildren ?? (
+            <>
+              <span className="truncate">{selected?.triggerLabel ?? selected?.label ?? placeholder}</span>
+              <ChevronDownIcon className="size-3 shrink-0 text-ink-faint" />
+            </>
+          )}
+        </button>
       </PopoverTrigger>
 
       <PopoverContent
         align="start"
-        className="w-[var(--radix-popover-trigger-width)] min-w-[180px] p-0"
+        className={cn('w-[var(--radix-popover-trigger-width)] min-w-[180px] p-0', contentClassName)}
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <Command shouldFilter={searchable}>
           {searchable && (
             <CommandInput placeholder={searchPlaceholder} className="h-7 text-xs" />
           )}
-          <CommandList className="max-h-[180px]">
+          <CommandList className={cn('max-h-[180px]', listClassName)}>
             <CommandEmpty className="py-3 text-center text-xs text-ink-faint">
               {emptyText}
             </CommandEmpty>

--- a/frontend/tests/e2e/app-smoke.spec.ts
+++ b/frontend/tests/e2e/app-smoke.spec.ts
@@ -125,13 +125,12 @@ test('grouped dropdown renders legacy diagram view groups', async ({ page }) => 
   // Open the diagram view dropdown
   await page.getByLabel('Diagram view').click()
 
-  // Verify group labels exist (scoped to label slots to avoid matching radio items)
-  const labels = page.locator('[data-slot="dropdown-menu-label"]')
-  await expect(labels.filter({ hasText: 'Class Views' })).toBeVisible()
-  await expect(labels.filter({ hasText: 'State Views' })).toBeVisible()
-  await expect(labels.filter({ hasText: 'Special Views' })).toBeVisible()
-  await expect(labels.filter({ hasText: 'Instance Views' })).toBeVisible()
-  await expect(page.locator('[data-slot="dropdown-menu-radio-group"] > [data-slot="dropdown-menu-radio-item"]')).toHaveCount(0)
+  // Verify grouped headings exist in the combobox.
+  await expect(page.locator('[cmdk-group-heading]').filter({ hasText: 'Class Views' })).toBeVisible()
+  await expect(page.locator('[cmdk-group-heading]').filter({ hasText: 'State Views' })).toBeVisible()
+  await expect(page.locator('[cmdk-group-heading]').filter({ hasText: 'Special Views' })).toBeVisible()
+  await expect(page.locator('[cmdk-group-heading]').filter({ hasText: 'Instance Views' })).toBeVisible()
+  await expect(page.getByPlaceholder('Search views...')).toBeVisible()
 
   // Verify all exposed diagram types are present
   for (const id of [

--- a/frontend/tests/e2e/crud-objects.spec.ts
+++ b/frontend/tests/e2e/crud-objects.spec.ts
@@ -92,7 +92,7 @@ test('Objects tab loads schema after compiling an example', async ({ page }) => 
   const canvasDropdown = page.getByRole('button', { name: /Diagram view/i })
   await expect(canvasDropdown).toBeVisible()
   await canvasDropdown.click()
-  const crudItem = page.getByRole('menuitemradio', { name: /CRUD UI/i })
+  const crudItem = page.getByTestId('diagram-view-crud')
   await expect(crudItem).toBeVisible()
 
   // Set up schema response waiter before triggering navigation

--- a/frontend/tests/e2e/display-options.spec.ts
+++ b/frontend/tests/e2e/display-options.spec.ts
@@ -123,11 +123,26 @@ async function getToggleState(page: Page, prefKey: string): Promise<boolean> {
 
 /** Switch diagram view mode via the "Diagram view" button. */
 async function switchViewMode(page: Page, viewLabel: string) {
+  const viewIds: Record<string, string> = {
+    Class: 'diagram-view-class',
+    'Entity Relationship': 'diagram-view-erd',
+    'CRUD UI': 'diagram-view-crud',
+    State: 'diagram-view-state',
+    'State Tables': 'diagram-view-stateTables',
+    Structure: 'diagram-view-structure',
+    Feature: 'diagram-view-feature',
+    Instance: 'diagram-view-instance',
+    'Event Sequence': 'diagram-view-eventSequence',
+  }
+
   // The view mode button is labeled "Diagram view" and shows the current mode
   const viewBtn = page.getByRole('button', { name: 'Diagram view' })
   await viewBtn.click()
-  // Click the desired view in the dropdown
-  await page.getByText(viewLabel, { exact: false }).first().click()
+  const targetId = viewIds[viewLabel]
+  if (!targetId) {
+    throw new Error(`Unknown view label: ${viewLabel}`)
+  }
+  await page.getByTestId(targetId).click()
   await page.waitForTimeout(500)
 }
 


### PR DESCRIPTION
## Summary
- replace the toolbar example, diagram view, and generate menus with grouped searchable comboboxes
- convert the sidebar diagram view picker and generated-output language picker to the same combobox pattern
- extend the shared combobox to support grouped keywords, custom triggers, disabled state, and item test ids
- update onboarding copy and E2E selectors to match the new combobox interaction model

## Testing
- `cd frontend && bun run build`
- `cd frontend && bun run test:e2e:typecheck`
- `cd frontend && bun run test:e2e -- tests/e2e/app-smoke.spec.ts tests/e2e/crud-objects.spec.ts`
- Live display-options E2E suite not run in this change