### PR TITLE
Add SVG state editing menus

### DIFF
--- a/frontend/src/components/diagram/DiagramPanel.tsx
+++ b/frontend/src/components/diagram/DiagramPanel.tsx
@@ -135,7 +135,7 @@ export function DiagramPanel() {
           )}
           {mountGv && (
             <DiagramLayer active={showGv}>
-              <SmartSvgView svg={currentSvg} />
+              <SmartSvgView svg={currentSvg} viewMode={viewMode} />
             </DiagramLayer>
           )}
           {editableLoading && (

--- a/frontend/src/components/diagram/SmartSvgView.tsx
+++ b/frontend/src/components/diagram/SmartSvgView.tsx
@@ -1,9 +1,33 @@
 import { memo, useRef, useState, useCallback, useMemo, useEffect, useLayoutEffect } from 'react'
 import { ZoomIn, ZoomOut, Maximize } from 'lucide-react'
 import { ControlButton } from './DiagramControls'
+import { ContextMenuShell } from './menus/ContextMenuShell'
+import { MenuItem } from './menus/MenuItem'
+import { useMenuClose } from '@/hooks/useMenuClose'
+import { getYDoc } from '@/hooks/useCollab'
+import { replaceYText } from '@/hooks/useCollabTabs'
+import { useSessionStore } from '@/stores/sessionStore'
+import { useCollabStore } from '@/stores/collabStore'
+import { useEphemeralStore } from '@/stores/ephemeralStore'
+import type { DiagramView } from '@/constants/diagram'
+import { getSvgDiagramAdapter } from './svg-adapters'
+import type {
+  SvgAdapterContext,
+  SvgInteractionTarget,
+  SvgMenuAction,
+  SvgTextInputRequest,
+} from './svg-adapters/types'
+import { SvgTextInputDialog } from './SvgTextInputDialog'
 
 interface SmartSvgViewProps {
   svg: string
+  viewMode?: DiagramView
+}
+
+interface SmartSvgMenuState {
+  position: { x: number; y: number }
+  actions: SvgMenuAction[]
+  ariaLabel: string
 }
 
 export function formatDiagramIdentifierForDisplay(raw: string): string {
@@ -116,6 +140,14 @@ function processSvg(raw: string): { html: string; dims: { width: number; height:
   })
   doc.querySelectorAll('foreignObject').forEach((fo) => fo.remove())
 
+  doc.querySelectorAll('g.node, g.edge, g.cluster').forEach((g) => {
+    const link = g.querySelector('a')
+    const linkTitle = link?.getAttribute('xlink:title') ?? link?.getAttribute('title')
+    if (linkTitle) {
+      g.setAttribute('data-link-title', linkTitle)
+    }
+  })
+
   // Strip `<a>` wrappers (Graphviz wraps nodes in links) — unwrap children, remove the <a>
   doc.querySelectorAll('a').forEach((a) => {
     while (a.firstChild) a.parentNode?.insertBefore(a.firstChild, a)
@@ -201,7 +233,64 @@ function processSvg(raw: string): { html: string; dims: { width: number; height:
 const PADDING = 24
 const DRAG_THRESHOLD = 3
 
-const SmartSvgViewInner = ({ svg }: SmartSvgViewProps) => {
+function getInteractionTarget(target: Element): SvgInteractionTarget | null {
+  const nodeGroup = target.closest('g.node, g.cluster')
+  if (nodeGroup) {
+    const rawId = nodeGroup.getAttribute('data-node-id')
+    if (!rawId) return null
+    return {
+      kind: 'node',
+      rawId,
+      anchorTitle: nodeGroup.getAttribute('data-link-title'),
+    }
+  }
+
+  const edgeGroup = target.closest('g.edge')
+  if (edgeGroup) {
+    const rawId = edgeGroup.getAttribute('data-edge-id')
+    if (!rawId) return null
+    return {
+      kind: 'edge',
+      rawId,
+      anchorTitle: edgeGroup.getAttribute('data-link-title'),
+    }
+  }
+
+  return null
+}
+
+function SmartSvgContextMenu({
+  menuState,
+  onClose,
+}: {
+  menuState: SmartSvgMenuState | null
+  onClose: () => void
+}) {
+  const menuRef = useRef<HTMLDivElement>(null)
+  useMenuClose(menuRef, menuState?.position ?? null, onClose)
+
+  if (!menuState) return null
+
+  return (
+    <ContextMenuShell menuRef={menuRef} position={menuState.position} ariaLabel={menuState.ariaLabel}>
+      {menuState.actions.map((action) => (
+        <MenuItem
+          key={action.id}
+          onClick={() => {
+            onClose()
+            void action.run()
+          }}
+          icon={null}
+          variant={action.variant}
+        >
+          {action.label}
+        </MenuItem>
+      ))}
+    </ContextMenuShell>
+  )
+}
+
+const SmartSvgViewInner = ({ svg, viewMode }: SmartSvgViewProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
   const [transform, _setTransform] = useState({ x: 0, y: 0, scale: 1 })
@@ -214,6 +303,10 @@ const SmartSvgViewInner = ({ svg }: SmartSvgViewProps) => {
     })
   }, [])
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [menuState, setMenuState] = useState<SmartSvgMenuState | null>(null)
+  const adapter = useMemo(() => getSvgDiagramAdapter(viewMode), [viewMode])
+  const [textInputRequest, setTextInputRequest] = useState<SvgTextInputRequest | null>(null)
+  const textInputResolverRef = useRef<((value: string | null) => void) | null>(null)
 
   // Drag state kept in refs to avoid re-renders during mouse interactions.
   // Re-renders during mousedown break React's event delegation for SVG
@@ -221,8 +314,48 @@ const SmartSvgViewInner = ({ svg }: SmartSvgViewProps) => {
   const dragRef = useRef({ pressed: false, active: false, startX: 0, startY: 0, originX: 0, originY: 0 })
   const { html: sanitizedSvg, dims: svgDims } = useMemo(() => processSvg(svg), [svg])
 
+  const closeMenu = useCallback(() => {
+    setMenuState(null)
+  }, [])
+
+  const closeTextInput = useCallback((value: string | null) => {
+    textInputResolverRef.current?.(value)
+    textInputResolverRef.current = null
+    setTextInputRequest(null)
+  }, [])
+
+  const replaceDiagramCode = useCallback((next: string) => {
+    const session = useSessionStore.getState()
+    session.setCodeFromSync(next)
+
+    if (!useCollabStore.getState().isCollaborating) return
+
+    const doc = getYDoc()
+    if (!doc) return
+
+    replaceYText(doc.getText(`tab:${session.activeTabId}`), next)
+  }, [])
+
   // Clear selection when SVG changes
-  useEffect(() => { setSelectedId(null) }, [svg])
+  useEffect(() => {
+    setSelectedId(null)
+    setMenuState(null)
+    closeTextInput(null)
+  }, [closeTextInput, svg, viewMode])
+
+  const adapterContext = useMemo<SvgAdapterContext>(() => ({
+    getCode: () => useSessionStore.getState().code,
+    replaceCode: replaceDiagramCode,
+    requestTextInput: async (request) => {
+      setTextInputRequest(request)
+      return await new Promise<string | null>((resolve) => {
+        textInputResolverRef.current = resolve
+      })
+    },
+    report: (message) => {
+      useEphemeralStore.getState().setExecutionOutput('', message)
+    },
+  }), [replaceDiagramCode])
 
   // Reapply data-selected when selection or SVG content changes.
   // Direct DOM mutation gets wiped when React re-renders dangerouslySetInnerHTML.
@@ -285,6 +418,7 @@ const SmartSvgViewInner = ({ svg }: SmartSvgViewProps) => {
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (e.button !== 0) return
+
     const d = dragRef.current
     const t = transformRef.current
     d.pressed = true
@@ -356,35 +490,57 @@ const SmartSvgViewInner = ({ svg }: SmartSvgViewProps) => {
         break
       case 'Escape':
         setSelectedId(null)
+        closeMenu()
         break
     }
-  }, [handleZoomIn, handleZoomOut, fitToView])
+  }, [closeMenu, handleZoomIn, handleZoomOut, fitToView])
 
   // Native click listener — React's onClick doesn't reliably receive events
   // from SVG elements inside dangerouslySetInnerHTML when re-renders occur.
   useEffect(() => {
     const el = containerRef.current
     if (!el) return
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Element
-      const nodeGroup = target.closest('g.node, g.cluster')
-      const edgeGroup = target.closest('g.edge')
+    const clickHandler = (e: MouseEvent) => {
+      const interactionTarget = getInteractionTarget(e.target as Element)
 
-      if (nodeGroup) {
-        const id = nodeGroup.getAttribute('data-node-id')
-        setSelectedId(id)
-        if (id) window.dispatchEvent(new CustomEvent('umple:diagram-select', { detail: { name: id, kind: 'node' } }))
-      } else if (edgeGroup) {
-        const id = edgeGroup.getAttribute('data-edge-id')
-        setSelectedId(id)
-        if (id) window.dispatchEvent(new CustomEvent('umple:diagram-select', { detail: { name: id, kind: 'edge' } }))
+      if (interactionTarget) {
+        setSelectedId(interactionTarget.rawId)
+        window.dispatchEvent(new CustomEvent('umple:diagram-select', {
+          detail: {
+            name: interactionTarget.rawId,
+            kind: interactionTarget.kind,
+          },
+        }))
       } else {
         setSelectedId(null)
       }
     }
-    el.addEventListener('click', handler)
-    return () => el.removeEventListener('click', handler)
-  }, [])
+    const menuHandler = (e: MouseEvent) => {
+      if (!adapter) return
+      const interactionTarget = getInteractionTarget(e.target as Element)
+      if (!interactionTarget) return
+
+      const actions = adapter.getContextMenuActions(interactionTarget, adapterContext)
+      if (actions.length === 0) return
+
+      e.preventDefault()
+      setSelectedId(interactionTarget.rawId)
+      setMenuState({
+        position: { x: e.clientX, y: e.clientY },
+        actions,
+        ariaLabel: interactionTarget.kind === 'edge' ? 'State transition menu' : 'State menu',
+      })
+    }
+
+    el.addEventListener('click', clickHandler)
+    el.addEventListener('contextmenu', menuHandler)
+    el.addEventListener('dblclick', menuHandler)
+    return () => {
+      el.removeEventListener('click', clickHandler)
+      el.removeEventListener('contextmenu', menuHandler)
+      el.removeEventListener('dblclick', menuHandler)
+    }
+  }, [adapter, adapterContext])
 
   if (!svg) {
     return (
@@ -439,6 +595,13 @@ const SmartSvgViewInner = ({ svg }: SmartSvgViewProps) => {
           transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
         }}
         dangerouslySetInnerHTML={{ __html: sanitizedSvg }}
+      />
+
+      <SmartSvgContextMenu menuState={menuState} onClose={closeMenu} />
+      <SvgTextInputDialog
+        request={textInputRequest}
+        onCancel={() => closeTextInput(null)}
+        onSubmit={(value) => closeTextInput(value)}
       />
     </div>
   )

--- a/frontend/src/components/diagram/SvgTextInputDialog.tsx
+++ b/frontend/src/components/diagram/SvgTextInputDialog.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Field, FieldContent, FieldGroup, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import type { SvgTextInputRequest } from './svg-adapters/types'
+
+interface SvgTextInputDialogProps {
+  request: SvgTextInputRequest | null
+  onCancel: () => void
+  onSubmit: (value: string) => void
+}
+
+export function SvgTextInputDialog({
+  request,
+  onCancel,
+  onSubmit,
+}: SvgTextInputDialogProps) {
+  const [value, setValue] = useState('')
+
+  useEffect(() => {
+    setValue(request?.defaultValue ?? '')
+  }, [request])
+
+  const open = request !== null
+  const submitDisabled = request?.inputType === 'color'
+    ? value.trim().length === 0
+    : value.trim().length === 0
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onCancel() }}>
+      <DialogContent className="sm:max-w-md" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{request?.title ?? 'Edit Value'}</DialogTitle>
+          {request?.description ? (
+            <DialogDescription>{request.description}</DialogDescription>
+          ) : null}
+        </DialogHeader>
+
+        <FieldGroup>
+          <Field>
+            <FieldLabel htmlFor="svg-text-input">{request?.label ?? 'Value'}</FieldLabel>
+            <FieldContent>
+              <Input
+                id="svg-text-input"
+                type={request?.inputType ?? 'text'}
+                value={value}
+                onChange={(event) => setValue(event.target.value)}
+                placeholder={request?.placeholder}
+                autoFocus
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && !submitDisabled) {
+                    event.preventDefault()
+                    onSubmit(value)
+                  }
+                }}
+                data-testid="svg-text-input-dialog-input"
+              />
+            </FieldContent>
+          </Field>
+        </FieldGroup>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => onSubmit(value)}
+            disabled={submitDisabled}
+            data-testid="svg-text-input-dialog-submit"
+          >
+            {request?.submitLabel ?? 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/diagram/__tests__/SmartSvgView.state.test.tsx
+++ b/frontend/src/components/diagram/__tests__/SmartSvgView.state.test.tsx
@@ -1,0 +1,303 @@
+// @vitest-environment jsdom
+import * as Y from 'yjs'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { SmartSvgView } from '../SmartSvgView'
+import { useCollabStore } from '@/stores/collabStore'
+import { useSessionStore } from '@/stores/sessionStore'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+let currentDoc: Y.Doc | null = null
+
+vi.mock('@/hooks/useCollab', () => ({
+  getYDoc: () => currentDoc,
+}))
+
+const svgGraphicsPrototype = SVGGraphicsElement.prototype as SVGGraphicsElement & {
+  getBBox?: () => { x: number; y: number; width: number; height: number }
+}
+const originalGetBBox = svgGraphicsPrototype.getBBox
+const originalMatchMedia = window.matchMedia
+
+const STATE_CODE = `class Phone {
+  screenLight {
+    Off {
+      callReceived -> On;
+    }
+
+    On {
+      hangUp -> Off;
+    }
+  }
+}
+`
+
+const STATE_SVG = `
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="180" height="120" viewBox="0 0 180 120">
+    <g class="node">
+      <title>Phone_screenLight_Off</title>
+      <a xlink:title="Class Phone, SM state, State Off">
+        <rect x="10" y="10" width="60" height="24"></rect>
+        <text x="20" y="26">Off</text>
+      </a>
+    </g>
+    <g class="node">
+      <title>Phone_screenLight_On</title>
+      <a xlink:title="Class Phone, SM state, State On">
+        <rect x="100" y="10" width="60" height="24"></rect>
+        <text x="120" y="26">On</text>
+      </a>
+    </g>
+    <g class="edge">
+      <title>Phone_screenLight_On->Phone_screenLight_Off</title>
+      <a xlink:title="From On to Off on hangUp">
+        <path d="M120,34 C120,60 60,60 40,34"></path>
+      </a>
+      <text x="86" y="58">hangUp</text>
+    </g>
+  </svg>
+`
+
+beforeAll(() => {
+  Object.defineProperty(svgGraphicsPrototype, 'getBBox', {
+    configurable: true,
+    value: () => ({ x: 0, y: 0, width: 180, height: 120 }),
+  })
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  })
+})
+
+afterAll(() => {
+  if (originalGetBBox) {
+    Object.defineProperty(svgGraphicsPrototype, 'getBBox', {
+      configurable: true,
+      value: originalGetBBox,
+    })
+  } else {
+    Reflect.deleteProperty(svgGraphicsPrototype, 'getBBox')
+  }
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: originalMatchMedia,
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  currentDoc?.destroy()
+  currentDoc = null
+  useCollabStore.setState({
+    isCollaborating: false,
+    roomId: null,
+    connected: false,
+    ready: false,
+    connectedUsers: [],
+  })
+  useSessionStore.setState({
+    code: '',
+    modelId: null,
+    activeTabId: 'main',
+    syncPending: false,
+    tabs: [{
+      id: 'main',
+      name: 'Model.ump',
+      code: '',
+      dirty: false,
+      savedCode: '',
+      undoStack: [],
+      redoStack: [],
+    }],
+  })
+})
+
+describe('SmartSvgView state interactions', () => {
+  it('opens a state node menu and renames the selected state', async () => {
+    useSessionStore.setState({
+      code: STATE_CODE,
+      modelId: 'model-1',
+      tabs: [{
+        id: 'main',
+        name: 'Model.ump',
+        code: STATE_CODE,
+        dirty: false,
+        savedCode: STATE_CODE,
+        undoStack: [],
+        redoStack: [],
+      }],
+    })
+
+    const { container } = render(
+      <TooltipProvider>
+        <SmartSvgView svg={STATE_SVG} viewMode="state" />
+      </TooltipProvider>,
+    )
+
+    fireEvent.contextMenu(container.querySelector('g.node') as Element)
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename State' }))
+    fireEvent.change(screen.getByTestId('svg-text-input-dialog-input'), { target: { value: 'Dark' } })
+    fireEvent.click(screen.getByTestId('svg-text-input-dialog-submit'))
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().code).toContain('Dark {')
+      expect(useSessionStore.getState().code).toContain('hangUp -> Dark;')
+    })
+
+    const [activeTab] = useSessionStore.getState().tabs
+    expect(activeTab.undoStack).toEqual([STATE_CODE])
+  })
+
+  it('opens a transition menu and updates the guard', async () => {
+    useSessionStore.setState({
+      code: STATE_CODE,
+      modelId: 'model-1',
+      tabs: [{
+        id: 'main',
+        name: 'Model.ump',
+        code: STATE_CODE,
+        dirty: false,
+        savedCode: STATE_CODE,
+        undoStack: [],
+        redoStack: [],
+      }],
+    })
+
+    const { container } = render(
+      <TooltipProvider>
+        <SmartSvgView svg={STATE_SVG} viewMode="state" />
+      </TooltipProvider>,
+    )
+
+    fireEvent.contextMenu(container.querySelector('g.edge') as Element)
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Change Guard' }))
+    fireEvent.change(screen.getByTestId('svg-text-input-dialog-input'), { target: { value: '[lineAvailable]' } })
+    fireEvent.click(screen.getByTestId('svg-text-input-dialog-submit'))
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().code).toContain('hangUp [lineAvailable] -> Off;')
+    })
+  })
+
+  it('adds a transition from the state menu', async () => {
+    useSessionStore.setState({
+      code: STATE_CODE,
+      modelId: 'model-1',
+      tabs: [{
+        id: 'main',
+        name: 'Model.ump',
+        code: STATE_CODE,
+        dirty: false,
+        savedCode: STATE_CODE,
+        undoStack: [],
+        redoStack: [],
+      }],
+    })
+
+    const { container } = render(
+      <TooltipProvider>
+        <SmartSvgView svg={STATE_SVG} viewMode="state" />
+      </TooltipProvider>,
+    )
+
+    const offNode = container.querySelector('[data-node-id="Phone_screenLight_Off"]')
+
+    fireEvent.contextMenu(offNode as Element)
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add Transition' }))
+    fireEvent.change(screen.getByTestId('svg-text-input-dialog-input'), { target: { value: 'reset' } })
+    fireEvent.click(screen.getByTestId('svg-text-input-dialog-submit'))
+    await waitFor(() => {
+      expect(screen.getByTestId('svg-text-input-dialog-input')).toBeDefined()
+    })
+    fireEvent.change(screen.getByTestId('svg-text-input-dialog-input'), { target: { value: 'On' } })
+    fireEvent.click(screen.getByTestId('svg-text-input-dialog-submit'))
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().code).toContain('reset -> On;')
+    })
+  })
+
+  it('lets users undo SVG menu edits', async () => {
+    useSessionStore.setState({
+      code: STATE_CODE,
+      modelId: 'model-1',
+      tabs: [{
+        id: 'main',
+        name: 'Model.ump',
+        code: STATE_CODE,
+        dirty: false,
+        savedCode: STATE_CODE,
+        undoStack: [],
+        redoStack: [],
+      }],
+    })
+
+    const { container } = render(
+      <TooltipProvider>
+        <SmartSvgView svg={STATE_SVG} viewMode="state" />
+      </TooltipProvider>,
+    )
+
+    fireEvent.contextMenu(container.querySelector('g.node') as Element)
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename State' }))
+    fireEvent.change(screen.getByTestId('svg-text-input-dialog-input'), { target: { value: 'Dark' } })
+    fireEvent.click(screen.getByTestId('svg-text-input-dialog-submit'))
+
+    await waitFor(() => {
+      expect(useSessionStore.getState().code).toContain('Dark {')
+    })
+
+    useSessionStore.getState().undo()
+
+    expect(useSessionStore.getState().code).toBe(STATE_CODE)
+  })
+
+  it('writes SVG edits into the shared Yjs tab when collaborating', async () => {
+    currentDoc = new Y.Doc()
+    currentDoc.getText('tab:main').insert(0, STATE_CODE)
+
+    useCollabStore.setState({
+      isCollaborating: true,
+      roomId: 'room-1',
+      connected: true,
+      ready: true,
+      connectedUsers: [],
+    })
+    useSessionStore.setState({
+      code: STATE_CODE,
+      modelId: 'model-1',
+      activeTabId: 'main',
+      tabs: [{
+        id: 'main',
+        name: 'Model.ump',
+        code: STATE_CODE,
+        dirty: false,
+        savedCode: STATE_CODE,
+        undoStack: [],
+        redoStack: [],
+      }],
+    })
+
+    const { container } = render(
+      <TooltipProvider>
+        <SmartSvgView svg={STATE_SVG} viewMode="state" />
+      </TooltipProvider>,
+    )
+
+    fireEvent.contextMenu(container.querySelector('g.node') as Element)
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename State' }))
+    fireEvent.change(screen.getByTestId('svg-text-input-dialog-input'), { target: { value: 'Dark' } })
+    fireEvent.click(screen.getByTestId('svg-text-input-dialog-submit'))
+
+    await waitFor(() => {
+      expect(currentDoc?.getText('tab:main').toString()).toContain('Dark {')
+      expect(currentDoc?.getText('tab:main').toString()).toContain('hangUp -> Dark;')
+    })
+  })
+})

--- a/frontend/src/components/diagram/__tests__/SmartSvgView.test.tsx
+++ b/frontend/src/components/diagram/__tests__/SmartSvgView.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { SmartSvgView, formatDiagramIdentifierForDisplay } from '../SmartSvgView'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -8,11 +8,20 @@ const svgGraphicsPrototype = SVGGraphicsElement.prototype as SVGGraphicsElement 
   getBBox?: () => { x: number; y: number; width: number; height: number }
 }
 const originalGetBBox = svgGraphicsPrototype.getBBox
+const originalMatchMedia = window.matchMedia
 
 beforeAll(() => {
   Object.defineProperty(svgGraphicsPrototype, 'getBBox', {
     configurable: true,
     value: () => ({ x: 0, y: 0, width: 120, height: 80 }),
+  })
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
   })
 })
 
@@ -25,6 +34,10 @@ afterAll(() => {
   } else {
     Reflect.deleteProperty(svgGraphicsPrototype, 'getBBox')
   }
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: originalMatchMedia,
+  })
 })
 
 afterEach(() => {

--- a/frontend/src/components/diagram/svg-adapters/__tests__/stateTransforms.test.ts
+++ b/frontend/src/components/diagram/svg-adapters/__tests__/stateTransforms.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from 'vitest'
+import {
+  addSubstateInCode,
+  addTransitionInCode,
+  deleteStateInCode,
+  deleteTransitionInCode,
+  parseStateEdgeTarget,
+  parseStateNodeTarget,
+  renameStateInCode,
+  setStateColorInCode,
+  setTransitionActionInCode,
+  setTransitionDestinationInCode,
+  setTransitionGuardInCode,
+  setTransitionTriggerInCode,
+} from '../stateTransforms'
+
+describe('stateTransforms', () => {
+  it('parses state node metadata from the SVG anchor title', () => {
+    expect(
+      parseStateNodeTarget({
+        rawId: 'CarTransmission_stateDrive_first',
+        anchorTitle: 'Class CarTransmission, SM state, State drive.first',
+      }),
+    ).toEqual({
+      rawId: 'CarTransmission_stateDrive_first',
+      label: 'drive.first',
+      stateName: 'first',
+      isCluster: false,
+    })
+  })
+
+  it('falls back to cluster ids when no SVG anchor title is available', () => {
+    expect(
+      parseStateNodeTarget({
+        rawId: 'clusterPhone_screenLight_Off',
+        anchorTitle: null,
+      }),
+    ).toEqual({
+      rawId: 'clusterPhone_screenLight_Off',
+      label: 'Phone_screenLight_Off',
+      stateName: 'Off',
+      isCluster: true,
+    })
+  })
+
+  it('parses transition metadata from the SVG anchor title', () => {
+    expect(
+      parseStateEdgeTarget({
+        rawId: 'CarTransmission_stateDrive_first->CarTransmission_stateDrive_second',
+        anchorTitle: 'From drive.first to drive.second on reachSecondSpeed\rGuard: [driveSelected]',
+      }),
+    ).toEqual({
+      rawId: 'CarTransmission_stateDrive_first->CarTransmission_stateDrive_second',
+      sourceRawId: 'CarTransmission_stateDrive_first',
+      targetRawId: 'CarTransmission_stateDrive_second',
+      sourceLabel: 'drive.first',
+      targetLabel: 'drive.second',
+      trigger: 'reachSecondSpeed',
+      guard: '[driveSelected]',
+      action: null,
+    })
+  })
+
+  it('renames a state only within its owning state machine', () => {
+    const code = `class Phone {
+  ringerSound {
+    Off {
+      callReceived -> On;
+    }
+
+    On {
+      silentButton -> Off;
+    }
+  }
+
+  screenLight {
+    Off {
+      callReceived -> On;
+    }
+
+    On {
+      hangUp -> Off;
+    }
+  }
+}
+`
+
+    const next = renameStateInCode(
+      code,
+      {
+        rawId: 'Phone_screenLight_Off',
+        anchorTitle: 'Class Phone, SM state, State screenLight.Off',
+      },
+      'Dark',
+    )
+
+    expect(next).toBe(`class Phone {
+  ringerSound {
+    Off {
+      callReceived -> On;
+    }
+
+    On {
+      silentButton -> Off;
+    }
+  }
+
+  screenLight {
+    Dark {
+      callReceived -> On;
+    }
+
+    On {
+      hangUp -> Dark;
+    }
+  }
+}
+`)
+  })
+
+  it('deletes a state block and incoming transitions in the same state machine', () => {
+    const code = `class Phone {
+  ringerSound {
+    Off {
+      callReceived -> On;
+    }
+
+    On {
+      silentButton -> Off;
+    }
+  }
+
+  screenLight {
+    Off {
+      callReceived -> On;
+    }
+
+    On {
+      hangUp -> Off;
+    }
+  }
+}
+`
+
+    const next = deleteStateInCode(code, {
+      rawId: 'Phone_screenLight_Off',
+      anchorTitle: 'Class Phone, SM state, State screenLight.Off',
+    })
+
+    expect(next).toBe(`class Phone {
+  ringerSound {
+    Off {
+      callReceived -> On;
+    }
+
+    On {
+      silentButton -> Off;
+    }
+  }
+
+  screenLight {
+    On {
+    }
+  }
+}
+`)
+  })
+
+  it('adds a substate at the end of the target state block', () => {
+    const code = `class CarTransmission {
+  state {
+    drive {
+      first {
+      }
+    }
+  }
+}
+`
+
+    const next = addSubstateInCode(code, {
+      rawId: 'clusterCarTransmission_state_drive',
+      anchorTitle: null,
+    }, 'second')
+
+    expect(next).toBe(`class CarTransmission {
+  state {
+    drive {
+      first {
+      }
+      second {
+      }
+    }
+  }
+}
+`)
+  })
+
+  it('adds or replaces displayColor within a state block', () => {
+    const withoutColor = `class PhoneLine {
+  state {
+    onHold {
+    }
+  }
+}
+`
+
+    expect(
+      setStateColorInCode(withoutColor, {
+        rawId: 'PhoneLine_state_onHold',
+        anchorTitle: 'Class PhoneLine, SM state, State onHold',
+      }, '#ff0000'),
+    ).toBe(`class PhoneLine {
+  state {
+    onHold {
+      displayColor #ff0000;
+    }
+  }
+}
+`)
+
+    const withColor = `class PhoneLine {
+  state {
+    onHold {
+      displayColor #00ff00;
+    }
+  }
+}
+`
+
+    expect(
+      setStateColorInCode(withColor, {
+        rawId: 'PhoneLine_state_onHold',
+        anchorTitle: 'Class PhoneLine, SM state, State onHold',
+      }, '#ff0000'),
+    ).toBe(`class PhoneLine {
+  state {
+    onHold {
+      displayColor #ff0000;
+    }
+  }
+}
+`)
+  })
+
+  it('updates transition trigger, guard, action, destination, and can delete the transition', () => {
+    const code = `class PhoneLine {
+  state {
+    communicating {
+      putOnHold -> onHold;
+    }
+
+    onHold {
+    }
+
+    waitForHook {
+    }
+  }
+}
+`
+
+    const edge = {
+      rawId: 'PhoneLine_state_communicating->PhoneLine_state_onHold',
+      anchorTitle: 'From communicating to onHold on putOnHold',
+    }
+
+    expect(setTransitionTriggerInCode(code, edge, 'takeOffHold')).toBe(`class PhoneLine {
+  state {
+    communicating {
+      takeOffHold -> onHold;
+    }
+
+    onHold {
+    }
+
+    waitForHook {
+    }
+  }
+}
+`)
+
+    expect(setTransitionGuardInCode(code, edge, '[lineAvailable]')).toBe(`class PhoneLine {
+  state {
+    communicating {
+      putOnHold [lineAvailable] -> onHold;
+    }
+
+    onHold {
+    }
+
+    waitForHook {
+    }
+  }
+}
+`)
+
+    expect(setTransitionActionInCode(code, edge, '{ logHold(); }')).toBe(`class PhoneLine {
+  state {
+    communicating {
+      putOnHold / { logHold(); } -> onHold;
+    }
+
+    onHold {
+    }
+
+    waitForHook {
+    }
+  }
+}
+`)
+
+    expect(
+      setTransitionDestinationInCode(code, edge, {
+        rawId: 'PhoneLine_state_waitForHook',
+        anchorTitle: 'Class PhoneLine, SM state, State waitForHook',
+      }),
+    ).toBe(`class PhoneLine {
+  state {
+    communicating {
+      putOnHold -> waitForHook;
+    }
+
+    onHold {
+    }
+
+    waitForHook {
+    }
+  }
+}
+`)
+
+    expect(deleteTransitionInCode(code, edge)).toBe(`class PhoneLine {
+  state {
+    communicating {
+    }
+
+    onHold {
+    }
+
+    waitForHook {
+    }
+  }
+}
+`)
+  })
+
+  it('adds a transition from one state to another', () => {
+    const code = `class Phone {
+  screenLight {
+    Off {
+    }
+
+    On {
+      hangUp -> Off;
+    }
+  }
+}
+`
+
+    const next = addTransitionInCode(
+      code,
+      {
+        rawId: 'Phone_screenLight_Off',
+        anchorTitle: 'Class Phone, SM state, State Off',
+      },
+      'reset',
+      {
+        rawId: 'Phone_screenLight_On',
+        anchorTitle: 'Class Phone, SM state, State On',
+      },
+    )
+
+    expect(next).toBe(`class Phone {
+  screenLight {
+    Off {
+      reset -> On;
+    }
+
+    On {
+      hangUp -> Off;
+    }
+  }
+}
+`)
+  })
+})

--- a/frontend/src/components/diagram/svg-adapters/index.ts
+++ b/frontend/src/components/diagram/svg-adapters/index.ts
@@ -1,0 +1,12 @@
+import type { DiagramView } from '@/constants/diagram'
+import type { SvgDiagramAdapter } from './types'
+import { stateSvgAdapter } from './state'
+
+const ADAPTERS = new Map<DiagramView, SvgDiagramAdapter>([
+  ['state', stateSvgAdapter],
+])
+
+export function getSvgDiagramAdapter(viewMode?: DiagramView): SvgDiagramAdapter | null {
+  if (!viewMode) return null
+  return ADAPTERS.get(viewMode) ?? null
+}

--- a/frontend/src/components/diagram/svg-adapters/state.ts
+++ b/frontend/src/components/diagram/svg-adapters/state.ts
@@ -1,0 +1,227 @@
+import {
+  addSubstateInCode,
+  addTransitionInCode,
+  deleteStateInCode,
+  deleteTransitionInCode,
+  parseStateEdgeTarget,
+  parseStateNodeTarget,
+  renameStateInCode,
+  setStateColorInCode,
+  setTransitionActionInCode,
+  setTransitionDestinationInCode,
+  setTransitionGuardInCode,
+  setTransitionTriggerInCode,
+  type SvgStateTarget,
+} from './stateTransforms'
+import type {
+  SvgAdapterContext,
+  SvgDiagramAdapter,
+  SvgInteractionTarget,
+  SvgMenuAction,
+  SvgTextInputRequest,
+} from './types'
+
+function applyCodeUpdate(ctx: SvgAdapterContext, next: string | null, fallbackMessage: string) {
+  if (!next || next === ctx.getCode()) {
+    ctx.report(fallbackMessage)
+    return
+  }
+  ctx.replaceCode(next)
+}
+
+async function promptValue(ctx: SvgAdapterContext, request: SvgTextInputRequest): Promise<string | null> {
+  const value = await ctx.requestTextInput(request)
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function asStateTarget(target: SvgInteractionTarget): SvgStateTarget {
+  return {
+    rawId: target.rawId,
+    anchorTitle: target.anchorTitle,
+  }
+}
+
+function buildNodeActions(target: SvgInteractionTarget, ctx: SvgAdapterContext): SvgMenuAction[] {
+  const stateTarget = asStateTarget(target)
+  const parsed = parseStateNodeTarget(stateTarget)
+
+  return [
+    {
+      id: 'rename-state',
+      label: 'Rename State',
+      async run() {
+        const nextName = await promptValue(ctx, {
+          title: 'Rename State',
+          description: `Update the name for ${parsed.stateName}.`,
+          label: 'State name',
+          defaultValue: parsed.stateName,
+          submitLabel: 'Rename',
+        })
+        if (!nextName) return
+        applyCodeUpdate(ctx, renameStateInCode(ctx.getCode(), stateTarget, nextName), 'Unable to rename this state.')
+      },
+    },
+    {
+      id: 'delete-state',
+      label: 'Delete State',
+      variant: 'destructive',
+      run() {
+        applyCodeUpdate(ctx, deleteStateInCode(ctx.getCode(), stateTarget), 'Unable to delete this state.')
+      },
+    },
+    {
+      id: 'add-substate',
+      label: 'Add Substate',
+      async run() {
+        const nextName = await promptValue(ctx, {
+          title: 'Add Substate',
+          description: `Create a new substate inside ${parsed.stateName}.`,
+          label: 'Substate name',
+          placeholder: 'NewState',
+          submitLabel: 'Add',
+        })
+        if (!nextName) return
+        applyCodeUpdate(ctx, addSubstateInCode(ctx.getCode(), stateTarget, nextName), 'Unable to add a substate here.')
+      },
+    },
+    {
+      id: 'add-transition',
+      label: 'Add Transition',
+      async run() {
+        const trigger = await promptValue(ctx, {
+          title: 'Add Transition',
+          description: `Create a transition from ${parsed.stateName}.`,
+          label: 'Trigger',
+          placeholder: 'eventName',
+          submitLabel: 'Next',
+        })
+        if (!trigger) return
+        const destination = await promptValue(ctx, {
+          title: 'Add Transition',
+          description: `Choose the destination for ${trigger}.`,
+          label: 'Destination state',
+          placeholder: 'TargetState',
+          submitLabel: 'Add',
+        })
+        if (!destination) return
+        applyCodeUpdate(
+          ctx,
+          addTransitionInCode(ctx.getCode(), stateTarget, trigger, {
+            rawId: destination,
+            anchorTitle: `Class Unknown, SM state, State ${destination}`,
+          }),
+          'Unable to add this transition.',
+        )
+      },
+    },
+    {
+      id: 'change-color',
+      label: 'Change Color',
+      async run() {
+        const color = await promptValue(ctx, {
+          title: 'Change State Color',
+          description: `Set the display color for ${parsed.stateName}.`,
+          label: 'Color',
+          defaultValue: '#ff0000',
+          submitLabel: 'Apply',
+          inputType: 'color',
+        })
+        if (!color) return
+        applyCodeUpdate(ctx, setStateColorInCode(ctx.getCode(), stateTarget, color), 'Unable to change this state color.')
+      },
+    },
+  ]
+}
+
+function buildEdgeActions(target: SvgInteractionTarget, ctx: SvgAdapterContext): SvgMenuAction[] {
+  const edgeTarget = asStateTarget(target)
+  const parsed = parseStateEdgeTarget(edgeTarget)
+
+  return [
+    {
+      id: 'change-event',
+      label: 'Change Event',
+      async run() {
+        const trigger = await promptValue(ctx, {
+          title: 'Change Event',
+          description: `Update the event for ${parsed.sourceLabel} -> ${parsed.targetLabel}.`,
+          label: 'Trigger',
+          defaultValue: parsed.trigger,
+          submitLabel: 'Save',
+        })
+        if (!trigger) return
+        applyCodeUpdate(ctx, setTransitionTriggerInCode(ctx.getCode(), edgeTarget, trigger), 'Unable to update this transition.')
+      },
+    },
+    {
+      id: 'change-guard',
+      label: 'Change Guard',
+      async run() {
+        const guard = await promptValue(ctx, {
+          title: 'Change Guard',
+          description: `Update the guard for ${parsed.sourceLabel} -> ${parsed.targetLabel}.`,
+          label: 'Guard',
+          defaultValue: parsed.guard ?? '[condition]',
+          submitLabel: 'Save',
+        })
+        if (!guard) return
+        applyCodeUpdate(ctx, setTransitionGuardInCode(ctx.getCode(), edgeTarget, guard), 'Unable to update this guard.')
+      },
+    },
+    {
+      id: 'change-action',
+      label: 'Change Action',
+      async run() {
+        const action = await promptValue(ctx, {
+          title: 'Change Action',
+          description: `Update the action for ${parsed.sourceLabel} -> ${parsed.targetLabel}.`,
+          label: 'Action',
+          defaultValue: parsed.action ?? '{ action(); }',
+          submitLabel: 'Save',
+        })
+        if (!action) return
+        applyCodeUpdate(ctx, setTransitionActionInCode(ctx.getCode(), edgeTarget, action), 'Unable to update this action.')
+      },
+    },
+    {
+      id: 'change-destination',
+      label: 'Change Destination',
+      async run() {
+        const destination = await promptValue(ctx, {
+          title: 'Change Destination',
+          description: `Update the destination for ${parsed.sourceLabel} -> ${parsed.targetLabel}.`,
+          label: 'Destination state',
+          defaultValue: parsed.targetLabel,
+          submitLabel: 'Save',
+        })
+        if (!destination) return
+        applyCodeUpdate(
+          ctx,
+          setTransitionDestinationInCode(ctx.getCode(), edgeTarget, {
+            rawId: parsed.targetRawId,
+            anchorTitle: `Class Unknown, SM state, State ${destination}`,
+          }),
+          'Unable to update this destination.',
+        )
+      },
+    },
+    {
+      id: 'delete-transition',
+      label: 'Delete Transition',
+      variant: 'destructive',
+      run() {
+        applyCodeUpdate(ctx, deleteTransitionInCode(ctx.getCode(), edgeTarget), 'Unable to delete this transition.')
+      },
+    },
+  ]
+}
+
+export const stateSvgAdapter: SvgDiagramAdapter = {
+  viewMode: 'state',
+  getContextMenuActions(target, ctx) {
+    return target.kind === 'edge'
+      ? buildEdgeActions(target, ctx)
+      : buildNodeActions(target, ctx)
+  },
+}

--- a/frontend/src/components/diagram/svg-adapters/stateTransforms.ts
+++ b/frontend/src/components/diagram/svg-adapters/stateTransforms.ts
@@ -1,0 +1,439 @@
+import { findDiagramRange } from '../../editor/diagramSelection'
+
+export interface SvgStateTarget {
+  rawId: string
+  anchorTitle: string | null
+}
+
+export interface ParsedStateNodeTarget {
+  rawId: string
+  label: string
+  stateName: string
+  isCluster: boolean
+}
+
+export interface ParsedStateEdgeTarget {
+  rawId: string
+  sourceRawId: string
+  targetRawId: string
+  sourceLabel: string
+  targetLabel: string
+  trigger: string
+  guard: string | null
+  action: string | null
+}
+
+interface TextRange {
+  from: number
+  to: number
+}
+
+interface ParsedTransitionLine {
+  indent: string
+  trigger: string
+  guard: string | null
+  action: string | null
+  destination: string
+}
+
+const STATE_HEADER_RE = /^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*\{/m
+const DISPLAY_COLOR_RE = /^(\s*)displayColor\s+#[0-9a-fA-F]{6}\s*;$/m
+
+function escapeForRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function blockRangeFrom(code: string, from: number): TextRange | null {
+  const braceIndex = code.indexOf('{', from)
+  if (braceIndex === -1) return null
+
+  let depth = 0
+  for (let i = braceIndex; i < code.length; i++) {
+    if (code[i] === '{') depth++
+    if (code[i] === '}') {
+      depth--
+      if (depth === 0) return { from, to: i + 1 }
+    }
+  }
+
+  return null
+}
+
+function findEnclosingStateMachineRange(code: string, index: number): TextRange | null {
+  const pattern = /\bstatemachine\s+[A-Za-z_][A-Za-z0-9_]*\b/g
+  let match: RegExpExecArray | null
+  let best: TextRange | null = null
+
+  while ((match = pattern.exec(code)) !== null) {
+    const range = blockRangeFrom(code, match.index)
+    if (!range) continue
+    if (index < range.from || index > range.to) continue
+    if (!best || range.to - range.from < best.to - best.from) best = range
+  }
+
+  return best
+}
+
+function findEnclosingNamedBlockRange(code: string, index: number, exclude: TextRange): TextRange | null {
+  const fallbackPattern = /^\s*(?:[A-Za-z_][A-Za-z0-9_]*)\s*\{/gm
+  let match: RegExpExecArray | null
+  let best: TextRange | null = null
+
+  while ((match = fallbackPattern.exec(code)) !== null) {
+    const range = blockRangeFrom(code, match.index)
+    if (!range) continue
+    if (index < range.from || index > range.to) continue
+    if (range.from === exclude.from && range.to === exclude.to) continue
+    if (!best || range.to - range.from < best.to - best.from) best = range
+  }
+
+  return best
+}
+
+function parseStateHeader(block: string): { indent: string; stateName: string } | null {
+  const match = block.match(STATE_HEADER_RE)
+  if (!match) return null
+  return { indent: match[1], stateName: match[2] }
+}
+
+function findStateRange(code: string, target: SvgStateTarget): TextRange | null {
+  const parsed = parseStateNodeTarget(target)
+  const candidates = [target.rawId, parsed.label, parsed.stateName]
+
+  for (const candidate of candidates) {
+    const range = findDiagramRange(code, { name: candidate, kind: 'node' })
+    if (range) return range
+  }
+
+  return null
+}
+
+function updateCodeRange(code: string, range: TextRange, next: string): string {
+  return code.slice(0, range.from) + next + code.slice(range.to)
+}
+
+function stateBodyIndent(block: string): string | null {
+  const parsed = parseStateHeader(block)
+  if (!parsed) return null
+  return `${parsed.indent}  `
+}
+
+function parseTransitionLine(line: string): ParsedTransitionLine | null {
+  const match = line.match(/^(\s*)(.+?)(?:\s+(\[[^\]]+\]))?(?:\s*\/\s*(\{.*\}))?\s*->\s*([A-Za-z_][A-Za-z0-9_.]*)\s*;\s*$/)
+  if (!match) return null
+
+  return {
+    indent: match[1],
+    trigger: normalizeWhitespace(match[2]),
+    guard: match[3] ? normalizeWhitespace(match[3]) : null,
+    action: match[4] ? normalizeWhitespace(match[4]) : null,
+    destination: normalizeWhitespace(match[5]),
+  }
+}
+
+function findTransitionLineRange(
+  sourceBlock: string,
+  edge: ParsedStateEdgeTarget,
+): TextRange | null {
+  let offset = 0
+  for (const line of sourceBlock.split('\n')) {
+    const parsed = parseTransitionLine(line)
+    const lineRange = { from: offset, to: offset + line.length }
+    offset += line.length + 1
+
+    if (!parsed) continue
+    if (parsed.destination !== edge.targetLabel) continue
+    if (normalizeWhitespace(parsed.trigger) !== normalizeWhitespace(edge.trigger)) continue
+    if ((parsed.guard ?? null) !== (edge.guard ?? null)) continue
+    return lineRange
+  }
+
+  offset = 0
+  for (const line of sourceBlock.split('\n')) {
+    const parsed = parseTransitionLine(line)
+    const lineRange = { from: offset, to: offset + line.length }
+    offset += line.length + 1
+
+    if (!parsed) continue
+    if (parsed.destination !== edge.targetLabel) continue
+    if (normalizeWhitespace(parsed.trigger) !== normalizeWhitespace(edge.trigger)) continue
+    return lineRange
+  }
+
+  return null
+}
+
+function cleanEmptyBlockLines(code: string): string {
+  return code
+    .replace(/\{\n(\s*)\n(\s*)\}/g, '{\n$2}')
+    .replace(/\{\n(?:\s*\n)+/g, '{\n')
+}
+
+function trimClusterPrefix(rawId: string): string {
+  if (rawId.startsWith('cluster_')) return rawId.slice('cluster_'.length)
+  if (rawId.startsWith('cluster')) return rawId.slice('cluster'.length)
+  return rawId
+}
+
+function formatAction(action: string | null): string | null {
+  if (!action) return null
+  const trimmed = normalizeWhitespace(action)
+  if (trimmed.length === 0) return null
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) return trimmed
+  return `{ ${trimmed} }`
+}
+
+function buildTransitionLine(
+  parsed: ParsedTransitionLine,
+  overrides: Partial<Pick<ParsedTransitionLine, 'trigger' | 'guard' | 'action' | 'destination'>>,
+): string {
+  const trigger = overrides.trigger ?? parsed.trigger
+  const guard = overrides.guard === undefined ? parsed.guard : overrides.guard
+  const action = overrides.action === undefined ? parsed.action : overrides.action
+  const destination = overrides.destination ?? parsed.destination
+
+  const guardPart = guard ? ` ${guard}` : ''
+  const actionPart = action ? ` / ${formatAction(action)}` : ''
+  return `${parsed.indent}${trigger}${guardPart}${actionPart} -> ${destination};`
+}
+
+function replaceInEnclosingStateMachine(
+  code: string,
+  stateRange: TextRange,
+  replacer: (stateMachineCode: string, localStateRange: TextRange) => string | null,
+): string | null {
+  const stateMachineRange = findEnclosingStateMachineRange(code, stateRange.from)
+    ?? findEnclosingNamedBlockRange(code, stateRange.from, stateRange)
+  if (!stateMachineRange) return null
+
+  const localStateRange = {
+    from: stateRange.from - stateMachineRange.from,
+    to: stateRange.to - stateMachineRange.from,
+  }
+  const stateMachineCode = code.slice(stateMachineRange.from, stateMachineRange.to)
+  const nextStateMachineCode = replacer(stateMachineCode, localStateRange)
+  if (!nextStateMachineCode) return null
+
+  return code.slice(0, stateMachineRange.from) + nextStateMachineCode + code.slice(stateMachineRange.to)
+}
+
+function parseEdgeOrNull(target: SvgStateTarget): ParsedStateEdgeTarget | null {
+  try {
+    return parseStateEdgeTarget(target)
+  } catch {
+    return null
+  }
+}
+
+export function parseStateNodeTarget(target: SvgStateTarget): ParsedStateNodeTarget {
+  const isCluster = target.rawId.startsWith('cluster')
+  const titleMatch = target.anchorTitle?.match(/^Class .*?, SM state, State ([^\r\n]+)/)
+  const label = titleMatch?.[1]?.trim() || trimClusterPrefix(target.rawId)
+  const stateName = label.split(/[._]/).slice(-1)[0]?.trim() || label
+
+  return {
+    rawId: target.rawId,
+    label,
+    stateName,
+    isCluster,
+  }
+}
+
+export function parseStateEdgeTarget(target: SvgStateTarget): ParsedStateEdgeTarget {
+  const [sourceRawId = '', targetRawId = ''] = target.rawId.split('->')
+  const lines = (target.anchorTitle ?? '').split(/[\r\n]+/).map((line) => line.trim()).filter(Boolean)
+  const firstLine = lines[0] ?? ''
+  const match = firstLine.match(/^From\s+(.+?)\s+to\s+(.+?)\s+(.+)$/)
+
+  let sourceLabel = trimClusterPrefix(sourceRawId)
+  let targetLabel = trimClusterPrefix(targetRawId)
+  let trigger = ''
+  if (match) {
+    sourceLabel = match[1].trim()
+    targetLabel = match[2].trim()
+    trigger = match[3].trim()
+    if (trigger.startsWith('on ')) trigger = trigger.slice(3).trim()
+  }
+
+  const guardMatch = (target.anchorTitle ?? '').match(/(?:^|[\r\n]+)Guard:\s*(.+?)(?:[\r\n]+|$)/)
+  const actionMatch = (target.anchorTitle ?? '').match(/Transition Action:\s*([\s\S]+)$/)
+
+  return {
+    rawId: target.rawId,
+    sourceRawId,
+    targetRawId,
+    sourceLabel,
+    targetLabel,
+    trigger,
+    guard: guardMatch?.[1]?.trim() || null,
+    action: actionMatch ? normalizeWhitespace(actionMatch[1]) : null,
+  }
+}
+
+export function renameStateInCode(code: string, target: SvgStateTarget, nextName: string): string | null {
+  const stateRange = findStateRange(code, target)
+  if (!stateRange) return null
+
+  return replaceInEnclosingStateMachine(code, stateRange, (stateMachineCode, localStateRange) => {
+    const stateBlock = stateMachineCode.slice(localStateRange.from, localStateRange.to)
+    const parsed = parseStateHeader(stateBlock)
+    if (!parsed) return null
+
+    const oldName = parsed.stateName
+    const namePattern = new RegExp(`\\b${escapeForRegex(oldName)}\\b`, 'g')
+    return stateMachineCode.replace(namePattern, nextName)
+  })
+}
+
+export function deleteStateInCode(code: string, target: SvgStateTarget): string | null {
+  const stateRange = findStateRange(code, target)
+  if (!stateRange) return null
+
+  return replaceInEnclosingStateMachine(code, stateRange, (stateMachineCode, localStateRange) => {
+    const stateBlock = stateMachineCode.slice(localStateRange.from, localStateRange.to)
+    const parsed = parseStateHeader(stateBlock)
+    if (!parsed) return null
+
+    const node = parseStateNodeTarget(target)
+    const destinationCandidates = new Set([parsed.stateName, node.label])
+
+    let nextStateMachineCode = stateMachineCode.slice(0, localStateRange.from) + stateMachineCode.slice(localStateRange.to)
+    nextStateMachineCode = nextStateMachineCode
+      .split('\n')
+      .filter((line) => {
+        const transition = parseTransitionLine(line)
+        if (!transition) return true
+        return !destinationCandidates.has(transition.destination)
+      })
+      .join('\n')
+      .replace(/\n{3,}/g, '\n\n')
+
+    return cleanEmptyBlockLines(nextStateMachineCode)
+  })
+}
+
+export function addSubstateInCode(code: string, target: SvgStateTarget, stateName: string): string | null {
+  const stateRange = findStateRange(code, target)
+  if (!stateRange) return null
+
+  const stateBlock = code.slice(stateRange.from, stateRange.to)
+  const parsed = parseStateHeader(stateBlock)
+  const bodyIndent = stateBodyIndent(stateBlock)
+  if (!parsed || !bodyIndent) return null
+
+  const closeIndex = stateBlock.lastIndexOf('}')
+  if (closeIndex === -1) return null
+
+  let prefix = stateBlock.slice(0, closeIndex).replace(/[ \t]+$/, '')
+  if (!prefix.endsWith('\n')) prefix += '\n'
+
+  const nextBlock = `${prefix}${bodyIndent}${stateName} {\n${bodyIndent}}\n${parsed.indent}}`
+  return updateCodeRange(code, stateRange, nextBlock)
+}
+
+export function setStateColorInCode(code: string, target: SvgStateTarget, color: string): string | null {
+  const stateRange = findStateRange(code, target)
+  if (!stateRange) return null
+
+  const stateBlock = code.slice(stateRange.from, stateRange.to)
+  const parsed = parseStateHeader(stateBlock)
+  const bodyIndent = stateBodyIndent(stateBlock)
+  if (!parsed || !bodyIndent) return null
+
+  let nextBlock = stateBlock
+  if (DISPLAY_COLOR_RE.test(nextBlock)) {
+    nextBlock = nextBlock.replace(DISPLAY_COLOR_RE, `${bodyIndent}displayColor ${color};`)
+  } else {
+    const openBraceIndex = nextBlock.indexOf('{')
+    if (openBraceIndex === -1) return null
+    nextBlock = `${nextBlock.slice(0, openBraceIndex + 1)}\n${bodyIndent}displayColor ${color};${nextBlock.slice(openBraceIndex + 1)}`
+  }
+
+  return updateCodeRange(code, stateRange, nextBlock)
+}
+
+export function addTransitionInCode(
+  code: string,
+  source: SvgStateTarget,
+  trigger: string,
+  destination: SvgStateTarget,
+): string | null {
+  const sourceRange = findStateRange(code, source)
+  if (!sourceRange) return null
+
+  const sourceBlock = code.slice(sourceRange.from, sourceRange.to)
+  const parsed = parseStateHeader(sourceBlock)
+  const bodyIndent = stateBodyIndent(sourceBlock)
+  const parsedDestination = parseStateNodeTarget(destination)
+  if (!parsed || !bodyIndent) return null
+
+  const closeIndex = sourceBlock.lastIndexOf('}')
+  if (closeIndex === -1) return null
+
+  let prefix = sourceBlock.slice(0, closeIndex).replace(/[ \t]+$/, '')
+  if (!prefix.endsWith('\n')) prefix += '\n'
+
+  const nextBlock = `${prefix}${bodyIndent}${normalizeWhitespace(trigger)} -> ${parsedDestination.label};\n${parsed.indent}}`
+  return updateCodeRange(code, sourceRange, nextBlock)
+}
+
+function updateTransitionInCode(
+  code: string,
+  target: SvgStateTarget,
+  overrides: Partial<Pick<ParsedTransitionLine, 'trigger' | 'guard' | 'action' | 'destination'>>,
+): string | null {
+  const edge = parseEdgeOrNull(target)
+  if (!edge) return null
+
+  const sourceRange = findDiagramRange(code, { name: edge.sourceRawId, kind: 'node' })
+  if (!sourceRange) return null
+
+  const sourceBlock = code.slice(sourceRange.from, sourceRange.to)
+  const lineRange = findTransitionLineRange(sourceBlock, edge)
+  if (!lineRange) return null
+
+  const line = sourceBlock.slice(lineRange.from, lineRange.to)
+  const parsedLine = parseTransitionLine(line)
+  if (!parsedLine) return null
+
+  const nextLine = buildTransitionLine(parsedLine, overrides)
+  const nextBlock = sourceBlock.slice(0, lineRange.from) + nextLine + sourceBlock.slice(lineRange.to)
+  return updateCodeRange(code, sourceRange, cleanEmptyBlockLines(nextBlock))
+}
+
+export function setTransitionTriggerInCode(code: string, target: SvgStateTarget, trigger: string): string | null {
+  return updateTransitionInCode(code, target, { trigger: normalizeWhitespace(trigger) })
+}
+
+export function setTransitionGuardInCode(code: string, target: SvgStateTarget, guard: string): string | null {
+  return updateTransitionInCode(code, target, { guard: normalizeWhitespace(guard) })
+}
+
+export function setTransitionActionInCode(code: string, target: SvgStateTarget, action: string): string | null {
+  return updateTransitionInCode(code, target, { action: normalizeWhitespace(action) })
+}
+
+export function setTransitionDestinationInCode(code: string, target: SvgStateTarget, destination: SvgStateTarget): string | null {
+  const parsedDestination = parseStateNodeTarget(destination)
+  return updateTransitionInCode(code, target, { destination: parsedDestination.label })
+}
+
+export function deleteTransitionInCode(code: string, target: SvgStateTarget): string | null {
+  const edge = parseEdgeOrNull(target)
+  if (!edge) return null
+
+  const sourceRange = findDiagramRange(code, { name: edge.sourceRawId, kind: 'node' })
+  if (!sourceRange) return null
+
+  const sourceBlock = code.slice(sourceRange.from, sourceRange.to)
+  const lineRange = findTransitionLineRange(sourceBlock, edge)
+  if (!lineRange) return null
+
+  let nextBlock = sourceBlock.slice(0, lineRange.from) + sourceBlock.slice(lineRange.to)
+  nextBlock = cleanEmptyBlockLines(nextBlock)
+  return updateCodeRange(code, sourceRange, nextBlock)
+}

--- a/frontend/src/components/diagram/svg-adapters/types.ts
+++ b/frontend/src/components/diagram/svg-adapters/types.ts
@@ -1,0 +1,35 @@
+import type { DiagramView } from '@/constants/diagram'
+export interface SvgInteractionTarget {
+  kind: 'node' | 'edge'
+  rawId: string
+  anchorTitle: string | null
+}
+
+export interface SvgMenuAction {
+  id: string
+  label: string
+  variant?: 'destructive'
+  run(): void | Promise<void>
+}
+
+export interface SvgTextInputRequest {
+  title: string
+  description?: string
+  label: string
+  defaultValue?: string
+  placeholder?: string
+  submitLabel?: string
+  inputType?: 'text' | 'color'
+}
+
+export interface SvgAdapterContext {
+  getCode(): string
+  replaceCode(next: string): void
+  requestTextInput(request: SvgTextInputRequest): Promise<string | null>
+  report(message: string): void
+}
+
+export interface SvgDiagramAdapter {
+  viewMode: DiagramView
+  getContextMenuActions(target: SvgInteractionTarget, ctx: SvgAdapterContext): SvgMenuAction[]
+}

--- a/frontend/src/components/ui/field.tsx
+++ b/frontend/src/components/ui/field.tsx
@@ -1,0 +1,246 @@
+import { useMemo } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-6",
+        "has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-3 font-medium",
+        "data-[variant=legend]:text-base",
+        "data-[variant=label]:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const fieldVariants = cva(
+  "group/field flex w-full gap-3 data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: ["flex-col [&>*]:w-full [&>.sr-only]:w-auto"],
+        horizontal: [
+          "flex-row items-center",
+          "[&>[data-slot=field-label]]:flex-auto",
+          "has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        ],
+        responsive: [
+          "flex-col @md/field-group:flex-row @md/field-group:items-center [&>*]:w-full @md/field-group:[&>*]:w-auto [&>.sr-only]:w-auto",
+          "@md/field-group:[&>[data-slot=field-label]]:flex-auto",
+          "@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        ],
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  }
+)
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-1.5 leading-snug",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",
+        "has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5 dark:has-data-[state=checked]:bg-primary/10",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-sm leading-normal font-normal text-muted-foreground group-has-[[data-orientation=horizontal]]/field:text-balance",
+        "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = [
+      ...new Map(errors.map((error) => [error?.message, error])).values(),
+    ]
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>
+        )}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
+}

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }


### PR DESCRIPTION
## Summary
- add context-menu editing for Graphviz state diagrams
- route SVG edits through shared session/collab state so undo and Yjs stay in sync
- add transform and interaction tests for state diagram SVG editing

## Test plan
- ./node_modules/.bin/vitest run src/components/diagram/__tests__/SmartSvgView.state.test.tsx src/components/diagram/__tests__/SmartSvgView.test.tsx src/components/diagram/svg-adapters/__tests__/stateTransforms.test.ts
- ./node_modules/.bin/tsc -b --pretty false