### PR TITLE
fix(ui): make manual compile opt-in

### DIFF
--- a/frontend/src/components/layout/AppToolbar.tsx
+++ b/frontend/src/components/layout/AppToolbar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useEphemeralStore } from '../../stores/ephemeralStore'
 import { useSessionStore, type DiagramView } from '../../stores/sessionStore'
+import { usePreferencesStore } from '../../stores/preferencesStore'
 import { useCompile, useExecute } from '../../hooks/useExecute'
 import { useGenerate } from '../../hooks/useGenerate'
 import { useExamples } from '../../hooks/useExamples'
@@ -47,6 +48,7 @@ export function AppToolbar() {
   const generatingCode = useEphemeralStore((s) => s.generatingCode)
   const executing = useEphemeralStore((s) => s.executing)
   const errorCount = useEphemeralStore((s) => s.outputErrorCount)
+  const autoCompile = usePreferencesStore((s) => s.autoCompile)
   const viewMode = useSessionStore((s) => s.viewMode)
   const setViewMode = useSessionStore((s) => s.setViewMode)
   const generateTargetId = useSessionStore((s) => s.generateTargetId)
@@ -220,28 +222,30 @@ export function AppToolbar() {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        <Tip content="Compile (Ctrl+Enter)" side="bottom">
-          <button
-            onClick={compile}
-            disabled={compiling}
-            aria-label={compiling ? 'Compiling' : 'Compile (Ctrl+Enter)'}
-            data-testid="compile-button"
-            className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border/70 bg-surface-0 px-2.5 text-xs font-medium text-ink-muted shadow-sm transition-colors hover:bg-surface-2 hover:text-ink disabled:cursor-not-allowed disabled:opacity-70"
-          >
-            {compiling ? (
-              <Loader2 className="size-3.5 shrink-0 animate-spin" />
-            ) : justCompiled ? (
-              <Check className="size-3.5 shrink-0 text-status-success animate-fade-in" />
-            ) : (
-              <Hammer className="size-3.5 shrink-0" />
-            )}
-            <span className="truncate">
-              {compiling ? 'Compiling...' : justCompiled ? (
-                <span className="text-status-success animate-fade-in">Compiled</span>
-              ) : 'Compile'}
-            </span>
-          </button>
-        </Tip>
+        {!autoCompile && (
+          <Tip content="Compile (Ctrl+Enter)" side="bottom">
+            <button
+              onClick={compile}
+              disabled={compiling}
+              aria-label={compiling ? 'Compiling' : 'Compile (Ctrl+Enter)'}
+              data-testid="compile-button"
+              className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border/70 bg-surface-0 px-2.5 text-xs font-medium text-ink-muted shadow-sm transition-colors hover:bg-surface-2 hover:text-ink disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {compiling ? (
+                <Loader2 className="size-3.5 shrink-0 animate-spin" />
+              ) : justCompiled ? (
+                <Check className="size-3.5 shrink-0 text-status-success animate-fade-in" />
+              ) : (
+                <Hammer className="size-3.5 shrink-0" />
+              )}
+              <span className="truncate">
+                {compiling ? 'Compiling...' : justCompiled ? (
+                  <span className="text-status-success animate-fade-in">Compiled</span>
+                ) : 'Compile'}
+              </span>
+            </button>
+          </Tip>
+        )}
 
         <Combobox
           groups={viewModeGroups}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet'
+import { Switch } from '@/components/ui/switch'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { usePreferencesStore } from '@/stores/preferencesStore'
 import { Monitor, Moon, Sun } from 'lucide-react'
@@ -37,9 +38,15 @@ export function AppSidebar() {
           <section className="space-y-3">
             <div>
               <h2 className="text-sm font-medium text-ink">Theme</h2>
-              <p className="mt-1 text-xs text-ink-muted">Choose how UmpleOnline looks.</p>
             </div>
             <ThemePicker />
+          </section>
+
+          <section className="mt-6 space-y-3">
+            <div>
+              <h2 className="text-sm font-medium text-ink">Compilation</h2>
+            </div>
+            <AutoCompileToggle />
           </section>
         </div>
 
@@ -48,6 +55,27 @@ export function AppSidebar() {
         </SheetFooter>
       </SheetContent>
     </Sheet>
+  )
+}
+
+function AutoCompileToggle() {
+  const autoCompile = usePreferencesStore((s) => s.autoCompile)
+  const setAutoCompile = usePreferencesStore((s) => s.setAutoCompile)
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5">
+      <div>
+        <p className="text-sm font-medium text-ink">Auto-compile</p>
+        <p className="text-xs text-ink-muted">
+          Compile every few seconds and hide the manual compile button.
+        </p>
+      </div>
+      <Switch
+        checked={autoCompile}
+        onCheckedChange={setAutoCompile}
+        aria-label="Auto-compile"
+      />
+    </div>
   )
 }
 

--- a/frontend/src/hooks/useCompiler.ts
+++ b/frontend/src/hooks/useCompiler.ts
@@ -154,6 +154,7 @@ export function useCompiler() {
   const modelId = useSessionStore((s) => s.modelId)
   const tabsVersion = useSessionStore((s) => s.tabsVersion)
   const viewMode = useSessionStore((s) => s.viewMode)
+  const autoCompile = usePreferencesStore((s) => s.autoCompile)
   const setSvgForView = useSessionStore((s) => s.setSvgForView)
   const setHtmlForView = useSessionStore((s) => s.setHtmlForView)
   const suboptionsKey = usePreferencesStore(selectSuboptionsKey)
@@ -187,6 +188,7 @@ export function useCompiler() {
     if (!urlModelResolved) return
 
     if (timerRef.current) clearTimeout(timerRef.current)
+    if (!autoCompile) return
 
     const { syncPending, clearSyncPending } = useSessionStore.getState()
     if (syncPending) clearSyncPending()
@@ -223,7 +225,7 @@ export function useCompiler() {
     // store, and every legitimate modelId change is accompanied by a code or
     // tabsVersion change.  Including it here caused a feedback loop: first
     // compile assigns a modelId → dep changes → second (redundant) compile.
-  }, [code, tabsVersion])
+  }, [autoCompile, code, tabsVersion])
 
   // When viewMode, display preferences, or dark theme change, re-fetch diagram only
   useEffect(() => {

--- a/frontend/src/stores/__tests__/preferencesStore.test.ts
+++ b/frontend/src/stores/__tests__/preferencesStore.test.ts
@@ -8,12 +8,17 @@ describe('preferencesStore', () => {
     usePreferencesStore.persist.clearStorage()
     usePreferencesStore.setState({
       showSidebar: false,
+      autoCompile: true,
       theme: 'system',
     })
   })
 
   it('hides the sidebar by default', () => {
     expect(usePreferencesStore.getState().showSidebar).toBe(false)
+  })
+
+  it('enables auto-compile by default', () => {
+    expect(usePreferencesStore.getState().autoCompile).toBe(true)
   })
 })
 

--- a/frontend/src/stores/preferencesStore.ts
+++ b/frontend/src/stores/preferencesStore.ts
@@ -95,6 +95,10 @@ interface PreferencesState {
   showSidebar: boolean
   toggleSidebar: () => void
 
+  // Compile behavior
+  autoCompile: boolean
+  setAutoCompile: (autoCompile: boolean) => void
+
   // Diagram display preferences
   showAttributes: boolean
   showMethods: boolean
@@ -132,6 +136,10 @@ export const usePreferencesStore = create<PreferencesState>()(
       showSidebar: false,
       toggleSidebar: () => set((s) => ({ showSidebar: !s.showSidebar })),
 
+      // Compile behavior
+      autoCompile: true,
+      setAutoCompile: (autoCompile) => set({ autoCompile }),
+
       // Diagram display preferences (match Umple compiler defaults)
       ...DISPLAY_PREF_DEFAULTS,
       layoutAlgorithm: 'dot',
@@ -163,7 +171,7 @@ export const usePreferencesStore = create<PreferencesState>()(
     }),
     {
       name: 'umple-preferences-v1',
-      version: 2,
+      version: 3,
       storage: createJSONStorage(getBrowserStorage),
       migrate: (persisted, version) => {
         const state = (persisted ?? {}) as Record<string, unknown>
@@ -171,6 +179,13 @@ export const usePreferencesStore = create<PreferencesState>()(
           return {
             ...state,
             showSidebar: false,
+            autoCompile: state.autoCompile ?? true,
+          } as any
+        }
+        if (version < 3) {
+          return {
+            ...state,
+            autoCompile: state.autoCompile ?? true,
           } as any
         }
         return state as any
@@ -184,6 +199,7 @@ export const usePreferencesStore = create<PreferencesState>()(
           'theme',
           'hasSeenWelcome',
           'showSidebar',
+          'autoCompile',
           ...DISPLAY_PREF_KEYS,
           'layoutAlgorithm',
           'activeProvider',
@@ -203,6 +219,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         theme: state.theme,
         hasSeenWelcome: state.hasSeenWelcome,
         showSidebar: state.showSidebar,
+        autoCompile: state.autoCompile,
         ...Object.fromEntries(DISPLAY_PREF_KEYS.map((key) => [key, state[key]])),
         layoutAlgorithm: state.layoutAlgorithm,
         activeProvider: state.activeProvider,

--- a/frontend/tests/e2e/app-smoke.spec.ts
+++ b/frontend/tests/e2e/app-smoke.spec.ts
@@ -74,6 +74,7 @@ test('renders empty editor and compiles when an example is loaded', async ({ pag
   await expect(page.getByTestId('app-shell')).toBeVisible()
   await expect(page.getByTestId('editor-panel')).toBeVisible()
   await expect(page.getByTestId('diagram-panel')).toBeVisible()
+  await expect(page.getByTestId('compile-button')).toHaveCount(0)
 
   // Navigate through hierarchical example palette (sidebar collapsed by default, use Ctrl+K)
   await page.keyboard.press('Control+k')
@@ -83,6 +84,20 @@ test('renders empty editor and compiles when an example is loaded', async ({ pag
   await page.getByTestId('command-item-example-Banking').click()
 
   await expect(page.getByTestId('class-node-Account')).toBeVisible({ timeout: 10_000 })
+})
+
+test('manual compile button appears only when auto-compile is disabled in preferences', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByTestId('app-shell')).toBeVisible()
+  await expect(page.getByTestId('compile-button')).toHaveCount(0)
+
+  await page.getByLabel('Toggle preferences sidebar').click()
+  const autoCompileSwitch = page.getByRole('switch', { name: 'Auto-compile' })
+  await expect(autoCompileSwitch).toHaveAttribute('data-state', 'checked')
+  await autoCompileSwitch.click()
+
+  await expect(autoCompileSwitch).toHaveAttribute('data-state', 'unchecked')
+  await expect(page.getByTestId('compile-button')).toBeVisible()
 })
 
 test('uses the selected diagram type for the first diagram request', async ({ page }) => {

--- a/frontend/tests/e2e/crud-objects.spec.ts
+++ b/frontend/tests/e2e/crud-objects.spec.ts
@@ -37,7 +37,7 @@ const schemaResponse = {
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
     localStorage.setItem('umple-preferences-v1', JSON.stringify({
-      state: { hasSeenWelcome: true },
+      state: { hasSeenWelcome: true, autoCompile: false },
       version: 0,
     }))
   })

--- a/frontend/tests/e2e/display-options.spec.ts
+++ b/frontend/tests/e2e/display-options.spec.ts
@@ -153,8 +153,11 @@ test.describe('Class diagram display options', () => {
     await page.goto('/')
     await expect(page.getByTestId('app-shell')).toBeVisible()
 
-    // Clear localStorage to reset display prefs to defaults
-    await page.evaluate(() => localStorage.removeItem('umple-preferences-v1'))
+    // Reset display prefs while keeping manual compile enabled for this suite
+    await page.evaluate(() => localStorage.setItem('umple-preferences-v1', JSON.stringify({
+      state: { hasSeenWelcome: true, autoCompile: false },
+      version: 0,
+    })))
     await page.reload()
     await expect(page.getByTestId('app-shell')).toBeVisible()
 
@@ -268,8 +271,11 @@ test.describe('Default code display options consistency', () => {
     await page.goto('/')
     await expect(page.getByTestId('app-shell')).toBeVisible()
 
-    // Clear localStorage to reset display prefs
-    await page.evaluate(() => localStorage.removeItem('umple-preferences-v1'))
+    // Reset display prefs while keeping manual compile enabled for this suite
+    await page.evaluate(() => localStorage.setItem('umple-preferences-v1', JSON.stringify({
+      state: { hasSeenWelcome: true, autoCompile: false },
+      version: 0,
+    })))
     await page.reload()
     await expect(page.getByTestId('app-shell')).toBeVisible()
 
@@ -330,8 +336,11 @@ test.describe('ReactFlow mode display options', () => {
     await page.goto('/')
     await expect(page.getByTestId('app-shell')).toBeVisible()
 
-    // Clear localStorage to reset display prefs
-    await page.evaluate(() => localStorage.removeItem('umple-preferences-v1'))
+    // Reset display prefs while keeping manual compile enabled for this suite
+    await page.evaluate(() => localStorage.setItem('umple-preferences-v1', JSON.stringify({
+      state: { hasSeenWelcome: true, autoCompile: false },
+      version: 0,
+    })))
     await page.reload()
     await expect(page.getByTestId('app-shell')).toBeVisible()
 
@@ -430,7 +439,10 @@ test.describe('Sidebar examples display options parity', () => {
   test('class diagram examples: display toggles work and RF/GV are consistent', async ({ page }) => {
     await page.goto('/')
     await expect(page.getByTestId('app-shell')).toBeVisible()
-    await page.evaluate(() => localStorage.removeItem('umple-preferences-v1'))
+    await page.evaluate(() => localStorage.setItem('umple-preferences-v1', JSON.stringify({
+      state: { hasSeenWelcome: true, autoCompile: false },
+      version: 0,
+    })))
     await page.reload()
     await expect(page.getByTestId('app-shell')).toBeVisible()
 
@@ -490,7 +502,10 @@ test.describe('Sidebar examples display options parity', () => {
   test('state diagram examples: display toggles work', async ({ page }) => {
     await page.goto('/')
     await expect(page.getByTestId('app-shell')).toBeVisible()
-    await page.evaluate(() => localStorage.removeItem('umple-preferences-v1'))
+    await page.evaluate(() => localStorage.setItem('umple-preferences-v1', JSON.stringify({
+      state: { hasSeenWelcome: true, autoCompile: false },
+      version: 0,
+    })))
     await page.reload()
     await expect(page.getByTestId('app-shell')).toBeVisible()
 
@@ -524,8 +539,11 @@ test.describe('State diagram display options', () => {
     await page.goto('/')
     await expect(page.getByTestId('app-shell')).toBeVisible()
 
-    // Clear localStorage to reset display prefs
-    await page.evaluate(() => localStorage.removeItem('umple-preferences-v1'))
+    // Reset display prefs while keeping manual compile enabled for this suite
+    await page.evaluate(() => localStorage.setItem('umple-preferences-v1', JSON.stringify({
+      state: { hasSeenWelcome: true, autoCompile: false },
+      version: 0,
+    })))
     await page.reload()
     await expect(page.getByTestId('app-shell')).toBeVisible()
 

--- a/frontend/tests/e2e/live-backend.spec.ts
+++ b/frontend/tests/e2e/live-backend.spec.ts
@@ -31,9 +31,13 @@ async function loadExample(page: Page, category: string, name: string) {
 /** Wait for compilation to finish (compile button becomes enabled again). */
 async function waitForCompile(page: Page) {
   const compileBtn = page.getByTestId('compile-button')
-  // Wait for compiling to start (button becomes disabled)
-  await expect(compileBtn).toBeDisabled({ timeout: 5_000 })
-  // Then wait for it to finish — the button re-enables
+  const compilePromise = page.waitForResponse(
+    (res) => res.url().includes('/api/compile') && res.status() === 200,
+    { timeout: 30_000 },
+  )
+  await expect(compileBtn).toBeEnabled({ timeout: 10_000 })
+  await compileBtn.click()
+  await compilePromise
   await expect(compileBtn).toBeEnabled({ timeout: 30_000 })
 }
 
@@ -111,6 +115,15 @@ test.describe('Live backend — all examples', () => {
   test.setTimeout(600_000) // 10 min budget for ~85 examples
 
   let categories: ExampleCategory[] = []
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('umple-preferences-v1', JSON.stringify({
+        state: { hasSeenWelcome: true, autoCompile: false },
+        version: 0,
+      }))
+    })
+  })
 
   test.beforeAll(async ({ request, baseURL }) => {
     const health = await request.get(`${baseURL}/api/health`)

--- a/frontend/tests/e2e/live-diagram-selection.spec.ts
+++ b/frontend/tests/e2e/live-diagram-selection.spec.ts
@@ -39,7 +39,7 @@ test.describe('Live backend — diagram selection', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem('umple-preferences-v1', JSON.stringify({
-        state: { hasSeenWelcome: true },
+        state: { hasSeenWelcome: true, autoCompile: false },
         version: 0,
       }))
     })

--- a/frontend/tests/e2e/live-generate.spec.ts
+++ b/frontend/tests/e2e/live-generate.spec.ts
@@ -127,6 +127,15 @@ async function compileAndWait(page: Page) {
 test.describe('Live backend — code generation targets', () => {
   test.setTimeout(300_000) // 5 min budget
 
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('umple-preferences-v1', JSON.stringify({
+        state: { hasSeenWelcome: true, autoCompile: false },
+        version: 0,
+      }))
+    })
+  })
+
   test.beforeAll(async ({ request, baseURL }) => {
     const health = await request.get(`${baseURL}/api/health`)
     expect(health.ok()).toBeTruthy()

--- a/frontend/tests/e2e/live-lsp.spec.ts
+++ b/frontend/tests/e2e/live-lsp.spec.ts
@@ -14,10 +14,16 @@ test.skip(
   'Set PLAYWRIGHT_LIVE_BACKEND=1 to run against the real backend stack.',
 )
 
-/** Wait for compilation to finish (compile button becomes enabled again). */
-async function waitForCompile(page: Page) {
+/** Trigger a manual compile and wait for it to complete. */
+async function compileAndWait(page: Page) {
   const compileBtn = page.getByTestId('compile-button')
-  await expect(compileBtn).toBeDisabled({ timeout: 5_000 })
+  const compilePromise = page.waitForResponse(
+    (res) => res.url().includes('/api/compile') && res.status() === 200,
+    { timeout: 30_000 },
+  )
+  await expect(compileBtn).toBeEnabled({ timeout: 10_000 })
+  await compileBtn.click()
+  await compilePromise
   await expect(compileBtn).toBeEnabled({ timeout: 30_000 })
 }
 
@@ -34,7 +40,7 @@ test.describe('Live backend — cross-tab use statements', () => {
     // Dismiss welcome dialog
     await page.addInitScript(() => {
       localStorage.setItem('umple-preferences-v1', JSON.stringify({
-        state: { hasSeenWelcome: true },
+        state: { hasSeenWelcome: true, autoCompile: false },
         version: 0,
       }))
     })
@@ -45,7 +51,7 @@ test.describe('Live backend — cross-tab use statements', () => {
   test('class in a second tab can be referenced via use statement', async ({ page }) => {
     // Type the main model with a use statement
     await setEditorCode(page, 'use Person.ump;\nclass Student {\n  isA Person;\n  studentId;\n}\n')
-    await waitForCompile(page)
+    await compileAndWait(page)
 
     // Create a new tab
     await page.getByTestId('add-tab-button').click()
@@ -59,11 +65,11 @@ test.describe('Live backend — cross-tab use statements', () => {
 
     // Type Person class in the new tab
     await setEditorCode(page, 'class Person {\n  name;\n  age;\n}\n')
-    await waitForCompile(page)
+    await compileAndWait(page)
 
     // Switch back to first tab
     await page.getByTestId('tab-bar').locator('[data-testid^="tab-"]').first().click()
-    await waitForCompile(page)
+    await compileAndWait(page)
 
     // The compilation should succeed — Student class should appear in the diagram
     // (if it failed, use statement couldn't resolve Person.ump)
@@ -77,7 +83,7 @@ test.describe('Live backend — LSP diagnostics', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem('umple-preferences-v1', JSON.stringify({
-        state: { hasSeenWelcome: true },
+        state: { hasSeenWelcome: true, autoCompile: false },
         version: 0,
       }))
     })
@@ -88,7 +94,7 @@ test.describe('Live backend — LSP diagnostics', () => {
   test('syntax error shows diagnostic underline in editor', async ({ page }) => {
     // Type valid code first to establish a model (triggers LSP connection)
     await setEditorCode(page, 'class Foo {\n  name;\n}\n')
-    await waitForCompile(page)
+    await compileAndWait(page)
 
     // Wait for LSP to connect (it needs modelId from first compile)
     await page.waitForTimeout(2000)


### PR DESCRIPTION
## Summary
- add a persisted auto-compile preference that defaults to on
- hide the manual compile button by default and show it only when auto-compile is disabled
- keep the preferences copy concise and update tests for the manual-compile mode

Closes #93

## Test plan
- bun run test -- preferencesStore
- bun run test:e2e:typecheck
- bun run build
- bun run test:e2e tests/e2e/app-smoke.spec.ts tests/e2e/crud-objects.spec.ts