### PR TITLE
fix(crud): render svg associations without arrows

### DIFF
--- a/frontend/src/components/crud/__tests__/instanceDiagram.test.ts
+++ b/frontend/src/components/crud/__tests__/instanceDiagram.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { CrudSchema } from '@/api/types'
-import { assocKey } from '@/stores/crudStore'
+import { assocKey, prepareCrudSchema } from '@/stores/crudStore'
 import { generateInstanceDiagramDot } from '../instanceDiagram'
 
 const reflexiveSchema: CrudSchema = {
@@ -211,6 +211,12 @@ const inheritedReflexiveSchema: CrudSchema = {
   enums: [],
 }
 
+prepareCrudSchema(reflexiveSchema)
+prepareCrudSchema(duplicateUnnamedAssociationSchema)
+prepareCrudSchema(inheritedTargetSchema)
+prepareCrudSchema(inheritedSourceSchema)
+prepareCrudSchema(inheritedReflexiveSchema)
+
 describe('generateInstanceDiagramDot', () => {
   it('keeps distinct role-based associations between the same two instances', () => {
     const advisorAssoc = reflexiveSchema.classes[0]!.associations[0]!
@@ -226,8 +232,8 @@ describe('generateInstanceDiagramDot', () => {
       ],
     })
 
-    expect(dot).toContain('Person_1 -> Person_2 [label="advisor"];')
-    expect(dot).toContain('Person_1 -> Person_2 [label="mentor"];')
+    expect(dot).toContain('Person_1 -> Person_2 [dir=none, taillabel="* advisees", headlabel="0..1 advisor"];')
+    expect(dot).toContain('Person_1 -> Person_2 [dir=none, taillabel="* mentees", headlabel="0..1 mentor"];')
     expect((dot.match(/Person_1 -> Person_2/g) ?? [])).toHaveLength(2)
   })
 
@@ -246,7 +252,7 @@ describe('generateInstanceDiagramDot', () => {
       Account: [{ _id: 2 }],
     })
 
-    expect((dot.match(/Order_1 -> Account_2/g) ?? [])).toHaveLength(2)
+    expect((dot.match(/Order_1 -> Account_2 \[dir=none, headlabel="0..1"\];/g) ?? [])).toHaveLength(2)
   })
 
   it('uses the real subclass node id for inherited association targets', () => {
@@ -259,8 +265,8 @@ describe('generateInstanceDiagramDot', () => {
     })
 
     expect(dot).toContain('Bend_12 [label="Bend #12"];')
-    expect(dot).toContain('Segment_1 -> Bend_12 [label="ends"];')
-    expect(dot).not.toContain('Segment_1 -> SegEnd_12 [label="ends"];')
+    expect(dot).toContain('Segment_1 -> Bend_12 [dir=none, taillabel="* segments", headlabel="1..* ends"];')
+    expect(dot).not.toContain('Segment_1 -> SegEnd_12 [dir=none, taillabel="* segments", headlabel="1..* ends"];')
   })
 
   it('renders inherited associations for subclass instances', () => {
@@ -274,7 +280,7 @@ describe('generateInstanceDiagramDot', () => {
 
     expect(dot).toContain('Computer_7 [label="Computer #7"];')
     expect(dot).toContain('Owner_3 [label="Owner #3"];')
-    expect(dot).toContain('Computer_7 -> Owner_3 [label="owner"];')
+    expect(dot).toContain('Computer_7 -> Owner_3 [dir=none, taillabel="* assets", headlabel="0..1 owner"];')
   })
 
   it('keeps both inherited self-association ends distinct when the inherited roles differ', () => {
@@ -290,7 +296,7 @@ describe('generateInstanceDiagramDot', () => {
       ],
     })
 
-    expect(dot).toContain('Student_1 -> Student_2 [label="advisor"];')
-    expect(dot).toContain('Student_1 -> Student_3 [label="advisees"];')
+    expect(dot).toContain('Student_1 -> Student_2 [dir=none, taillabel="* advisees", headlabel="0..1 advisor"];')
+    expect(dot).toContain('Student_1 -> Student_3 [dir=none, taillabel="0..1 advisor", headlabel="* advisees"];')
   })
 })

--- a/frontend/src/components/crud/instanceDiagram.ts
+++ b/frontend/src/components/crud/instanceDiagram.ts
@@ -25,6 +25,12 @@ function associationPairKey(
   return `${nodeKey}::${assocKey}`
 }
 
+function formatEndpointLabel(multiplicity?: string, roleName?: string): string | undefined {
+  const parts = [multiplicity, roleName].filter(Boolean)
+  if (parts.length === 0) return undefined
+  return escapeLabel(parts.join(' '))
+}
+
 export function generateInstanceDiagramDot(
   schema: CrudSchema,
   instances: Record<string, CrudInstance[]>,
@@ -73,8 +79,15 @@ export function generateInstanceDiagramDot(
           const edgeKey = associationPairKey(schema, srcNode, tgtNode, assoc)
           if (drawnEdges.has(edgeKey)) continue
           drawnEdges.add(edgeKey)
-          const label = assoc.roleName ? ` [label="${escapeLabel(assoc.roleName)}"]` : ''
-          lines.push(`  ${srcNode} -> ${tgtNode}${label};`)
+          const reverseAssoc = findReverseAssoc(schema, assoc)
+          const tailLabel = formatEndpointLabel(reverseAssoc?.multiplicity.raw, reverseAssoc?.roleName ?? assoc.reverseRoleName)
+          const headLabel = formatEndpointLabel(assoc.multiplicity.raw, assoc.roleName)
+          const attrs = ['dir=none']
+
+          if (tailLabel) attrs.push(`taillabel="${tailLabel}"`)
+          if (headLabel) attrs.push(`headlabel="${headLabel}"`)
+
+          lines.push(`  ${srcNode} -> ${tgtNode} [${attrs.join(', ')}];`)
         }
       }
     }


### PR DESCRIPTION
## Summary
- render CRUD SVG associations as plain bidirectional lines instead of arrowed edges
- preserve multiplicity and role information on both association ends in generated DOT
- update instance diagram tests to cover bidirectional, inherited, and reflexive associations

## Test plan
- bun x vitest run src/components/crud/__tests__/instanceDiagram.test.ts
