### PR TITLE
Refactor shared example categories across diagram views

### DIFF
--- a/backend/internal/api/handlers/example.go
+++ b/backend/internal/api/handlers/example.go
@@ -28,17 +28,34 @@ type ExampleEntry struct {
 	Filename string `json:"filename"`
 }
 
+type ExampleCategoryID string
+
+const (
+	ExampleCategoryClass     ExampleCategoryID = "class"
+	ExampleCategoryState     ExampleCategoryID = "state"
+	ExampleCategoryStructure ExampleCategoryID = "structure"
+	ExampleCategoryFeature   ExampleCategoryID = "feature"
+	ExampleCategoryOther     ExampleCategoryID = "other"
+)
+
 type ExampleCategory struct {
-	Name     string         `json:"name"`
-	Examples []ExampleEntry `json:"examples"`
+	ID       ExampleCategoryID `json:"id"`
+	Label    string            `json:"label"`
+	Name     string            `json:"name"`
+	Examples []ExampleEntry    `json:"examples"`
+}
+
+type exampleCategoryDef struct {
+	ID    ExampleCategoryID
+	Label string
 }
 
 // categoryOrder defines the display order of example categories.
-var categoryOrder = []string{
-	"Class Diagrams",
-	"State Machines",
-	"Composite Structure",
-	"Feature Diagrams",
+var categoryOrder = []exampleCategoryDef{
+	{ID: ExampleCategoryClass, Label: "Class Diagrams"},
+	{ID: ExampleCategoryState, Label: "State Machines"},
+	{ID: ExampleCategoryStructure, Label: "Composite Structure"},
+	{ID: ExampleCategoryFeature, Label: "Feature Diagrams"},
 }
 
 // hiddenExamples are present on disk but were intentionally not exposed in the
@@ -49,8 +66,8 @@ var hiddenExamples = map[string]bool{
 
 // categoryMembers maps each category to its curated list of example names
 // (without .ump extension). Derived from legacy UmpleOnline (umple.php).
-var categoryMembers = map[string][]string{
-	"Class Diagrams": {
+var categoryMembers = map[ExampleCategoryID][]string{
+	ExampleCategoryClass: {
 		"2DShapes", "AccessControl", "AccessControl2", "Accidents", "Accommodations",
 		"AfghanRainDesign", "AirlineExample", "Auction", "BankingSystemA", "BankingSystemB",
 		"CanalSystem", "Claim", "CommunityAssociation", "Compositions", "CoOpSystem",
@@ -63,7 +80,7 @@ var categoryMembers = map[string][]string{
 		"School", "TelephoneSystem", "UniversitySystem", "VendingMachineClassDiagram",
 		"WarehouseSystem", "realestate",
 	},
-	"State Machines": {
+	ExampleCategoryState: {
 		"AgentsCommunication", "ApplicationProcessing", "Auction", "Booking",
 		"CanalLockStateMachine", "CarTransmission", "CollisionAvoidance",
 		"CollisionAvoidanceA1", "CollisionAvoidanceA2", "CollisionAvoidanceA3",
@@ -76,10 +93,10 @@ var categoryMembers = map[string][]string{
 		"TelephoneSystem2", "TicTacToe", "TimedCommands", "TollBooth",
 		"TrafficLightsA", "TrafficLightsB",
 	},
-	"Composite Structure": {
+	ExampleCategoryStructure: {
 		"PingPong", "OBDCarSystem",
 	},
-	"Feature Diagrams": {
+	ExampleCategoryFeature: {
 		"BerkeleyDB_SPL", "BerkeleyDB_SP_featureDepend", "HelloWorld_SPL",
 	},
 }
@@ -136,48 +153,48 @@ var displayLabels = map[string]string{
 	"VendingMachineClassDiagram":    "Vending Machine",
 	"WarehouseSystem":               "Warehouse System",
 	// State Machines
-	"AgentsCommunication":       "Agents Communicating *",
-	"ApplicationProcessing":     "Application for a Grant",
-	"Booking":                   "Booking (Airline)",
-	"CanalLockStateMachine":     "Canal Lock",
-	"CarTransmission":           "Car Transmission",
-	"CollisionAvoidance":        "Collision Avoidance With And-Cross Transition",
-	"CollisionAvoidanceA1":      "Collision Avoidance - Alternative 1",
-	"CollisionAvoidanceA2":      "Collision Avoidance - Alternative 2",
-	"CollisionAvoidanceA3":      "Collision Avoidance - Alternative 3",
-	"ComplexStateMachine":       "Complex Symbolic *",
-	"CourseSectionFlat":         "Course Section",
-	"CourseSectionNested":       "Course Section (Nested)",
-	"DigitalWatchFlat":          "Digital Watch (Flat) *",
-	"DigitalWatchNested":        "Digital Watch Nested *",
-	"Dishwasher":                "Dishwasher",
-	"Elevator_State_Machine":    "Elevator",
-	"GarageDoor":                "Garage Door",
-	"HomeHeater":                "Home Heating System",
-	"LibraryLoanStateMachine":   "Library Loan",
-	"Lights":                    "Light (3 alternatives)",
-	"MicrowaveOven2":            "Microwave Oven *",
-	"Ovens":                     "Oven (3 alternatives)",
-	"ParliamentBill":            "Parliament Bill",
-	"Phone":                     "Phone and Lines",
-	"Runway":                    "Runway",
-	"SecurityLight":             "Security Light",
-	"SpecificFlight":            "Specific Flight (Airline)",
-	"SpecificFlightFlat":        "Specific Flight (Airline - Flat)",
-	"TcpIpSimulation":           "TCP/IP Simulation *",
-	"TelephoneSystem2":          "Telephone Set Modes",
-	"TicTacToe":                 "Tic Tac Toe or Noughts and Crosses",
-	"TimedCommands":             "Timed Commands *",
-	"TollBooth":                 "Toll Booth",
-	"TrafficLightsA":            "Traffic Lights A",
-	"TrafficLightsB":            "Traffic Lights B",
+	"AgentsCommunication":     "Agents Communicating *",
+	"ApplicationProcessing":   "Application for a Grant",
+	"Booking":                 "Booking (Airline)",
+	"CanalLockStateMachine":   "Canal Lock",
+	"CarTransmission":         "Car Transmission",
+	"CollisionAvoidance":      "Collision Avoidance With And-Cross Transition",
+	"CollisionAvoidanceA1":    "Collision Avoidance - Alternative 1",
+	"CollisionAvoidanceA2":    "Collision Avoidance - Alternative 2",
+	"CollisionAvoidanceA3":    "Collision Avoidance - Alternative 3",
+	"ComplexStateMachine":     "Complex Symbolic *",
+	"CourseSectionFlat":       "Course Section",
+	"CourseSectionNested":     "Course Section (Nested)",
+	"DigitalWatchFlat":        "Digital Watch (Flat) *",
+	"DigitalWatchNested":      "Digital Watch Nested *",
+	"Dishwasher":              "Dishwasher",
+	"Elevator_State_Machine":  "Elevator",
+	"GarageDoor":              "Garage Door",
+	"HomeHeater":              "Home Heating System",
+	"LibraryLoanStateMachine": "Library Loan",
+	"Lights":                  "Light (3 alternatives)",
+	"MicrowaveOven2":          "Microwave Oven *",
+	"Ovens":                   "Oven (3 alternatives)",
+	"ParliamentBill":          "Parliament Bill",
+	"Phone":                   "Phone and Lines",
+	"Runway":                  "Runway",
+	"SecurityLight":           "Security Light",
+	"SpecificFlight":          "Specific Flight (Airline)",
+	"SpecificFlightFlat":      "Specific Flight (Airline - Flat)",
+	"TcpIpSimulation":         "TCP/IP Simulation *",
+	"TelephoneSystem2":        "Telephone Set Modes",
+	"TicTacToe":               "Tic Tac Toe or Noughts and Crosses",
+	"TimedCommands":           "Timed Commands *",
+	"TollBooth":               "Toll Booth",
+	"TrafficLightsA":          "Traffic Lights A",
+	"TrafficLightsB":          "Traffic Lights B",
 	// Composite Structure
 	"PingPong":     "Ping Pong",
 	"OBDCarSystem": "OBD Car System",
 	// Feature Diagrams
 	"BerkeleyDB_SPL":              "BerkeleyDB SPL",
 	"BerkeleyDB_SP_featureDepend": "Feature Dependencies of BerkeleyDB SPL",
-	"HelloWorld_SPL":               "HelloWorld SPL",
+	"HelloWorld_SPL":              "HelloWorld SPL",
 }
 
 // labelFor returns the human-readable label for an example name.
@@ -213,8 +230,8 @@ func (h *ExampleHandler) List(w http.ResponseWriter, r *http.Request) {
 	claimed := make(map[string]bool)
 
 	var categories []ExampleCategory
-	for _, catName := range categoryOrder {
-		members := categoryMembers[catName]
+	for _, category := range categoryOrder {
+		members := categoryMembers[category.ID]
 		var exs []ExampleEntry
 		for _, name := range members {
 			if available[name] {
@@ -228,7 +245,9 @@ func (h *ExampleHandler) List(w http.ResponseWriter, r *http.Request) {
 		}
 		if len(exs) > 0 {
 			categories = append(categories, ExampleCategory{
-				Name:     catName,
+				ID:       category.ID,
+				Label:    category.Label,
+				Name:     category.Label,
 				Examples: exs,
 			})
 		}
@@ -250,6 +269,8 @@ func (h *ExampleHandler) List(w http.ResponseWriter, r *http.Request) {
 			return strings.ToLower(other[i].Name) < strings.ToLower(other[j].Name)
 		})
 		categories = append(categories, ExampleCategory{
+			ID:       ExampleCategoryOther,
+			Label:    "Other",
 			Name:     "Other",
 			Examples: other,
 		})
@@ -259,12 +280,14 @@ func (h *ExampleHandler) List(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(categories)
 }
 
-// categoryForExample returns the category name for the given example (without
-// .ump extension), or empty string if uncategorized.
-func categoryForExample(name string) string {
-	for cat, members := range categoryMembers {
-		if slices.Contains(members, name) {
-			return cat
+// categoryForExample returns the canonical category for the given example
+// (without .ump extension), or empty string if uncategorized. Some examples
+// appear in multiple categories, so this follows the display order above to
+// choose the default category for URL/bootstrap flows.
+func categoryForExample(name string) ExampleCategoryID {
+	for _, category := range categoryOrder {
+		if slices.Contains(categoryMembers[category.ID], name) {
+			return category.ID
 		}
 	}
 	return ""
@@ -293,8 +316,8 @@ func (h *ExampleHandler) Get(w http.ResponseWriter, r *http.Request) {
 		"code": userCode,
 	}
 
-	if cat := categoryForExample(baseName); cat != "" {
-		resp["category"] = cat
+	if categoryID := categoryForExample(baseName); categoryID != "" {
+		resp["defaultCategoryId"] = string(categoryID)
 	}
 
 	// If the example has a layout section, pre-create a model on disk with the

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,5 @@
 import type {
-  CompileRequest, CompileResponse, ExampleCategory, GenerateRequest, GenerateResponse,
+  CompileRequest, CompileResponse, ExampleCategory, ExampleResponse, GenerateRequest, GenerateResponse,
   DiagramResponse, GetModelResponse, CrudSchemaResponse, PromoteResponse,
 } from './types'
 
@@ -46,7 +46,7 @@ export const api = {
     return request(`/models/${encodeURIComponent(id)}`, { signal })
   },
 
-  getExample(name: string): Promise<{ name: string; code: string; modelId?: string; category?: string }> {
+  getExample(name: string): Promise<ExampleResponse> {
     return request(`/examples/${encodeURIComponent(name)}`)
   },
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -164,9 +164,20 @@ export interface ExampleEntry {
   filename: string
 }
 
+export type ExampleCategoryId = 'class' | 'state' | 'structure' | 'feature' | 'other'
+
 export interface ExampleCategory {
+  id: ExampleCategoryId
+  label: string
   name: string
   examples: ExampleEntry[]
+}
+
+export interface ExampleResponse {
+  name: string
+  code: string
+  modelId?: string
+  defaultCategoryId?: ExampleCategoryId
 }
 
 export interface GenerateRequest {

--- a/frontend/src/components/command/CommandPalette.tsx
+++ b/frontend/src/components/command/CommandPalette.tsx
@@ -5,6 +5,8 @@ import { useGenerate } from '../../hooks/useGenerate'
 import { useExamples } from '../../hooks/useExamples'
 import { GENERATE_ONLY_TARGET_GROUPS } from '../../generation/targets'
 import { DIAGRAM_VIEW_ICON, VIEW_MODE_GROUPS } from '../../constants/diagram'
+import { EXAMPLE_CATEGORY_LABELS } from '../../constants/examples'
+import type { ExampleCategoryId } from '../../api/types'
 import {
   LayoutGrid, Workflow, GitBranch, Network,
   Code, Layers, Maximize2, Minimize2,
@@ -22,11 +24,11 @@ import {
   CommandSeparator,
 } from '@/components/ui/command'
 
-const CATEGORY_ICONS: Record<string, React.ReactNode> = {
-  'Class Diagrams': <LayoutGrid />,
-  'State Machines': <Workflow />,
-  'Composite Structure': <Network />,
-  'Feature Diagrams': <GitBranch />,
+const CATEGORY_ICONS: Partial<Record<ExampleCategoryId, React.ReactNode>> = {
+  class: <LayoutGrid />,
+  state: <Workflow />,
+  structure: <Network />,
+  feature: <GitBranch />,
 }
 
 export function CommandPalette() {
@@ -102,13 +104,15 @@ export function CommandPalette() {
     generate(language)
   }, [closeCommandPalette, generate])
 
-  const currentCategory = useMemo(
-    () => page && page !== 'examples' ? categories.find((c) => c.name === page) : undefined,
-    [categories, page],
-  )
+  const currentCategory = useMemo(() => {
+    if (!page || page === 'examples') return undefined
+    return categories.find((c) => c.id === page)
+  }, [categories, page])
   const canToggleRenderer = viewMode === 'class' && !!umpleModel?.umpleClasses?.length
 
-  const breadcrumb = pages.map((p) => (p === 'examples' ? 'Examples' : p)).join(' \u203A ')
+  const breadcrumb = pages
+    .map((p) => (p === 'examples' ? 'Examples' : EXAMPLE_CATEGORY_LABELS[p as ExampleCategoryId] ?? p))
+    .join(' \u203A ')
 
   return (
     <CommandDialog
@@ -246,12 +250,12 @@ export function CommandPalette() {
           <CommandGroup heading="Categories">
             {categories.map((cat) => (
               <CommandItem
-                key={cat.name}
-                onSelect={() => pushPage(cat.name)}
-                data-testid={`command-item-category-${cat.name}`}
+                key={cat.id}
+                onSelect={() => pushPage(cat.id)}
+                data-testid={`command-item-category-${cat.label}`}
               >
-                {CATEGORY_ICONS[cat.name] ?? <FolderOpen />}
-                {cat.name}
+                {CATEGORY_ICONS[cat.id] ?? <FolderOpen />}
+                {cat.label}
                 <span className="ml-auto text-xs text-muted-foreground">
                   {cat.examples.length}
                 </span>
@@ -262,13 +266,16 @@ export function CommandPalette() {
 
         {/* Examples: example list within a category */}
         {currentCategory && (
-          <CommandGroup heading={page}>
+          <CommandGroup heading={currentCategory.label}>
             {currentCategory.examples.map((ex) => (
                 <CommandItem
                   key={ex.name}
                   onSelect={() => {
                     closeCommandPalette()
-                    loadExample(ex.name, currentCategory.name)
+                    loadExample(ex.name, {
+                      categoryId: currentCategory.id,
+                      switchToDefaultView: true,
+                    })
                   }}
                   data-testid={`command-item-example-${ex.name}`}
                 >

--- a/frontend/src/components/layout/AppToolbar.tsx
+++ b/frontend/src/components/layout/AppToolbar.tsx
@@ -109,11 +109,17 @@ export function AppToolbar() {
               <DropdownMenuItem disabled>Loading examples...</DropdownMenuItem>
             ) : (
               exampleCategories.map((cat) => (
-                <DropdownMenuSub key={cat.name}>
-                  <DropdownMenuSubTrigger>{cat.name}</DropdownMenuSubTrigger>
+                <DropdownMenuSub key={cat.id}>
+                  <DropdownMenuSubTrigger>{cat.label}</DropdownMenuSubTrigger>
                   <DropdownMenuSubContent className="w-56 max-h-72">
                     {cat.examples.map((ex) => (
-                      <DropdownMenuItem key={ex.name} onSelect={() => loadExample(ex.name, cat.name)}>
+                      <DropdownMenuItem
+                        key={ex.name}
+                        onSelect={() => loadExample(ex.name, {
+                          categoryId: cat.id,
+                          switchToDefaultView: true,
+                        })}
+                      >
                         {ex.label || ex.name}
                       </DropdownMenuItem>
                     ))}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -6,7 +6,8 @@ import { useExamples } from '../../hooks/useExamples'
 import { useExecute } from '../../hooks/useExecute'
 import { useGenerate } from '../../hooks/useGenerate'
 import { GENERATE_ONLY_TARGETS, GENERATE_ONLY_TARGET_GROUPS, getGenerateTarget } from '../../generation/targets'
-import { LAYOUT_OPTIONS, VIEW_MODE_GROUPS, getViewForExampleCategory, getLayoutOption } from '../../constants/diagram'
+import { LAYOUT_OPTIONS, VIEW_MODE_GROUPS, getLayoutOption } from '../../constants/diagram'
+import { canViewUseExampleCategory } from '../../constants/examples'
 import { Combobox } from '@/components/ui/combobox'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
@@ -202,7 +203,7 @@ function ToolsGroup() {
 
   const exampleOptions = useMemo(
     () => allCategories
-      .filter((cat) => (getViewForExampleCategory(cat.name) ?? 'class') === viewMode)
+      .filter((cat) => canViewUseExampleCategory(viewMode, cat.id))
       .flatMap((cat) => cat.examples)
       .map((ex) => ({ value: ex.name, label: ex.label || ex.name })),
     [allCategories, viewMode]

--- a/frontend/src/constants/diagram.ts
+++ b/frontend/src/constants/diagram.ts
@@ -37,7 +37,6 @@ export interface DiagramViewMode {
   longLabel: string
   outputKind: DiagramOutputKind
   diagramType?: string
-  exampleCategories?: string[]
   legacyDiagramTypes?: string[]
   displayToggles?: DiagramDisplayToggle[]
 }
@@ -108,7 +107,6 @@ export const VIEW_MODE_GROUPS: DiagramViewGroup[] = [
         longLabel: 'Class Diagram',
         outputKind: 'gv',
         diagramType: 'GvClassDiagram',
-        exampleCategories: ['Class Diagrams'],
         legacyDiagramTypes: ['GvClass', 'class'],
         displayToggles: CLASS_TOGGLES,
       },
@@ -118,7 +116,6 @@ export const VIEW_MODE_GROUPS: DiagramViewGroup[] = [
         longLabel: 'Entity Relationship Diagram',
         outputKind: 'gv',
         diagramType: 'GvEntityRelationshipDiagram',
-        exampleCategories: ['Entity Relationships'],
         legacyDiagramTypes: ['erd'],
       },
       {
@@ -138,7 +135,6 @@ export const VIEW_MODE_GROUPS: DiagramViewGroup[] = [
         longLabel: 'State Machine Diagram',
         outputKind: 'gv',
         diagramType: 'GvStateDiagram',
-        exampleCategories: ['State Machines'],
         legacyDiagramTypes: ['state'],
         displayToggles: STATE_TOGGLES,
       },
@@ -160,7 +156,6 @@ export const VIEW_MODE_GROUPS: DiagramViewGroup[] = [
         longLabel: 'Composite Structure Diagram',
         outputKind: 'html',
         diagramType: 'StructureDiagram',
-        exampleCategories: ['Composite Structure'],
         legacyDiagramTypes: ['structure'],
       },
       {
@@ -169,7 +164,6 @@ export const VIEW_MODE_GROUPS: DiagramViewGroup[] = [
         longLabel: 'Feature Diagram',
         outputKind: 'gv',
         diagramType: 'GvFeatureDiagram',
-        exampleCategories: ['Feature Diagrams'],
         legacyDiagramTypes: ['feature'],
         displayToggles: FEATURE_TOGGLES,
       },
@@ -225,12 +219,6 @@ export const DISPLAY_PREF_DEFAULTS: Record<DisplayPrefKey, boolean> = {
 
 export const DISPLAY_PREF_KEYS = Object.keys(DISPLAY_PREF_DEFAULTS) as DisplayPrefKey[]
 
-export const EXAMPLE_CATEGORY_TO_VIEW = Object.fromEntries(
-  ALL_VIEW_MODES.flatMap((mode) =>
-    (mode.exampleCategories ?? []).map((category) => [category, mode.value] as const)
-  )
-) as Partial<Record<string, DiagramView>>
-
 const LEGACY_DIAGRAM_TYPE_TO_VIEW = Object.fromEntries(
   ALL_VIEW_MODES.flatMap((mode) =>
     (mode.legacyDiagramTypes ?? []).map((legacyType) => [legacyType, mode.value] as const)
@@ -239,10 +227,6 @@ const LEGACY_DIAGRAM_TYPE_TO_VIEW = Object.fromEntries(
 
 export function getViewModeOption(view: DiagramView): DiagramViewMode | null {
   return VIEW_MODE_BY_VALUE.get(view) ?? null
-}
-
-export function getViewForExampleCategory(category: string): DiagramView | null {
-  return EXAMPLE_CATEGORY_TO_VIEW[category] ?? null
 }
 
 export function getViewForLegacyDiagramType(diagramType: string): DiagramView | null {

--- a/frontend/src/constants/examples.ts
+++ b/frontend/src/constants/examples.ts
@@ -1,0 +1,41 @@
+import type { ExampleCategoryId } from '../api/types'
+import type { DiagramView } from './diagram'
+
+export const EXAMPLE_CATEGORY_LABELS: Record<ExampleCategoryId, string> = {
+  class: 'Class Diagrams',
+  state: 'State Machines',
+  structure: 'Composite Structure',
+  feature: 'Feature Diagrams',
+  other: 'Other',
+}
+
+const DEFAULT_VIEW_BY_EXAMPLE_CATEGORY: Partial<Record<ExampleCategoryId, DiagramView>> = {
+  class: 'class',
+  state: 'state',
+  structure: 'structure',
+  feature: 'feature',
+}
+
+const VIEW_TO_EXAMPLE_CATEGORIES: Record<DiagramView, ExampleCategoryId[]> = {
+  class: ['class'],
+  erd: ['class'],
+  instance: ['class'],
+  crud: ['class'],
+  state: ['state'],
+  stateTables: ['state'],
+  eventSequence: ['state'],
+  structure: ['structure'],
+  feature: ['feature'],
+}
+
+export function getDefaultViewForExampleCategory(categoryId: ExampleCategoryId): DiagramView | null {
+  return DEFAULT_VIEW_BY_EXAMPLE_CATEGORY[categoryId] ?? null
+}
+
+export function getExampleCategoryIdsForView(view: DiagramView): ExampleCategoryId[] {
+  return VIEW_TO_EXAMPLE_CATEGORIES[view] ?? []
+}
+
+export function canViewUseExampleCategory(view: DiagramView, categoryId: ExampleCategoryId): boolean {
+  return getExampleCategoryIdsForView(view).includes(categoryId)
+}

--- a/frontend/src/hooks/useExamples.ts
+++ b/frontend/src/hooks/useExamples.ts
@@ -4,12 +4,17 @@ import { useCollabStore } from '../stores/collabStore'
 import { useEphemeralStore } from '../stores/ephemeralStore'
 import { collabLoadExample } from './useCollabTabs'
 import { api } from '../api/client'
-import type { ExampleCategory } from '../api/types'
-import { getViewForExampleCategory } from '../constants/diagram'
+import type { ExampleCategory, ExampleCategoryId } from '../api/types'
+import { getDefaultViewForExampleCategory } from '../constants/examples'
 
 // Module-level cache so all consumers share one fetch
 let cachedCategories: ExampleCategory[] | null = null
 let fetchPromise: Promise<ExampleCategory[]> | null = null
+
+interface LoadExampleOptions {
+  categoryId?: ExampleCategoryId
+  switchToDefaultView?: boolean
+}
 
 export function useExamples() {
   const [allCategories, setAllCategories] = useState<ExampleCategory[]>(cachedCategories ?? [])
@@ -42,9 +47,9 @@ export function useExamples() {
     [allCategories],
   )
 
-  const loadExample = useCallback(async (name: string, categoryName?: string) => {
-    if (categoryName) {
-      const targetView = getViewForExampleCategory(categoryName)
+  const loadExample = useCallback(async (name: string, options?: LoadExampleOptions) => {
+    if (options?.switchToDefaultView && options.categoryId) {
+      const targetView = getDefaultViewForExampleCategory(options.categoryId)
       if (targetView) useSessionStore.getState().setViewMode(targetView)
     }
     try {

--- a/frontend/src/hooks/useModelFromURL.ts
+++ b/frontend/src/hooks/useModelFromURL.ts
@@ -3,7 +3,8 @@ import { useSessionStore } from '../stores/sessionStore'
 import { useCollabStore } from '../stores/collabStore'
 import { useEphemeralStore } from '../stores/ephemeralStore'
 import { isTemporaryModel } from '../lib/modelId'
-import { getViewForExampleCategory, getViewForLegacyDiagramType } from '../constants/diagram'
+import { getViewForLegacyDiagramType } from '../constants/diagram'
+import { getDefaultViewForExampleCategory } from '../constants/examples'
 import { getGenerateTarget } from '../generation/targets'
 import { api } from '../api/client'
 
@@ -115,8 +116,8 @@ export function useModelFromURL() {
         loadExample(res.name, res.code, res.modelId)
 
         // Auto-switch view mode from category, unless ?diagramtype= overrides.
-        if (!initialDiagramType && res.category) {
-          const view = getViewForExampleCategory(res.category)
+        if (!initialDiagramType && res.defaultCategoryId) {
+          const view = getDefaultViewForExampleCategory(res.defaultCategoryId)
           if (view) setViewMode(view)
         }
 

--- a/frontend/tests/e2e/app-smoke.spec.ts
+++ b/frontend/tests/e2e/app-smoke.spec.ts
@@ -24,12 +24,16 @@ test.beforeEach(async ({ page }) => {
     await route.fulfill({
       json: [
         {
+          id: 'class',
+          label: 'Samples',
           name: 'Samples',
           examples: [
             { name: 'Banking', filename: 'banking.ump' },
           ],
         },
         {
+          id: 'structure',
+          label: 'Composite Structure',
           name: 'Composite Structure',
           examples: [
             { name: 'PingPong', filename: 'PingPong.ump' },
@@ -48,6 +52,7 @@ test.beforeEach(async ({ page }) => {
         code: name === 'PingPong'
           ? `class Component1 {\n  public in Integer pIn1;\n  public out Integer pOut1;\n}\n\nclass Atomic {\n  Component1 cmp1;\n}\n`
           : `class Account {\n  balance;\n}\n`,
+        defaultCategoryId: name === 'PingPong' ? 'structure' : 'class',
       },
     })
   })

--- a/frontend/tests/e2e/live-backend.spec.ts
+++ b/frontend/tests/e2e/live-backend.spec.ts
@@ -10,7 +10,7 @@
  */
 import { expect, test, type Page } from '@playwright/test'
 import type { ExampleCategory } from '../../src/api/types'
-import { EXAMPLE_CATEGORY_TO_VIEW } from '../../src/constants/diagram'
+import { getDefaultViewForExampleCategory } from '../../src/constants/examples'
 
 test.skip(
   !process.env.PLAYWRIGHT_LIVE_BACKEND,
@@ -132,15 +132,15 @@ test.describe('Live backend — all examples', () => {
     let passed = 0
 
     for (const cat of categories) {
-      const view = EXAMPLE_CATEGORY_TO_VIEW[cat.name]
+      const view = getDefaultViewForExampleCategory(cat.id)
       if (!view) continue // skip categories we don't map (e.g. "Other")
 
       for (const ex of cat.examples) {
-        const label = `${cat.name} / ${ex.name}`
+        const label = `${cat.label} / ${ex.name}`
 
         // Load via command palette
         try {
-          await loadExample(page, cat.name, ex.name)
+          await loadExample(page, cat.label, ex.name)
         } catch {
           compileFailures.push(`${label} — failed to load via command palette`)
           continue


### PR DESCRIPTION
## Summary
- add stable example category IDs and labels to the backend examples API
- return a default example category for example bootstrap flows instead of relying on display-name matching
- move example-to-view policy into a dedicated frontend examples constant module
- let class, ERD, instance, and CRUD views share class examples, and state, state tables, and event sequence share state examples
- update the command palette, toolbar, sidebar, URL loading flow, and e2e fixtures to use category IDs

## Testing
- `bun run build`
- `bun run test:e2e:typecheck`
- `go test ./internal/api/handlers/...`