### PR TITLE
Remove canvas Ctrl+number tab shortcuts

### DIFF
--- a/frontend/src/components/layout/CanvasBanner.tsx
+++ b/frontend/src/components/layout/CanvasBanner.tsx
@@ -31,21 +31,6 @@ export function CanvasBanner() {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === '1') {
-        e.preventDefault()
-        e.stopPropagation()
-        const state = useEphemeralStore.getState()
-        if (state.rightPanelView === 'generated') {
-          state.setRightPanelView('diagram')
-        }
-      }
-      if ((e.metaKey || e.ctrlKey) && e.key === '2') {
-        if (useEphemeralStore.getState().generationRequested) {
-          e.preventDefault()
-          e.stopPropagation()
-          useEphemeralStore.getState().setRightPanelView('generated')
-        }
-      }
       if ((e.metaKey || e.ctrlKey) && e.key === "'") {
         e.preventDefault()
         e.stopPropagation()
@@ -60,7 +45,7 @@ export function CanvasBanner() {
     <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center h-[var(--toolbar-h)] px-3 shrink-0 border-b border-border" data-testid="canvas-banner">
       <div />
       <div className="flex items-center justify-center gap-0.5 min-w-0 overflow-hidden">
-        <Tip content="Diagram (Ctrl+1)" side="bottom">
+        <Tip content="Diagram" side="bottom">
           <button
             onClick={() => {
               if (rightPanelView === 'generated') {
@@ -74,7 +59,7 @@ export function CanvasBanner() {
         </Tip>
         {generationRequested && (
           <div className="flex items-center min-w-0">
-            <Tip content="Generated code (Ctrl+2)" side="bottom">
+            <Tip content="Generated code" side="bottom">
               <button
                 onClick={() => setRightPanelView('generated')}
                 className={cn(lineTabClasses({ active: rightPanelView === 'generated' }), 'text-xs px-2.5 py-1 flex items-center gap-1.5 min-w-0 max-w-48')}

--- a/frontend/src/components/layout/__tests__/CanvasBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/CanvasBanner.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+
+import { CanvasBanner } from '../CanvasBanner'
+import { useEphemeralStore } from '@/stores/ephemeralStore'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/ui/combobox', () => ({
+  Combobox: () => <button type="button">Change language</button>,
+}))
+
+vi.mock('@/hooks/useGenerate', () => ({
+  useGenerate: () => vi.fn(),
+}))
+
+afterEach(() => {
+  cleanup()
+  useEphemeralStore.setState({
+    diagramOnly: false,
+    outputView: 'hidden',
+    rightPanelView: 'diagram',
+    generationRequested: false,
+    generatingCode: false,
+    generatedTargetId: 'Java',
+  })
+})
+
+describe('CanvasBanner', () => {
+  it('does not switch canvas tabs with Ctrl+number', () => {
+    useEphemeralStore.setState({
+      rightPanelView: 'generated',
+      generationRequested: true,
+      generatedTargetId: 'Java',
+    })
+
+    render(<CanvasBanner />)
+
+    fireEvent.keyDown(window, { key: '1', ctrlKey: true })
+    expect(useEphemeralStore.getState().rightPanelView).toBe('generated')
+
+    useEphemeralStore.setState({ rightPanelView: 'diagram' })
+    fireEvent.keyDown(window, { key: '2', ctrlKey: true })
+    expect(useEphemeralStore.getState().rightPanelView).toBe('diagram')
+  })
+
+  it("keeps Ctrl+' bound to the output panel toggle", () => {
+    render(<CanvasBanner />)
+
+    fireEvent.keyDown(window, { key: "'", ctrlKey: true })
+    expect(useEphemeralStore.getState().outputView).toBe('panel')
+
+    fireEvent.keyDown(window, { key: "'", ctrlKey: true })
+    expect(useEphemeralStore.getState().outputView).toBe('hidden')
+  })
+})


### PR DESCRIPTION
## Summary
- Remove canvas `Ctrl/Cmd+1` and `Ctrl/Cmd+2` keyboard handlers that switched between diagram/generated view tabs.
- Keep `Ctrl/Cmd+'` output panel toggle in `CanvasBanner` intact.
- Add regression coverage in `CanvasBanner.test.tsx` for the removed numeric shortcuts and preserved toggle behavior.

## Test plan
- Verified by focused unit coverage in `frontend/src/components/layout/__tests__/CanvasBanner.test.tsx`.
