### PR TITLE
fix(ui): streamline top navigation and preferences sheet

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <title>UmpleOnline</title>
+    <title>UmpleOnline v2 (experimental)</title>
     <script>
       // Apply dark mode class before first paint to prevent white flash
       ;(function() {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,8 +24,15 @@ function useThemeEffect() {
   }, [theme])
 }
 
+function useDocumentTitleEffect() {
+  useEffect(() => {
+    document.title = 'UmpleOnline v2 (experimental)'
+  }, [])
+}
+
 export default function App() {
   useThemeEffect()
+  useDocumentTitleEffect()
   return (
     <TooltipProvider>
       <Outlet />

--- a/frontend/src/components/editor/TabBar.tsx
+++ b/frontend/src/components/editor/TabBar.tsx
@@ -9,7 +9,6 @@ import {
   collabCloseOtherTabs,
 } from '../../hooks/useCollabTabs'
 import { Plus, X, ChevronLeft, ChevronRight, PanelLeft } from 'lucide-react'
-import { Tip } from '@/components/ui/tooltip'
 import { OutputBadges } from './ExecutionPanel'
 import { CollabButton } from './CollabButton'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -21,6 +20,14 @@ import {
 } from '@/components/ui/context-menu'
 import { cn } from '@/lib/utils'
 import { stripUmpExt } from '@/lib/umpFile'
+import { Tip } from '@/components/ui/tooltip'
+
+function getSidebarShortcutLabel() {
+  if (typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)) {
+    return 'Cmd+B'
+  }
+  return 'Ctrl+B'
+}
 
 // ── TabBar ────────────────────────────────────────────────────────────
 
@@ -101,24 +108,25 @@ export function TabBar() {
 
   const showSidebar = usePreferencesStore((s) => s.showSidebar)
   const toggleSidebar = usePreferencesStore((s) => s.toggleSidebar)
-
   const activeIndex = tabs.findIndex((t) => t.id === activeTabId)
+  const sidebarShortcutLabel = getSidebarShortcutLabel()
 
   return (
     <Tabs value={activeTabId} onValueChange={setActiveTab} className="shrink-0">
       <div className="flex items-center h-[var(--toolbar-h)] shrink-0 border-b border-border">
-        {/* Sidebar toggle (visible when sidebar is closed) */}
-        {!showSidebar && (
-          <Tip content="Show sidebar" side="bottom">
-            <button
-              onClick={toggleSidebar}
-              className="flex items-center justify-center w-9 h-full text-ink-faint hover:text-ink-muted transition-colors cursor-pointer shrink-0"
-              aria-label="Show sidebar"
-            >
-              <PanelLeft className="size-3.5" />
-            </button>
-          </Tip>
-        )}
+        <Tip content={`Toggle preferences sidebar (${sidebarShortcutLabel})`} side="bottom">
+          <button
+            onClick={toggleSidebar}
+            className={cn(
+              'flex items-center justify-center w-9 h-full transition-colors cursor-pointer shrink-0',
+              showSidebar ? 'text-ink bg-surface-2' : 'text-ink-faint hover:text-ink-muted',
+            )}
+            aria-label="Toggle preferences sidebar"
+            aria-pressed={showSidebar}
+          >
+            <PanelLeft className="size-3.5" />
+          </button>
+        </Tip>
 
         {/* Scroll left */}
         {canScrollLeft && (

--- a/frontend/src/components/editor/__tests__/TabBar.test.tsx
+++ b/frontend/src/components/editor/__tests__/TabBar.test.tsx
@@ -28,8 +28,7 @@ describe('TabBar', () => {
 
   afterEach(() => {
     cleanup()
-    sessionStorage.clear()
-    localStorage.clear()
+    usePreferencesStore.persist.clearStorage()
     usePreferencesStore.setState({ showSidebar: true })
     useSessionStore.setState({
       code: '',

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useEffect } from 'react'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 import { AppToolbar } from './AppToolbar'
 import { AppSidebar } from './Sidebar'
@@ -16,38 +16,53 @@ import { WelcomeDialog } from '@/components/onboarding/WelcomeDialog'
 import { OnboardingTour } from '@/components/onboarding/OnboardingTour'
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary'
 import { TaskSheet } from '@/components/task/TaskSheet'
-import { SidebarProvider } from '@/components/ui/sidebar/sidebar'
+
+const SIDEBAR_TOGGLE_GUARD_MS = 350
 
 export function AppShell() {
   const showEditor = useEphemeralStore((s) => s.showEditor)
   const diagramOnly = useEphemeralStore((s) => s.diagramOnly)
   const outputView = useEphemeralStore((s) => s.outputView)
-  const showSidebar = usePreferencesStore((s) => s.showSidebar)
-  const handleOpenChange = useCallback(
-    (open: boolean) => usePreferencesStore.setState({ showSidebar: open }),
-    [],
-  )
   useCompiler()
   useModelFromURL()
   useCollab()
   useTaskRoute()
 
+  useEffect(() => {
+    let lastSidebarToggleAt = 0
+
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey || e.key.toLowerCase() !== 'b') {
+        return
+      }
+
+      const now = Date.now()
+      if (now - lastSidebarToggleAt < SIDEBAR_TOGGLE_GUARD_MS) {
+        e.preventDefault()
+        e.stopPropagation()
+        return
+      }
+
+      lastSidebarToggleAt = now
+      e.preventDefault()
+      e.stopPropagation()
+      usePreferencesStore.getState().toggleSidebar()
+    }
+
+    window.addEventListener('keydown', handler, true)
+    return () => window.removeEventListener('keydown', handler, true)
+  }, [])
+
   const editorVisible = showEditor && !diagramOnly
 
   return (
-    <SidebarProvider
-      open={showSidebar}
-      onOpenChange={handleOpenChange}
-      className="bg-surface-1"
-    >
+    <div className="flex h-screen w-full bg-surface-1">
       <a href="#main-content" className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-brand focus:px-4 focus:py-2 focus:text-ink-inverse focus:text-sm focus:font-medium">
         Skip to editor
       </a>
 
-      {/* Left sidebar (shadcn Sidebar framework) */}
       <AppSidebar />
 
-      {/* Main content area */}
       <main id="main-content" className="flex-1 min-w-0 flex flex-col" data-testid="app-shell">
         <AppToolbar />
         <div className="relative flex-1 min-h-0 px-2.5 pb-2.5">
@@ -94,6 +109,6 @@ export function AppShell() {
         <OnboardingTour />
       </main>
       <TaskSheet />
-    </SidebarProvider>
+    </div>
   )
 }

--- a/frontend/src/components/layout/AppToolbar.tsx
+++ b/frontend/src/components/layout/AppToolbar.tsx
@@ -1,14 +1,28 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useEphemeralStore } from '../../stores/ephemeralStore'
 import { useSessionStore, type DiagramView } from '../../stores/sessionStore'
-import { useCompile } from '../../hooks/useExecute'
+import { useCompile, useExecute } from '../../hooks/useExecute'
 import { useGenerate } from '../../hooks/useGenerate'
 import { useExamples } from '../../hooks/useExamples'
-import { GENERATE_ONLY_TARGET_GROUPS } from '../../generation/targets'
+import { GENERATE_ONLY_TARGET_GROUPS, getGenerateTarget } from '../../generation/targets'
 import { AiConfigForm } from '@/components/sidebar/AiConfigForm'
 import { useTaskStore } from '../../stores/taskStore'
-import { ToolbarDivider } from '@/components/diagram/CanvasToolbar'
-import { Hammer, Loader2, Check, ChevronDown, Code, Sparkles, ClipboardList, Plus, Search, BookOpen } from 'lucide-react'
+import {
+  BookOpen,
+  Check,
+  ChevronDown,
+  CircleHelp,
+  ClipboardList,
+  Code,
+  GitFork,
+  Hammer,
+  Loader2,
+  Play,
+  Plus,
+  Search,
+  Shield,
+  Sparkles,
+} from 'lucide-react'
 import { Combobox, type ComboboxGroup } from '@/components/ui/combobox'
 import {
   DropdownMenu,
@@ -21,19 +35,25 @@ import { Tip } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { VIEW_MODE_GROUPS } from '../../constants/diagram'
 
-const pillBase = 'flex items-center bg-surface-0 rounded-lg border border-border shadow-sm px-1 py-1'
+const shellBtn = 'inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-xs font-medium text-ink-muted transition-colors hover:bg-surface-2 hover:text-ink'
 const toolbarBtn = 'flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors cursor-pointer'
+const iconBtn = 'inline-flex size-8 items-center justify-center rounded-lg text-ink-muted transition-colors hover:bg-surface-2 hover:text-ink'
 
 export function AppToolbar() {
   const { compile } = useCompile()
+  const { execute } = useExecute()
+  const openCommandPalette = useEphemeralStore((s) => s.openCommandPalette)
   const compiling = useEphemeralStore((s) => s.compiling)
   const generatingCode = useEphemeralStore((s) => s.generatingCode)
   const executing = useEphemeralStore((s) => s.executing)
   const errorCount = useEphemeralStore((s) => s.outputErrorCount)
   const viewMode = useSessionStore((s) => s.viewMode)
   const setViewMode = useSessionStore((s) => s.setViewMode)
+  const generateTargetId = useSessionStore((s) => s.generateTargetId)
   const handleGenerate = useGenerate()
   const { categories: exampleCategories, loadExample, loading: loadingExamples } = useExamples()
+  const selectedGenerateTarget = getGenerateTarget(generateTargetId)
+  const canExecuteGenerateTarget = Boolean(selectedGenerateTarget?.executable)
 
   const viewModeGroups = useMemo<ComboboxGroup[]>(
     () => VIEW_MODE_GROUPS.map((group) => ({
@@ -78,12 +98,14 @@ export function AppToolbar() {
   const [justCompiled, setJustCompiled] = useState(false)
 
   useEffect(() => {
-    if (prevCompilingRef.current && !compiling && errorCount === 0) {
+    const didJustCompile = prevCompilingRef.current && !compiling && errorCount === 0
+    prevCompilingRef.current = compiling
+
+    if (didJustCompile) {
       setJustCompiled(true)
       const timer = setTimeout(() => setJustCompiled(false), 1200)
       return () => clearTimeout(timer)
     }
-    prevCompilingRef.current = compiling
   }, [compiling, errorCount])
 
   useEffect(() => {
@@ -99,12 +121,87 @@ export function AppToolbar() {
   }, [compile])
 
   return (
-    <div className="relative flex items-center justify-center h-[var(--toolbar-h)] px-3 shrink-0" data-testid="app-toolbar">
-      <div className={cn(pillBase, 'absolute left-3 top-1/2 -translate-y-1/2')}>
+    <div
+      className="relative flex items-center justify-between gap-3 h-[var(--toolbar-h)] px-3 shrink-0 border-b border-border/70 bg-surface-1/95 backdrop-blur-sm"
+      data-testid="app-toolbar"
+    >
+      <div className="flex items-center gap-2 shrink-0">
+        <Tip
+          side="bottom"
+          content={(
+            <div className="space-y-1">
+              <p className="font-medium">UmpleOnline v2 is experimental.</p>
+              <p>
+                Use
+                {' '}
+                <a href="https://try.umple.org" target="_blank" rel="noreferrer" className="text-brand hover:text-brand-hover">
+                  try.umple.org
+                </a>
+                {' '}
+                for production work.
+              </p>
+            </div>
+          )}
+        >
+          <a
+            href="https://umple.org"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg px-2 py-1.5 text-ink transition-colors hover:bg-surface-2"
+            aria-label="Open the Umple website"
+          >
+            <img src="/umple-logo.svg" alt="" className="h-5 w-auto shrink-0" />
+            <span className="text-sm font-semibold tracking-tight whitespace-nowrap">UmpleOnline (v2)</span>
+          </a>
+        </Tip>
+
+        <Tip content="Open the user manual" side="bottom">
+          <a
+            href="https://manual.umple.org"
+            target="_blank"
+            rel="noreferrer"
+            className={shellBtn}
+          >
+            <BookOpen className="size-3.5" />
+            Manual
+          </a>
+        </Tip>
+      </div>
+
+      <div className="flex flex-1 min-w-0 justify-center">
+        <div className="flex min-w-0 items-center gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div data-tour="examples">
+          <Combobox
+            groups={exampleGroups}
+            onSelect={(selection) => {
+              const parsed = JSON.parse(selection) as { name: string; categoryId: string }
+              void loadExample(parsed.name, {
+                categoryId: parsed.categoryId as import('../../api/types').ExampleCategoryId,
+                switchToDefaultView: true,
+              })
+            }}
+            placeholder="Examples"
+            searchPlaceholder="Search examples..."
+            emptyText={loadingExamples ? 'Loading examples...' : 'No examples.'}
+            disabled={loadingExamples && exampleGroups.length === 0}
+            className={cn(toolbarBtn, 'w-auto h-8 border border-border/70 bg-surface-0 px-2.5 py-1 shadow-sm focus:border-border-strong focus:ring-0')}
+            contentClassName="w-64 min-w-[16rem]"
+            listClassName="max-h-72"
+            triggerChildren={(
+              <>
+                <BookOpen className="size-3.5" />
+                Examples
+                <ChevronDown className="size-3 shrink-0" />
+              </>
+            )}
+            ariaLabel="Examples"
+          />
+        </div>
+
         <DropdownMenu>
           <Tip content="Tasks" side="bottom">
             <DropdownMenuTrigger asChild>
-              <button className={toolbarBtn} aria-label="Tasks">
+              <button className={cn(shellBtn, 'border border-border/70 bg-surface-0 shadow-sm')} aria-label="Tasks">
                 <ClipboardList className="size-3.5" />
                 Tasks
                 <ChevronDown className="size-3 shrink-0" />
@@ -123,42 +220,13 @@ export function AppToolbar() {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        <ToolbarDivider />
-        <Combobox
-          groups={exampleGroups}
-          onSelect={(selection) => {
-            const parsed = JSON.parse(selection) as { name: string; categoryId: string }
-            void loadExample(parsed.name, {
-              categoryId: parsed.categoryId as import('../../api/types').ExampleCategoryId,
-              switchToDefaultView: true,
-            })
-          }}
-          placeholder="Examples"
-          searchPlaceholder="Search examples..."
-          emptyText={loadingExamples ? 'Loading examples...' : 'No examples.'}
-          disabled={loadingExamples && exampleGroups.length === 0}
-          className={cn(toolbarBtn, 'w-auto h-auto border-0 bg-transparent px-1.5 py-0.5 focus:border-transparent focus:ring-0')}
-          contentClassName="w-64 min-w-[16rem]"
-          listClassName="max-h-72"
-          triggerChildren={(
-            <>
-              <BookOpen className="size-3.5" />
-              Examples
-              <ChevronDown className="size-3 shrink-0" />
-            </>
-          )}
-          ariaLabel="Examples"
-        />
-      </div>
-
-      <div className={cn(pillBase, 'gap-0.5')}>
         <Tip content="Compile (Ctrl+Enter)" side="bottom">
           <button
             onClick={compile}
             disabled={compiling}
             aria-label={compiling ? 'Compiling' : 'Compile (Ctrl+Enter)'}
             data-testid="compile-button"
-            className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer rounded-md text-ink-muted hover:text-ink hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-70"
+            className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border/70 bg-surface-0 px-2.5 text-xs font-medium text-ink-muted shadow-sm transition-colors hover:bg-surface-2 hover:text-ink disabled:cursor-not-allowed disabled:opacity-70"
           >
             {compiling ? (
               <Loader2 className="size-3.5 shrink-0 animate-spin" />
@@ -180,46 +248,61 @@ export function AppToolbar() {
           value={viewMode}
           onSelect={(value) => setViewMode(value as DiagramView)}
           searchPlaceholder="Search views..."
-          className="w-auto h-auto border-0 bg-transparent px-2 py-1 font-medium text-ink-muted hover:text-ink hover:bg-surface-2 focus:border-transparent focus:ring-0"
+          className="w-auto h-8 border border-border/70 bg-surface-0 px-2.5 py-1 font-medium text-ink-muted shadow-sm hover:text-ink hover:bg-surface-2 focus:border-border-strong focus:ring-0"
           contentClassName="w-64 min-w-[16rem]"
           listClassName="max-h-80"
           ariaLabel="Diagram view"
           data-tour="diagram-view"
         />
 
-        <ToolbarDivider />
+        <div data-tour="generate">
+          <Combobox
+            groups={generateGroups}
+            value={generateTargetId}
+            onSelect={(targetId) => {
+              void handleGenerate(targetId)
+            }}
+            placeholder="Generate"
+            searchPlaceholder="Search targets..."
+            disabled={generatingCode}
+            className="w-auto h-8 border border-border/70 bg-surface-0 px-2.5 py-1 font-medium text-ink-muted shadow-sm hover:text-ink hover:bg-surface-2 focus:border-border-strong focus:ring-0"
+            contentClassName="w-72 min-w-[18rem]"
+            listClassName="max-h-80"
+            triggerChildren={(
+              <>
+                {generatingCode ? (
+                  <Loader2 className="size-3.5 shrink-0 animate-spin" />
+                ) : (
+                  <Code className="size-3.5 shrink-0" />
+                )}
+                <span className="truncate">{generatingCode ? 'Generating...' : 'Generate'}</span>
+                <ChevronDown className="size-3 shrink-0" />
+              </>
+            )}
+            ariaLabel="Generate"
+          />
+        </div>
 
-        <Combobox
-          groups={generateGroups}
-          onSelect={(targetId) => {
-            void handleGenerate(targetId)
-          }}
-          placeholder="Generate"
-          searchPlaceholder="Search targets..."
-          disabled={generatingCode}
-          className="w-auto h-auto border-0 bg-transparent px-2 py-1 font-medium text-ink-muted hover:text-ink hover:bg-surface-2 focus:border-transparent focus:ring-0"
-          contentClassName="w-72 min-w-[18rem]"
-          listClassName="max-h-80"
-          triggerChildren={(
-            <>
-              {generatingCode ? (
-                <Loader2 className="size-3.5 shrink-0 animate-spin" />
-              ) : (
-                <Code className="size-3.5 shrink-0" />
-              )}
-              <span className="truncate">{generatingCode ? 'Generating...' : 'Generate'}</span>
-              <ChevronDown className="size-3 shrink-0" />
-            </>
-          )}
-          ariaLabel="Generate"
-        />
-      </div>
+        <Tip content={canExecuteGenerateTarget ? `Execute ${selectedGenerateTarget?.label ?? generateTargetId}` : 'Execution is only supported for Java and Python'} side="bottom">
+          <button
+            onClick={() => void execute(generateTargetId)}
+            disabled={executing || !canExecuteGenerateTarget}
+            aria-label={executing ? 'Executing' : `Execute ${selectedGenerateTarget?.label ?? generateTargetId}`}
+            className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border/70 bg-surface-0 px-2.5 text-xs font-medium text-ink-muted shadow-sm transition-colors hover:bg-surface-2 hover:text-ink disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {executing ? (
+              <Loader2 className="size-3.5 shrink-0 animate-spin" />
+            ) : (
+              <Play className="size-3.5 shrink-0" />
+            )}
+            <span className="truncate">{executing ? 'Executing...' : 'Execute'}</span>
+          </button>
+        </Tip>
 
-      <div className={cn(pillBase, 'absolute right-3 top-1/2 -translate-y-1/2')}>
         <Popover>
           <Tip content="Umple AI" side="bottom">
             <PopoverTrigger asChild>
-              <button className={toolbarBtn} aria-label="Umple AI configuration">
+              <button className={cn(shellBtn, 'border border-border/70 bg-surface-0 shadow-sm')} aria-label="Umple AI configuration">
                 <Sparkles className="size-3.5" />
                 AI
               </button>
@@ -230,6 +313,31 @@ export function AppToolbar() {
             <AiConfigForm />
           </PopoverContent>
         </Popover>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1 shrink-0">
+        <Tip content="Search commands and examples (Ctrl+K)" side="bottom">
+          <button onClick={openCommandPalette} className={iconBtn} aria-label="Open command palette">
+            <Search className="size-4" />
+          </button>
+        </Tip>
+
+        <TopLinkIconButton
+          href="https://umple.org/privacy"
+          label="Privacy and security"
+          icon={Shield}
+        />
+        <TopLinkIconButton
+          href="https://github.com/umple/umpleonline"
+          label="GitHub repository"
+          icon={GitFork}
+        />
+        <TopLinkIconButton
+          href="https://umple.org/questions"
+          label="Ask a question"
+          icon={CircleHelp}
+        />
       </div>
 
       {(compiling || generatingCode || executing) && (
@@ -238,5 +346,29 @@ export function AppToolbar() {
         </div>
       )}
     </div>
+  )
+}
+
+function TopLinkIconButton({
+  href,
+  label,
+  icon: Icon,
+}: {
+  href: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}) {
+  return (
+    <Tip content={label} side="bottom">
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        className={iconBtn}
+        aria-label={label}
+      >
+        <Icon className="size-4" />
+      </a>
+    </Tip>
   )
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,436 +1,105 @@
-import { useMemo } from 'react'
-import { useEphemeralStore } from '../../stores/ephemeralStore'
-import { useSessionStore, VIEW_OUTPUT_KIND } from '../../stores/sessionStore'
-import { usePreferencesStore, type GvLayoutAlgorithm } from '../../stores/preferencesStore'
-import { useExamples } from '../../hooks/useExamples'
-import { useExecute } from '../../hooks/useExecute'
-import { useGenerate } from '../../hooks/useGenerate'
-import { GENERATE_ONLY_TARGETS, GENERATE_ONLY_TARGET_GROUPS, getGenerateTarget } from '../../generation/targets'
-import { LAYOUT_OPTIONS, VIEW_MODE_GROUPS, getLayoutOption } from '../../constants/diagram'
-import { canViewUseExampleCategory } from '../../constants/examples'
-import { Combobox, type ComboboxGroup } from '@/components/ui/combobox'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
 import {
-  Sidebar,
-  SidebarHeader,
-  SidebarContent,
-  SidebarFooter,
-  SidebarGroup,
-  SidebarGroupLabel,
-  SidebarGroupContent,
-  SidebarRail,
-  useSidebar,
-} from '@/components/ui/sidebar/sidebar'
-import {
-  Collapsible,
-  CollapsibleTrigger,
-  CollapsibleContent,
-} from '@/components/ui/sidebar/collapsible'
-import {
-  ChevronsUpDown,
-  ChevronRight,
-  Search,
-  Code,
-  Play,
-  Loader2,
-  Columns2,
-  BookOpen,
-  MessageCircleQuestion,
-  GitFork,
-  Bug,
-  Globe,
-  GraduationCap,
-  Shield,
-  ExternalLink,
-  ClipboardList,
-  Wrench,
-  ListChecks,
-  Sparkles,
-} from 'lucide-react'
-import { AiConfigForm } from '@/components/sidebar/AiConfigForm'
-import { TaskSidebarSection } from '@/components/task/TaskSidebarSection'
-import { useTaskStore } from '@/stores/taskStore'
-import { ThemeToggle } from '@/components/layout/ThemeToggle'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuGroup,
-} from '@/components/ui/dropdown-menu'
-import { Tip } from '@/components/ui/tooltip'
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { usePreferencesStore } from '@/stores/preferencesStore'
+import { Monitor, Moon, Sun } from 'lucide-react'
 
-// ── Main sidebar component ──
+function getSidebarShortcutLabel() {
+  if (typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)) {
+    return 'Cmd+B'
+  }
+  return 'Ctrl+B'
+}
 
 export function AppSidebar() {
-  return (
-    <Sidebar collapsible="offcanvas" data-testid="sidebar">
-      <SidebarHeader className="flex-row items-center justify-between px-4 pt-4 pb-3 border-b border-border/60">
-        <div className="flex items-center gap-2.5 text-ink min-w-0">
-          <img src="/umple-logo.svg" alt="" className="h-6 w-auto shrink-0" />
-          <span className="text-lg font-semibold tracking-tight truncate">UmpleOnline</span>
-        </div>
-        <HeaderActions />
-      </SidebarHeader>
-
-      <TaskSidebarSection />
-
-      <SidebarContent className="scrollbar-thin py-1">
-        <ToolsGroup />
-        <TasksGroup />
-        <AiGroup />
-      </SidebarContent>
-
-      <AppSidebarFooter />
-      <SidebarRail />
-    </Sidebar>
-  )
-}
-
-// ── Header action buttons ──
-
-function HeaderActions() {
-  const openCommandPalette = useEphemeralStore((s) => s.openCommandPalette)
-  const { toggleSidebar } = useSidebar()
+  const open = usePreferencesStore((s) => s.showSidebar)
+  const shortcutLabel = getSidebarShortcutLabel()
 
   return (
-    <div className="flex items-center gap-0.5 shrink-0">
-      <Tip content="Search (Ctrl K)" side="bottom">
-        <button
-          onClick={openCommandPalette}
-          className="p-1.5 text-ink-muted hover:text-ink hover:bg-surface-2 rounded-lg transition-colors cursor-pointer"
-          aria-label="Command palette"
-        >
-          <Search className="size-4" />
-        </button>
-      </Tip>
-      <Tip content="Toggle sidebar (Ctrl B)" side="bottom">
-        <button
-          onClick={toggleSidebar}
-          data-tour="sidebar-toggle"
-          className="p-1.5 transition-colors cursor-pointer rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2"
-          aria-label="Toggle sidebar"
-        >
-          <Columns2 className="size-4" />
-        </button>
-      </Tip>
-    </div>
-  )
-}
+    <Sheet
+      open={open}
+      onOpenChange={(nextOpen) => usePreferencesStore.setState({ showSidebar: nextOpen })}
+    >
+      <SheetContent
+        side="left"
+        className="w-[20rem] max-w-[20rem] p-0"
+      >
+        <SheetHeader className="items-start pr-12">
+          <SheetTitle>Preferences</SheetTitle>
+        </SheetHeader>
 
-// ── Collapsible group wrapper (shared pattern) ──
-
-function CollapsibleGroup({
-  title,
-  icon: Icon,
-  defaultOpen = false,
-  'data-tour': dataTour,
-  children,
-}: {
-  title: string
-  icon: React.ComponentType<{ className?: string }>
-  defaultOpen?: boolean
-  'data-tour'?: string
-  children: React.ReactNode
-}) {
-  return (
-    <Collapsible defaultOpen={defaultOpen} className="group/collapsible">
-      <SidebarGroup data-tour={dataTour}>
-        <SidebarGroupLabel asChild>
-          <CollapsibleTrigger className="cursor-pointer">
-            <Icon className="size-4" />
-            {title}
-            <ChevronRight className="ml-auto size-3.5 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
-          </CollapsibleTrigger>
-        </SidebarGroupLabel>
-        <CollapsibleContent className="overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up">
-          <SidebarGroupContent>
-            <div className="relative px-2 pb-2 pt-1 ml-4">
-              <div className="absolute left-2 top-0 bottom-1 w-px bg-border/50" />
-              <div className="pl-3">
-                {children}
-              </div>
+        <div className="flex-1 overflow-y-auto p-4">
+          <section className="space-y-3">
+            <div>
+              <h2 className="text-sm font-medium text-ink">Theme</h2>
+              <p className="mt-1 text-xs text-ink-muted">Choose how UmpleOnline looks.</p>
             </div>
-          </SidebarGroupContent>
-        </CollapsibleContent>
-      </SidebarGroup>
-    </Collapsible>
+            <ThemePicker />
+          </section>
+        </div>
+
+        <SheetFooter className="border-t border-border bg-surface-1 px-4 py-3">
+          <p className="text-xs text-ink-faint">Press {shortcutLabel} to open or close this panel.</p>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
   )
 }
 
-// ── Sub-label (Examples, Generate, etc.) ──
+function ThemePicker() {
+  const theme = usePreferencesStore((s) => s.theme)
+  const setTheme = usePreferencesStore((s) => s.setTheme)
 
-function SubLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="text-xxs font-semibold text-ink-faint uppercase tracking-wider mb-1.5">
-      {children}
-    </div>
-  )
-}
-
-// ── GROUP: Tools (Examples + Generate Code + Layout) ──
-
-function ToolsGroup() {
-  const { viewMode, setViewMode } = useSessionStore()
-  const { layoutAlgorithm, setLayoutAlgorithm } = usePreferencesStore()
-  const code = useSessionStore((s) => s.code)
-  const generatingCode = useEphemeralStore((s) => s.generatingCode)
-  const { execute } = useExecute()
-  const running = useEphemeralStore((s) => s.executing)
-  const generate = useGenerate()
-  const { categories: allCategories, loadExample, loading: loadingExamples } = useExamples()
-  const targetId = useSessionStore((s) => s.generateTargetId)
-  const setTargetId = useSessionStore((s) => s.setGenerateTargetId)
-  const selectedExample = useSessionStore((s) => s.selectedExample)
-
-  const showLayout = VIEW_OUTPUT_KIND[viewMode] !== 'html'
-
-  const selectedTarget = useMemo(
-    () => getGenerateTarget(targetId) ?? GENERATE_ONLY_TARGETS[0],
-    [targetId],
-  )
-
-  const generateGroups = useMemo(
-    () => GENERATE_ONLY_TARGET_GROUPS.map((g) => ({
-      label: g.label,
-      options: g.targets.map((t) => ({ value: t.id, label: t.label })),
-    })),
-    []
-  )
-
-  const viewModeGroups = useMemo<ComboboxGroup[]>(
-    () => VIEW_MODE_GROUPS.map((group) => ({
-      label: group.label,
-      options: group.modes.map((mode) => ({
-        value: mode.value,
-        label: mode.longLabel ?? mode.label,
-        keywords: [mode.label, mode.longLabel, group.label].filter(Boolean) as string[],
-      })),
-    })),
-    [],
-  )
-
-  const exampleOptions = useMemo(
-    () => allCategories
-      .filter((cat) => canViewUseExampleCategory(viewMode, cat.id))
-      .flatMap((cat) => cat.examples)
-      .map((ex) => ({ value: ex.name, label: ex.label || ex.name })),
-    [allCategories, viewMode]
-  )
-
-  function handleGenerate() {
-    if (!code.trim() || generatingCode) return
-    generate(targetId)
+  function handleSwitch(value: 'light' | 'dark' | 'system') {
+    document.documentElement.classList.add('disable-transitions')
+    setTheme(value)
+    requestAnimationFrame(() => {
+      document.documentElement.classList.remove('disable-transitions')
+    })
   }
 
   return (
-    <CollapsibleGroup title="Tools" icon={Wrench} defaultOpen>
-      <div className="space-y-4">
-        {/* Examples */}
-        <div data-tour="examples">
-          <SubLabel>Examples</SubLabel>
-          <div className="space-y-1.5">
-            <Combobox
-              groups={viewModeGroups}
-              value={viewMode}
-              onSelect={(value) => setViewMode(value as typeof viewMode)}
-              placeholder="Select view..."
-              searchPlaceholder="Search views..."
-            />
-            <Combobox
-              key={viewMode}
-              options={exampleOptions}
-              value={selectedExample ?? undefined}
-              onSelect={loadExample}
-              placeholder={loadingExamples ? 'Loading examples...' : exampleOptions.length > 0 ? 'Load an example...' : 'No examples'}
-              searchPlaceholder="Search examples..."
-              emptyText={loadingExamples ? 'Loading examples...' : 'No results.'}
-              disabled={loadingExamples && exampleOptions.length === 0}
-            />
-          </div>
-        </div>
-
-        {/* Generate */}
-        <div data-tour="generate">
-          <SubLabel>Generate</SubLabel>
-          <div className="space-y-2">
-            <Combobox
-              groups={generateGroups}
-              value={targetId}
-              onSelect={(id) => {
-                setTargetId(id)
-                if (code.trim() && !generatingCode) generate(id)
-              }}
-              placeholder="Select target..."
-              searchPlaceholder="Search targets..."
-            />
-            <div className="flex gap-1.5">
-              <Button
-                onClick={handleGenerate}
-                disabled={generatingCode}
-                size="xs"
-                className="flex-1 text-xs"
-              >
-                {generatingCode ? (
-                  <Loader2 className="size-3 animate-spin" />
-                ) : (
-                  <Code className="size-3" />
-                )}
-                Generate
-              </Button>
-              <Button
-                onClick={() => execute(selectedTarget.id)}
-                disabled={running || !selectedTarget.executable}
-                variant="secondary"
-                size="xs"
-                className="text-xs"
-              title={selectedTarget.executable ? 'Execute generated code' : 'Execution is only supported for Java and Python'}
-            >
-                {running ? (
-                  <Loader2 className="size-3 animate-spin" />
-                ) : (
-                  <Play className="size-3" />
-                )}
-                Execute
-              </Button>
-            </div>
-          </div>
-        </div>
-
-        {/* Layout Algorithm */}
-        {showLayout && (
-          <div data-tour="layout-algorithm">
-            <SubLabel>Layout Algorithm</SubLabel>
-            <Select value={layoutAlgorithm} onValueChange={(v) => setLayoutAlgorithm(v as GvLayoutAlgorithm)}>
-              <SelectTrigger>
-                <SelectValue>{getLayoutOption(layoutAlgorithm)?.label}</SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {LAYOUT_OPTIONS.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
-      </div>
-    </CollapsibleGroup>
+    <ToggleGroup
+      type="single"
+      value={theme}
+      onValueChange={(value) => {
+        if (value === 'light' || value === 'dark' || value === 'system') {
+          handleSwitch(value)
+        }
+      }}
+      variant="outline"
+      className="grid w-full grid-cols-3 gap-2"
+      spacing={2}
+    >
+      <ThemeOption value="light" label="Light" icon={Sun} />
+      <ThemeOption value="dark" label="Dark" icon={Moon} />
+      <ThemeOption value="system" label="System" icon={Monitor} />
+    </ToggleGroup>
   )
 }
 
-// ── GROUP: Tasks (Create + Manage) ──
-
-const TASK_ACTIONS = [
-  { action: 'create' as const, icon: ClipboardList, label: 'Create Task', desc: 'New assignment from current model' },
-  { action: 'manage' as const, icon: Search, label: 'Manage Task', desc: 'Edit, view responses, share' },
-]
-
-function TasksGroup() {
+function ThemeOption({
+  value,
+  label,
+  icon: Icon,
+}: {
+  value: 'light' | 'dark' | 'system'
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}) {
   return (
-    <CollapsibleGroup title="Tasks" icon={ListChecks}>
-      <div className="space-y-3">
-        <p className="text-xs text-ink-muted leading-relaxed">
-          Create assignments for students or manage existing ones.
-        </p>
-        <div className="space-y-1">
-          {TASK_ACTIONS.map(({ action, icon: Icon, label, desc }) => (
-            <button
-              key={action}
-              onClick={() => useTaskStore.getState().openSheet(action)}
-              className="group flex items-center gap-2 rounded-md px-2.5 py-2 text-xs text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors cursor-pointer w-full text-left"
-            >
-              <div className="flex items-center justify-center size-6 rounded-md bg-brand/8 text-brand group-hover:bg-brand/12 transition-colors">
-                <Icon className="size-3.5" />
-              </div>
-              <div>
-                <span className="font-medium text-ink block leading-tight">{label}</span>
-                <span className="text-xxs text-ink-faint">{desc}</span>
-              </div>
-            </button>
-          ))}
-        </div>
-      </div>
-    </CollapsibleGroup>
-  )
-}
-
-// ── GROUP: Umple AI ──
-
-function AiGroup() {
-  return (
-    <CollapsibleGroup title="Umple AI" icon={Sparkles} data-tour="ai-config">
-      <AiConfigForm />
-    </CollapsibleGroup>
-  )
-}
-
-// ── Footer links data ──
-
-const FOOTER_LINKS = [
-  {
-    items: [
-      { label: 'User Manual', href: 'https://manual.umple.org', icon: BookOpen },
-      { label: 'Ask a Question', href: 'https://umple.org/questions', icon: MessageCircleQuestion },
-    ],
-  },
-  {
-    items: [
-      { label: 'GitHub Repository', href: 'https://github.com/umple/umple', icon: GitFork },
-      { label: 'Report an Issue', href: 'https://github.com/umple/umple/issues/new', icon: Bug },
-      { label: 'Umple Website', href: 'https://umple.org', icon: Globe },
-    ],
-  },
-  {
-    items: [
-      { label: 'University of Ottawa', href: 'https://www.uottawa.ca', icon: GraduationCap },
-      { label: 'Privacy Policy', href: 'https://umple.org/privacy', icon: Shield },
-    ],
-  },
-]
-
-// ── Sidebar footer ──
-
-function AppSidebarFooter() {
-  return (
-    <SidebarFooter className="flex-row items-center gap-2 h-12 px-4 border-t border-border/60" data-testid="sidebar-footer">
-      <div className="min-w-0 flex-1">
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            className="inline-flex h-9 max-w-full min-w-0 items-center gap-1.5 pl-1 pr-1.5 cursor-pointer rounded-full hover:bg-surface-2 data-[state=open]:bg-surface-2 transition-colors group"
-            aria-label="University of Ottawa resources"
-            data-testid="sidebar-footer-menu"
-          >
-            <div className="rounded-full shrink-0 flex items-center justify-center size-7 bg-surface-2 overflow-hidden">
-              <img src="/umple-logo.svg" alt="UmpleOnline" className="size-4 shrink-0" />
-            </div>
-            <span className="min-w-0 flex-1 text-sm text-ink truncate">Umple</span>
-            <ChevronsUpDown className="size-3.5 text-ink-faint shrink-0 group-hover:text-ink transition-colors" />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent side="top" align="start" className="w-56">
-            {FOOTER_LINKS.map((group, gi) => (
-              <DropdownMenuGroup key={gi}>
-                {gi > 0 && <DropdownMenuSeparator />}
-                {group.items.map((item) => (
-                  <DropdownMenuItem
-                    key={item.href}
-                    onSelect={() => window.open(item.href, '_blank', 'noopener,noreferrer')}
-                  >
-                    <item.icon className="size-3.5" />
-                    <span>{item.label}<span className="sr-only"> (opens in new window)</span></span>
-                    <ExternalLink className="ml-auto size-3 text-ink-faint" />
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuGroup>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-      <ThemeToggle />
-    </SidebarFooter>
+    <ToggleGroupItem
+      value={value}
+      className="flex h-16 flex-col gap-1 rounded-xl border border-border/70 bg-surface-0 px-2 text-xs text-ink-muted hover:bg-surface-2 hover:text-ink data-[state=on]:border-border-strong data-[state=on]:bg-surface-2 data-[state=on]:text-ink"
+      aria-label={label}
+    >
+      <Icon className="size-4" />
+      <span>{label}</span>
+    </ToggleGroupItem>
   )
 }

--- a/frontend/src/components/onboarding/OnboardingTour.tsx
+++ b/frontend/src/components/onboarding/OnboardingTour.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { usePreferencesStore } from '@/stores/preferencesStore'
 import { useSessionStore } from '@/stores/sessionStore'
 import { useEphemeralStore } from '@/stores/ephemeralStore'
 import { Button } from '@/components/ui/button'
@@ -29,11 +28,6 @@ interface TourStep {
   onActivate?: () => void
 }
 
-function ensureSidebarOpen() {
-  const prefs = usePreferencesStore.getState()
-  if (!prefs.showSidebar) prefs.toggleSidebar()
-}
-
 const TOUR_STEPS: TourStep[] = [
   {
     target: '[data-tour="diagram-view"]',
@@ -51,7 +45,6 @@ const TOUR_STEPS: TourStep[] = [
     placement: 'right',
     icon: MousePointerClick,
     interactive: true,
-    onActivate: ensureSidebarOpen,
     detectComplete: () => {
       const { selectedExample, viewMode } = useSessionStore.getState()
       return viewMode === 'state' && selectedExample !== null
@@ -72,7 +65,6 @@ const TOUR_STEPS: TourStep[] = [
     placement: 'right',
     icon: MousePointerClick,
     interactive: true,
-    onActivate: ensureSidebarOpen,
     detectComplete: () => {
       const { generatedCode } = useEphemeralStore.getState()
       return generatedCode.length > 0
@@ -83,9 +75,9 @@ const TOUR_STEPS: TourStep[] = [
 // ── Feature hints for the final step ──
 
 const FEATURE_HINTS = [
-  { icon: Bot, label: 'Umple AI', hint: 'Configure an AI provider in the sidebar to get modeling assistance' },
+  { icon: Bot, label: 'Umple AI', hint: 'Use the AI button in the top toolbar to configure a provider and get modeling assistance' },
   { icon: LayoutDashboard, label: 'Layout Algorithm', hint: 'Change how diagram nodes are arranged (dot, sfdp, circo, etc.)' },
-  { icon: Columns2, label: 'Toggle Sidebar', hint: 'Hide the sidebar for more space — press Ctrl+B or click the rail to toggle' },
+  { icon: Columns2, label: 'Preferences Sidebar', hint: 'Open the sidebar from the top toolbar when you need theme or release preferences' },
   { icon: Command, label: 'Command Palette', hint: 'Press Ctrl+K to quickly search examples, diagrams, and generators' },
 ]
 

--- a/frontend/src/stores/__tests__/preferencesStore.test.ts
+++ b/frontend/src/stores/__tests__/preferencesStore.test.ts
@@ -1,7 +1,21 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
-import { buildSuboptions } from '../preferencesStore'
+import { buildSuboptions, usePreferencesStore } from '../preferencesStore'
+
+describe('preferencesStore', () => {
+  beforeEach(() => {
+    usePreferencesStore.persist.clearStorage()
+    usePreferencesStore.setState({
+      showSidebar: false,
+      theme: 'system',
+    })
+  })
+
+  it('hides the sidebar by default', () => {
+    expect(usePreferencesStore.getState().showSidebar).toBe(false)
+  })
+})
 
 describe('buildSuboptions', () => {
   it('keeps showmethods enabled for class trait diagrams', () => {

--- a/frontend/src/stores/preferencesStore.ts
+++ b/frontend/src/stores/preferencesStore.ts
@@ -41,6 +41,43 @@ export function createDefaultProviderConfigs(): Record<AiProvider, ProviderConfi
   ) as Record<AiProvider, ProviderConfig>
 }
 
+const memoryStorage = (() => {
+  const data = new Map<string, string>()
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value)
+    },
+    removeItem: (key: string) => {
+      data.delete(key)
+    },
+    clear: () => {
+      data.clear()
+    },
+    key: (index: number) => Array.from(data.keys())[index] ?? null,
+    get length() {
+      return data.size
+    },
+  } satisfies Storage
+})()
+
+function isStorageLike(value: unknown): value is Storage {
+  return !!value
+    && typeof (value as Storage).getItem === 'function'
+    && typeof (value as Storage).setItem === 'function'
+    && typeof (value as Storage).removeItem === 'function'
+}
+
+function getBrowserStorage(): Storage {
+  if (typeof window !== 'undefined' && isStorageLike(window.localStorage)) {
+    return window.localStorage
+  }
+  if (isStorageLike(globalThis.localStorage)) {
+    return globalThis.localStorage
+  }
+  return memoryStorage
+}
+
 export type { DisplayPrefKey, GvLayoutAlgorithm } from '../constants/diagram'
 
 // ── Store ──
@@ -92,7 +129,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       dismissWelcome: () => set({ hasSeenWelcome: true }),
 
       // Sidebar
-      showSidebar: true,
+      showSidebar: false,
       toggleSidebar: () => set((s) => ({ showSidebar: !s.showSidebar })),
 
       // Diagram display preferences (match Umple compiler defaults)
@@ -126,9 +163,18 @@ export const usePreferencesStore = create<PreferencesState>()(
     }),
     {
       name: 'umple-preferences-v1',
-      version: 1,
-      storage: createJSONStorage(() => localStorage),
-      migrate: (persisted) => persisted as any,
+      version: 2,
+      storage: createJSONStorage(getBrowserStorage),
+      migrate: (persisted, version) => {
+        const state = (persisted ?? {}) as Record<string, unknown>
+        if (version < 2) {
+          return {
+            ...state,
+            showSidebar: false,
+          } as any
+        }
+        return state as any
+      },
       merge: (persisted, current) => {
         const p = (persisted ?? {}) as Record<string, unknown>
         // Only restore keys that partialize stores — stale keys from older


### PR DESCRIPTION
First stage of #93.

## Summary
- move the old sidebar controls into a simpler top-level navigation flow
- replace the sidebar rail with a lightweight preferences sheet
- restore and harden the preferences toggle behavior and related UI hints

## Test plan
- bun run test src/components/editor/__tests__/TabBar.test.tsx
- bun run build
