### PR TITLE
Support configurable frontend host binding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,9 @@ EXECUTION_URL=http://code-exec:4400
 # CORS (comma-separated origins for production)
 ALLOWED_ORIGINS=https://your-domain.example.com
 
-# Frontend (Vite dev server only) — set in frontend/.env, not here.
+# Production frontend host bind
+FRONTEND_BIND_HOST=127.0.0.1
+FRONTEND_HOST_PORT=3100
+
+# Frontend dev server options still live in frontend/.env, not here.
 # See frontend/.env.example for VITE_ALLOWED_HOSTS.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,11 @@ Release automatically copies `docker-compose.prod.yml` from the repo, but the se
 
 ```bash
 mkdir -p ~/deploy/umpleonline
-echo "ALLOWED_ORIGINS=https://your-domain.example.com" > ~/deploy/umpleonline/.env
+cat > ~/deploy/umpleonline/.env <<'EOF'
+ALLOWED_ORIGINS=https://your-domain.example.com
+FRONTEND_BIND_HOST=127.0.0.1
+FRONTEND_HOST_PORT=3100
+EOF
 ```
 
 Required host dependencies:
@@ -151,6 +155,6 @@ Required host dependencies:
 2. Install TXL on the host at `/usr/local/bin/txl` and `/usr/local/lib/txl`
 3. Create the deploy directory, `.env`, and `data/models` directory (see above)
 4. Copy any existing `data/models` contents if you need persisted models on the new server
-5. Configure a reverse proxy (nginx or Cloudflare Tunnel) to forward the domain to `localhost:3100`
+5. Configure a reverse proxy (nginx or Cloudflare Tunnel) to forward the domain to that server's configured `FRONTEND_HOST_PORT` on localhost
 6. Update the 6 GitHub secrets to point to the new server
 7. Run the Release workflow for the commit you want in production

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -56,7 +56,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "3100:80"
+      - "${FRONTEND_BIND_HOST:-127.0.0.1}:${FRONTEND_HOST_PORT:-3100}:80"
     depends_on:
       backend:
         condition: service_healthy

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -112,9 +112,18 @@ wait_for_backend() {
 }
 
 check_frontend() {
+  local frontend_check_host="$1"
+  local frontend_host_port="$2"
+  local frontend_check_url_host="$frontend_check_host"
+
+  case "$frontend_check_url_host" in
+    \[*\]) ;;
+    *:*) frontend_check_url_host="[$frontend_check_url_host]" ;;
+  esac
+
   echo "==> Checking frontend..."
-  if ! curl -sf http://localhost:3100/ > /dev/null; then
-    echo "ERROR: Frontend not responding on host port 3100"
+  if ! curl -sf "http://${frontend_check_url_host}:${frontend_host_port}/" > /dev/null; then
+    echo "ERROR: Frontend not responding on ${frontend_check_host}:${frontend_host_port}"
     compose -f docker-compose.prod.yml logs frontend --tail=40
     return 1
   fi
@@ -164,6 +173,18 @@ if [ "$ALLOWED_ORIGINS" = "http://localhost:3100" ]; then
   exit 1
 fi
 
+FRONTEND_BIND_HOST="$(read_env_value "FRONTEND_BIND_HOST" .env || true)"
+FRONTEND_BIND_HOST="${FRONTEND_BIND_HOST:-127.0.0.1}"
+FRONTEND_HOST_PORT="$(read_env_value "FRONTEND_HOST_PORT" .env || true)"
+FRONTEND_HOST_PORT="${FRONTEND_HOST_PORT:-3100}"
+
+FRONTEND_CHECK_HOST="$FRONTEND_BIND_HOST"
+if [ "$FRONTEND_CHECK_HOST" = "0.0.0.0" ]; then
+  FRONTEND_CHECK_HOST="127.0.0.1"
+elif [ "$FRONTEND_CHECK_HOST" = "::" ]; then
+  FRONTEND_CHECK_HOST="::1"
+fi
+
 DOCKER_GID="$(stat -c '%g' /var/run/docker.sock)"
 PREVIOUS_BACKEND_IMAGE="$(read_env_value "BACKEND_IMAGE" .env || true)"
 PREVIOUS_FRONTEND_IMAGE="$(read_env_value "FRONTEND_IMAGE" .env || true)"
@@ -185,6 +206,8 @@ echo "    CODE_EXEC_IMAGE=$CODE_EXEC_IMAGE"
 echo "    COLLAB_IMAGE=$COLLAB_IMAGE"
 echo "    LSP_PROXY_IMAGE=$LSP_PROXY_IMAGE"
 echo "    DOCKER_GID=$DOCKER_GID"
+echo "    FRONTEND_BIND_HOST=$FRONTEND_BIND_HOST"
+echo "    FRONTEND_HOST_PORT=$FRONTEND_HOST_PORT"
 
 cleanup_docker_storage
 
@@ -206,7 +229,7 @@ echo "==> Restarting services..."
 compose -f docker-compose.prod.yml up -d --remove-orphans
 
 wait_for_backend
-check_frontend
+check_frontend "$FRONTEND_CHECK_HOST" "$FRONTEND_HOST_PORT"
 
 ROLLBACK_ARMED=0
 


### PR DESCRIPTION
## Summary
- make the production frontend host bind and host port configurable via `.env`
- update the release health check to validate configured IPv4 and IPv6 frontend binds
- document the new deployment env settings for server setup and proxying

## Test plan
- `bash -n scripts/release.sh`
- `ALLOWED_ORIGINS=https://example.com DOCKER_GID=1 FRONTEND_BIND_HOST=::1 FRONTEND_HOST_PORT=3100 docker compose -f docker-compose.prod.yml config >/dev/null`