### PR TITLE
Remove per-class CRUD random generation

### DIFF
--- a/frontend/src/components/crud/InstanceTable.tsx
+++ b/frontend/src/components/crud/InstanceTable.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Plus, Pencil, Trash2, Trash, ChevronRight, ChevronDown, Shuffle } from 'lucide-react'
+import { Plus, Pencil, Trash2, Trash, ChevronRight, ChevronDown } from 'lucide-react'
 import { useCrudStore, type CrudInstance, assocKey, getAssocIds, classHasCompositionChildren, collectClassAssociations, collectClassInstances } from '@/stores/crudStore'
 import type { CrudAssociation, CrudClass, CrudSchema } from '@/api/types'
 import {
@@ -20,7 +20,6 @@ export function InstanceTable({ cls }: { cls: CrudClass }) {
   const openEditor = useCrudStore((s) => s.openEditor)
   const deleteInstance = useCrudStore((s) => s.deleteInstance)
   const clearAllInstances = useCrudStore((s) => s.clearAllInstances)
-  const generateRandom = useCrudStore((s) => s.generateRandom)
   const [expandedRow, setExpandedRow] = useState<number | null>(null)
 
   const visibleAttrs = cls.attributes.slice(0, 8)
@@ -39,15 +38,6 @@ export function InstanceTable({ cls }: { cls: CrudClass }) {
           <span className="text-xs text-ink-faint tabular-nums">{instances.length} instance{instances.length !== 1 ? 's' : ''}</span>
         </div>
         <div className="flex items-center gap-1">
-          <Tip content="Generate 5 random instances" side="bottom">
-            <button
-              onClick={() => generateRandom(cls.name, 5)}
-              className="flex items-center gap-1 px-2 py-1 text-xs text-ink-faint hover:text-ink-muted transition-colors cursor-pointer rounded-md hover:bg-surface-1"
-            >
-              <Shuffle className="size-3" />
-              Random
-            </button>
-          </Tip>
           {instances.length > 0 && (
             <Tip content="Clear all instances" side="bottom">
               <button

--- a/frontend/src/stores/crudStore.ts
+++ b/frontend/src/stores/crudStore.ts
@@ -152,7 +152,6 @@ interface CrudState {
   resetInstances: () => void
   exportJson: () => string
   importJson: (json: string) => boolean
-  generateRandom: (className: string, count: number) => void
   generateRandomAll: () => void
 }
 
@@ -1710,31 +1709,6 @@ export const useCrudStore = create<CrudState>((set, get) => ({
     } catch {
       return false
     }
-  },
-
-  generateRandom: (className, count) => {
-    const { schema } = get()
-    if (!schema) return
-    const cls = schema.classes.find((c) => c.name === className)
-    if (!cls || cls.isAbstract) return
-
-    set((s) => {
-      const newInstances = { ...s.instances }
-      const list = [...(newInstances[className] ?? [])]
-      let nextId = s.nextId
-
-      for (let i = 0; i < count; i++) {
-        list.push(createRandomInstanceForClass(cls, schema, nextId))
-        nextId++
-      }
-
-      newInstances[className] = list
-      return {
-        instances: newInstances,
-        nextId,
-        ...computeGlobalValidationState(schema, newInstances),
-      }
-    })
   },
 
   generateRandomAll: () => {

--- a/frontend/tests/e2e/app-smoke.spec.ts
+++ b/frontend/tests/e2e/app-smoke.spec.ts
@@ -178,8 +178,6 @@ test('command palette lists all supported diagram commands and diagram commands 
   }
 
   await expect(page.getByTestId('command-item-gen-Java')).toBeVisible()
-  await expect(page.getByTestId('command-item-gen-stateDiagram')).toHaveCount(0)
-  await expect(page.getByTestId('command-item-gen-featureDiagram')).toHaveCount(0)
 
   await page.getByTestId('command-item-diagram-erd').click()
   await expect.poll(() => diagramTypes[diagramTypes.length - 1]).toBe('GvEntityRelationshipDiagram')


### PR DESCRIPTION
## Summary
- remove the per-class random generation button from the CRUD instance table
- delete the unused CRUD store action behind that button
- drop smoke assertions that only checked unsupported generate commands stay absent

## Test plan
- bun x tsc --noEmit
- bun run test src/components/crud/__tests__/InstanceTable.test.tsx
- bun run test:e2e tests/e2e/app-smoke.spec.ts
