### PR TITLE
fix: improve diagram source selection

### DIFF
--- a/frontend/src/components/diagram/SmartSvgView.tsx
+++ b/frontend/src/components/diagram/SmartSvgView.tsx
@@ -8,7 +8,7 @@ interface SmartSvgViewProps {
 
 export function formatDiagramIdentifierForDisplay(raw: string): string {
   const formatToken = (token: string) => {
-    const trimmed = token.trim()
+    const trimmed = token.trim().replace(/^cluster_/, '')
     const match = trimmed.match(/^(.*)_(\d+)$/)
     if (!match) return trimmed
     const [, className, instanceId] = match
@@ -51,8 +51,12 @@ const SVG_THEME_CSS = `
   .edge text { fill: var(--color-ink-muted); }
 
   /* Hover highlights */
-  .node, .edge { cursor: pointer; }
+  .node, .edge, .cluster { cursor: pointer; }
   .node:hover polygon, .node:hover ellipse, .node:hover path, .node:hover polyline {
+    stroke: var(--color-brand);
+    transition: stroke 0.15s ease;
+  }
+  .cluster:hover polygon, .cluster:hover path {
     stroke: var(--color-brand);
     transition: stroke 0.15s ease;
   }
@@ -151,7 +155,7 @@ function processSvg(raw: string): { html: string; dims: { width: number; height:
   })
 
   // Add data attributes to node/edge groups for interaction targeting
-  doc.querySelectorAll('g.node').forEach((g) => {
+  doc.querySelectorAll('g.node, g.cluster').forEach((g) => {
     const title = g.querySelector('title')
     if (title?.textContent) {
       const rawId = title.textContent.trim()
@@ -363,7 +367,7 @@ const SmartSvgViewInner = ({ svg }: SmartSvgViewProps) => {
     if (!el) return
     const handler = (e: MouseEvent) => {
       const target = e.target as Element
-      const nodeGroup = target.closest('g.node')
+      const nodeGroup = target.closest('g.node, g.cluster')
       const edgeGroup = target.closest('g.edge')
 
       if (nodeGroup) {

--- a/frontend/src/components/editor/EditorPanel.tsx
+++ b/frontend/src/components/editor/EditorPanel.tsx
@@ -13,38 +13,9 @@ import { useCollabEditor } from '../../hooks/useCollabEditor'
 import { useCollabTabs } from '../../hooks/useCollabTabs'
 import { useLsp } from '../../hooks/useLsp'
 import { attachLspToView } from '../../codemirror/lsp'
-
-interface DiagramSelectDetail {
-  name: string
-  kind: 'node' | 'edge'
-}
+import { findDiagramRange, type DiagramSelectDetail } from './diagramSelection'
 
 const AgentPanel = lazy(() => import('../agent/AgentPanel'))
-
-/**
- * Find the character range of a top-level class/interface/trait definition in Umple source.
- * Matches brace depth to find the full block extent.
- */
-function findClassRange(code: string, className: string): { from: number; to: number } | null {
-  const escaped = className.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const pattern = new RegExp(`(associationClass|class|interface|trait)\\s+${escaped}(\\s|\\{|$)`)
-  const match = pattern.exec(code)
-  if (!match) return null
-
-  const from = match.index
-  let braceCount = 0
-  let foundOpen = false
-  for (let i = from; i < code.length; i++) {
-    if (code[i] === '{') { braceCount++; foundOpen = true }
-    else if (code[i] === '}') {
-      braceCount--
-      if (foundOpen && braceCount === 0) return { from, to: i + 1 }
-    }
-  }
-  // No braces — select to end of line
-  const eol = code.indexOf('\n', from)
-  return { from, to: eol === -1 ? code.length : eol }
-}
 
 export function EditorPanel() {
   const code = useSessionStore((s) => s.code)
@@ -81,15 +52,11 @@ export function EditorPanel() {
   useEffect(() => {
     const handler = (e: Event) => {
       const { name, kind } = (e as CustomEvent<DiagramSelectDetail>).detail
-      const view = editorRef.current?.view
+      const view = editorViewRef.current ?? editorRef.current?.view
       if (!view) return
 
       const doc = view.state.doc.toString()
-      const className = kind === 'edge'
-        ? name.split(/->|--/)[0].trim()
-        : name
-
-      const range = findClassRange(doc, className)
+      const range = findDiagramRange(doc, { name, kind })
       if (!range) return
 
       view.dispatch({

--- a/frontend/src/components/editor/diagramSelection.test.ts
+++ b/frontend/src/components/editor/diagramSelection.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { findDiagramRange } from './diagramSelection'
+
+describe('findDiagramRange', () => {
+  it('matches the correct repeated state name inside its owning state machine', () => {
+    const code = `class Phone {
+  ringerSound {
+    Off{
+      callReceived [!permanentMute] -> On ;
+    }
+
+    On{
+      silentButton -> Off ;
+    }
+  }
+
+  screenLight {
+    Off{
+      callReceived -> On ;
+      pickUp -> On;
+      dial -> On;
+    }
+
+    On{
+      after(30000) -> Dimmed;
+      hangUp -> Off;
+    }
+  }
+
+  vibration {
+    Off {
+      callReceived -> On ;
+     }
+  }
+}
+`
+
+    const range = findDiagramRange(code, { name: 'Phone_screenLight_Off', kind: 'node' })
+    expect(range).not.toBeNull()
+    expect(code.slice(range!.from, range!.to)).toBe(`    Off{
+      callReceived -> On ;
+      pickUp -> On;
+      dial -> On;
+    }`)
+  })
+
+  it('keeps numeric suffixes that are part of numbered state names', () => {
+    const code = `class Oven1 {
+  cook { OFF{} ON{} }
+  Integer leftTime = 0;
+  ovenstate {
+    s1_1 {
+      enterTime(Integer t) [t > 0] / {leftTime = t;} -> s1_2;
+    }
+    s1_2 {
+      enterTime(Integer t) [t > 0] / {leftTime = t;} -> s1_2;
+      start / {cook = Cook.ON;} -> s1_3;
+    }
+    s1_3 {
+    }
+  }
+}
+`
+
+    const range = findDiagramRange(code, { name: 'Oven1_ovenstate_s1_1', kind: 'node' })
+    expect(range).not.toBeNull()
+    expect(code.slice(range!.from, range!.to)).toBe(`    s1_1 {
+      enterTime(Integer t) [t > 0] / {leftTime = t;} -> s1_2;
+    }`)
+  })
+
+  it('still resolves simple instance ids back to their class definitions', () => {
+    const code = `class Segment {
+  bend;
+}
+
+class Lock {
+}
+`
+
+    const range = findDiagramRange(code, { name: 'Segment_12', kind: 'node' })
+    expect(range).not.toBeNull()
+    expect(code.slice(range!.from, range!.to)).toBe(`class Segment {
+  bend;
+}`)
+  })
+})

--- a/frontend/src/components/editor/diagramSelection.ts
+++ b/frontend/src/components/editor/diagramSelection.ts
@@ -1,0 +1,212 @@
+export interface DiagramSelectDetail {
+  name: string
+  kind: 'node' | 'edge'
+}
+
+interface TextRange {
+  from: number
+  to: number
+}
+
+function escapeForRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function stripNumericInstanceSuffix(value: string): string {
+  return value.replace(/_(\d+)$/, '')
+}
+
+function normalizeDiagramLookupToken(value: string): string {
+  return value.trim().replace(/^cluster_/, '').replace(/^["']|["']$/g, '')
+}
+
+function isNumericCandidate(value: string): boolean {
+  return /^\d+$/.test(value)
+}
+
+function unique(values: string[]): string[] {
+  return values.filter((value, index) => value.length > 0 && !isNumericCandidate(value) && values.indexOf(value) === index)
+}
+
+function getUnderscoreCandidates(value: string): string[] {
+  const parts = value.split('_').map((part) => part.trim()).filter(Boolean)
+  if (parts.length < 2) return []
+
+  const suffixes: string[] = []
+  for (let i = 0; i < parts.length; i++) {
+    suffixes.push(parts.slice(i).join('_'))
+  }
+
+  const prefixes: string[] = []
+  for (let i = parts.length - 1; i > 0; i--) {
+    prefixes.push(parts.slice(0, i).join('_'))
+  }
+
+  return unique([...suffixes, ...prefixes, ...parts])
+}
+
+function getLookupCandidates(rawName: string, kind: DiagramSelectDetail['kind']): string[] {
+  const tokens = kind === 'edge'
+    ? rawName.split(/->|--/).map((token) => token.trim())
+    : [rawName.trim()]
+
+  return unique(tokens.flatMap((token) => {
+    const normalized = normalizeDiagramLookupToken(token)
+    const strippedInstance = stripNumericInstanceSuffix(normalized)
+    const parts = normalized.split(/::|\./).map((part) => part.trim()).filter(Boolean)
+    const strippedParts = strippedInstance === normalized
+      ? []
+      : strippedInstance.split(/::|\./).map((part) => part.trim()).filter(Boolean)
+
+    return unique([
+      normalized,
+      strippedInstance,
+      ...parts,
+      ...parts.flatMap(getUnderscoreCandidates),
+      ...strippedParts,
+      ...strippedParts.flatMap(getUnderscoreCandidates),
+    ])
+  }))
+}
+
+function lineRangeAt(code: string, index: number): TextRange {
+  const from = code.lastIndexOf('\n', index - 1) + 1
+  const to = code.indexOf('\n', index)
+  return { from, to: to === -1 ? code.length : to }
+}
+
+function blockRangeFrom(code: string, from: number): TextRange | null {
+  const braceIndex = code.indexOf('{', from)
+  if (braceIndex === -1) return null
+
+  let depth = 0
+  for (let i = braceIndex; i < code.length; i++) {
+    if (code[i] === '{') depth++
+    if (code[i] === '}') {
+      depth--
+      if (depth === 0) return { from, to: i + 1 }
+    }
+  }
+
+  return null
+}
+
+function rangeFromPattern(code: string, pattern: RegExp): TextRange | null {
+  const match = pattern.exec(code)
+  if (!match) return null
+
+  const from = match.index
+  return blockRangeFrom(code, from) ?? lineRangeAt(code, from)
+}
+
+function findDefinitionRange(code: string, name: string): TextRange | null {
+  const escaped = escapeForRegex(name)
+  const keywordBlock = rangeFromPattern(
+    code,
+    new RegExp(`\\b(?:associationClass|class|interface|trait|statemachine)\\s+${escaped}(?=\\s|\\{|$)`),
+  )
+  if (keywordBlock) return keywordBlock
+
+  const namedBlock = rangeFromPattern(
+    code,
+    new RegExp(`^\\s*(?:final\\s+)?${escaped}(?=\\s*\\{)`, 'm'),
+  )
+  if (namedBlock) return namedBlock
+
+  const relationLine = rangeFromPattern(
+    code,
+    new RegExp(`^[^\\n]*\\b${escaped}\\b[^\\n]*(?:--|->|<@>)[^\\n]*;?`, 'm'),
+  )
+  if (relationLine) return relationLine
+
+  const match = new RegExp(`\\b${escaped}\\b`).exec(code)
+  return match ? lineRangeAt(code, match.index) : null
+}
+
+function partitionUnderscoreSegments(parts: string[]): string[][] {
+  const filtered = parts.map((part) => part.trim()).filter(Boolean)
+  if (filtered.length === 0) return []
+
+  const partitions: string[][] = []
+  const seen = new Set<string>()
+
+  const walk = (index: number, current: string[]) => {
+    if (index === filtered.length) {
+      const key = current.join('\u0000')
+      if (!seen.has(key)) {
+        seen.add(key)
+        partitions.push([...current])
+      }
+      return
+    }
+
+    const part = filtered[index]
+    if (current.length === 0) {
+      walk(index + 1, [part])
+      return
+    }
+
+    current.push(part)
+    walk(index + 1, current)
+    current.pop()
+
+    const last = current[current.length - 1]
+    current[current.length - 1] = `${last}_${part}`
+    walk(index + 1, current)
+    current[current.length - 1] = last
+  }
+
+  walk(0, [])
+  return partitions
+}
+
+function getNodeLookupPaths(rawName: string): string[][] {
+  const normalized = normalizeDiagramLookupToken(rawName)
+  const underscoreParts = normalized.split('_').map((part) => part.trim()).filter(Boolean)
+  const partitions = partitionUnderscoreSegments(underscoreParts)
+    .filter((path) => path.every((segment) => !isNumericCandidate(segment)))
+  const strippedInstance = stripNumericInstanceSuffix(normalized)
+
+  if (strippedInstance !== normalized) {
+    partitions.push([strippedInstance])
+  }
+
+  return partitions
+}
+
+function findDefinitionRangeWithin(code: string, name: string, scope: TextRange): TextRange | null {
+  const scopedCode = code.slice(scope.from, scope.to)
+  const range = findDefinitionRange(scopedCode, name)
+  return range
+    ? { from: range.from + scope.from, to: range.to + scope.from }
+    : null
+}
+
+function findRangeForPath(code: string, path: string[]): TextRange | null {
+  let scope: TextRange = { from: 0, to: code.length }
+  let match: TextRange | null = null
+
+  for (const segment of path) {
+    match = findDefinitionRangeWithin(code, segment, scope)
+    if (!match) return null
+    scope = match
+  }
+
+  return match
+}
+
+export function findDiagramRange(code: string, detail: DiagramSelectDetail): TextRange | null {
+  if (detail.kind === 'node') {
+    for (const path of getNodeLookupPaths(detail.name)) {
+      const range = findRangeForPath(code, path)
+      if (range) return range
+    }
+  }
+
+  for (const candidate of getLookupCandidates(detail.name, detail.kind)) {
+    const range = findDefinitionRange(code, candidate)
+    if (range) return range
+  }
+
+  return null
+}

--- a/frontend/tests/e2e/live-diagram-selection.spec.ts
+++ b/frontend/tests/e2e/live-diagram-selection.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test, type Page } from '@playwright/test'
+
+test.skip(
+  !process.env.PLAYWRIGHT_LIVE_BACKEND,
+  'Set PLAYWRIGHT_LIVE_BACKEND=1 to run against the real backend stack.',
+)
+
+const STATE_MODEL = `class Light {
+  status {
+    Off {
+      turnOn -> On;
+    }
+    On {
+      turnOff -> Off;
+    }
+  }
+}
+`
+
+async function setEditorCode(page: Page, code: string) {
+  const editor = page.locator('.cm-content')
+  await editor.click()
+  await page.keyboard.press('Control+a')
+  await page.keyboard.type(code, { delay: 0 })
+}
+
+async function compileAndWait(page: Page) {
+  const compileButton = page.getByTestId('compile-button')
+  await expect(compileButton).toBeEnabled({ timeout: 10_000 })
+  await compileButton.click()
+  await page.waitForTimeout(500)
+  await expect(compileButton).toBeEnabled({ timeout: 30_000 })
+  await page.waitForTimeout(2_000)
+}
+
+test.describe('Live backend — diagram selection', () => {
+  test.setTimeout(60_000)
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('umple-preferences-v1', JSON.stringify({
+        state: { hasSeenWelcome: true },
+        version: 0,
+      }))
+    })
+  })
+
+  test.beforeAll(async ({ request, baseURL }) => {
+    const health = await request.get(`${baseURL}/api/health`)
+    expect(health.ok()).toBeTruthy()
+  })
+
+  test('clicking a state diagram node highlights the corresponding source', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('app-shell')).toBeVisible()
+
+    await setEditorCode(page, STATE_MODEL)
+    await page.getByLabel('Diagram view').click()
+    await page.getByTestId('diagram-view-state').click()
+    await compileAndWait(page)
+
+    await expect(page.locator('[data-testid="diagram-canvas"] [data-node-id]').first()).toBeVisible({ timeout: 15_000 })
+
+    const nodeIds = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('[data-node-id]'))
+        .map((el) => el.getAttribute('data-node-id') ?? '')
+        .filter(Boolean),
+    )
+
+    const targetId = nodeIds.find((id) => id === 'Off')
+      ?? nodeIds.find((id) => id === 'On')
+      ?? nodeIds.find((id) => id === 'status')
+      ?? nodeIds.find((id) => /Off/i.test(id))
+      ?? nodeIds.find((id) => /On/i.test(id))
+      ?? nodeIds.find((id) => /status/i.test(id))
+
+    expect(targetId, `No clickable state node found. SVG node ids: ${nodeIds.join(', ')}`).toBeTruthy()
+
+    await page.locator(`[data-node-id="${targetId}"]`).click()
+
+    await expect(page.getByTestId('smart-svg-selected-id')).toContainText(targetId as string)
+    await expect.poll(async () => page.locator('.cm-selectionBackground').count(), {
+      message: `Expected editor highlight after clicking "${targetId}"`,
+      timeout: 5_000,
+    }).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add path-aware diagram node lookup so repeated state names resolve within the correct owning scope
- preserve numbered state names like `s1_1` while still mapping simple instance ids back to their class definitions
- add focused unit coverage for lookup behavior and a live Playwright check for state-diagram selection

## Test plan
- `cd frontend && bun run test src/components/editor/diagramSelection.test.ts src/components/diagram/__tests__/SmartSvgView.test.tsx`
- `cd frontend && bun x tsc --noEmit`
- Not run: live Playwright suite
