### PR TITLE
Fix command palette example hierarchy

### DIFF
--- a/frontend/src/components/command/CommandPalette.tsx
+++ b/frontend/src/components/command/CommandPalette.tsx
@@ -5,13 +5,11 @@ import { useGenerate } from '../../hooks/useGenerate'
 import { useExamples } from '../../hooks/useExamples'
 import { GENERATE_ONLY_TARGET_GROUPS } from '../../generation/targets'
 import { DIAGRAM_VIEW_ICON, VIEW_MODE_GROUPS } from '../../constants/diagram'
-import { EXAMPLE_CATEGORY_LABELS } from '../../constants/examples'
 import type { ExampleCategoryId } from '../../api/types'
 import {
   LayoutGrid, Workflow, GitBranch, Network,
   Code, Layers, Maximize2, Minimize2,
   Terminal, FileCode,
-  ChevronRight, ChevronLeft, BookOpen, FolderOpen,
 } from 'lucide-react'
 import {
   CommandDialog,
@@ -35,7 +33,7 @@ export function CommandPalette() {
   const {
     commandPaletteOpen, closeCommandPalette,
     setDiagramOnly, diagramOnly, toggleOutputPanel,
-    setRenderMode, renderMode, commandPaletteInitialPage,
+    setRenderMode, renderMode,
   } = useEphemeralStore()
   const setViewMode = useSessionStore((s) => s.setViewMode)
   const viewMode = useSessionStore((s) => s.viewMode)
@@ -43,23 +41,14 @@ export function CommandPalette() {
   const generate = useGenerate()
   const { categories, loadExample, loading } = useExamples()
 
-  const [pages, setPages] = useState<string[]>([])
   const [search, setSearch] = useState('')
-
-  const page = pages[pages.length - 1]
 
   // Reset state when palette closes
   useEffect(() => {
     if (!commandPaletteOpen) {
-      setPages([])
-      setSearch('')
-      return
-    }
-    if (commandPaletteInitialPage) {
-      setPages(commandPaletteInitialPage)
       setSearch('')
     }
-  }, [commandPaletteOpen, commandPaletteInitialPage])
+  }, [commandPaletteOpen])
 
   // Global Ctrl+K shortcut
   useEffect(() => {
@@ -79,40 +68,22 @@ export function CommandPalette() {
     return () => window.removeEventListener('keydown', handler, true)
   }, [])
 
-  const pushPage = useCallback((p: string) => {
-    setPages((prev) => [...prev, p])
-    setSearch('')
-  }, [])
-
-  const popPage = useCallback(() => {
-    setPages((prev) => prev.slice(0, -1))
-    setSearch('')
-  }, [])
-
-  const handleCommandKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.key === 'Backspace' && !search && pages.length > 0) {
-        e.preventDefault()
-        popPage()
-      }
-    },
-    [search, pages.length, popPage],
-  )
-
   const handleGenerate = useCallback(async (language: string) => {
     closeCommandPalette()
     generate(language)
   }, [closeCommandPalette, generate])
 
-  const currentCategory = useMemo(() => {
-    if (!page || page === 'examples') return undefined
-    return categories.find((c) => c.id === page)
-  }, [categories, page])
+  const exampleItems = useMemo(() => {
+    return categories.flatMap((category) => (
+      category.examples.map((example) => ({
+        categoryId: category.id,
+        categoryLabel: category.label,
+        exampleName: example.name,
+        exampleLabel: example.label || example.name,
+      }))
+    ))
+  }, [categories])
   const canToggleRenderer = viewMode === 'class' && !!umpleModel?.umpleClasses?.length
-
-  const breadcrumb = pages
-    .map((p) => (p === 'examples' ? 'Examples' : EXAMPLE_CATEGORY_LABELS[p as ExampleCategoryId] ?? p))
-    .join(' \u203A ')
 
   return (
     <CommandDialog
@@ -121,170 +92,117 @@ export function CommandPalette() {
       showCloseButton={false}
       className="sm:max-w-[520px]"
       data-testid="command-palette"
-      onCommandKeyDown={handleCommandKeyDown}
     >
       <CommandInput
-        placeholder={!page ? 'Type a command...' : 'Search...'}
+        placeholder="Type a command or search examples..."
         data-testid="command-palette-input"
         value={search}
         onValueChange={setSearch}
       />
 
-      {pages.length > 0 && (
-        <div
-          className="flex items-center gap-1.5 border-b border-border px-3 py-1.5"
-          data-testid="command-palette-breadcrumb"
-        >
-          <button
-            type="button"
-            onClick={popPage}
-            aria-label="Go back"
-            className="flex items-center justify-center rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-            data-testid="command-palette-back"
-          >
-            <ChevronLeft className="size-3.5" />
-          </button>
-          <span className="text-xs text-muted-foreground">{breadcrumb}</span>
-        </div>
-      )}
-
       <CommandList data-testid="command-palette-results">
         <CommandEmpty>No results found</CommandEmpty>
 
-        {/* Root page */}
-        {!page && (
-          <>
-            {VIEW_MODE_GROUPS.map((group) => (
-              <CommandGroup key={group.label} heading={group.label}>
-                {group.modes.map((mode) => (
-                  <CommandItem
-                    key={mode.value}
-                    onSelect={() => {
-                      setViewMode(mode.value)
-                      useEphemeralStore.getState().setRightPanelView('diagram')
-                      closeCommandPalette()
-                    }}
-                    data-testid={`command-item-diagram-${mode.value}`}
-                  >
-                    <DIAGRAM_VIEW_ICON />
-                    {mode.longLabel ?? mode.label}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            ))}
-
-            <CommandSeparator />
-
-            {GENERATE_ONLY_TARGET_GROUPS.map((group) => (
-              <CommandGroup key={group.label} heading={group.label}>
-                {group.targets.map((target) => (
-                  <CommandItem
-                    key={target.id}
-                    onSelect={() => handleGenerate(target.id)}
-                    data-testid={`command-item-gen-${target.id}`}
-                  >
-                    <Code />
-                    {target.label}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            ))}
-
-            <CommandSeparator />
-            <CommandGroup heading="View">
-              {canToggleRenderer && (
-                <CommandItem
-                  onSelect={() => {
-                    setRenderMode(renderMode === 'editable' ? 'graphviz' : 'editable')
-                    closeCommandPalette()
-                  }}
-                  data-testid="command-item-view-renderer"
-                >
-                  <Layers />
-                  Switch to {renderMode === 'editable' ? 'Graphviz' : 'Editable'} Rendering
-                </CommandItem>
-              )}
+        {VIEW_MODE_GROUPS.map((group) => (
+          <CommandGroup key={group.label} heading={group.label}>
+            {group.modes.map((mode) => (
               <CommandItem
+                key={mode.value}
                 onSelect={() => {
-                  setDiagramOnly(!diagramOnly)
+                  setViewMode(mode.value)
+                  useEphemeralStore.getState().setRightPanelView('diagram')
                   closeCommandPalette()
                 }}
-                data-testid="command-item-view-diagram-only"
+                data-testid={`command-item-diagram-${mode.value}`}
               >
-                {diagramOnly ? <Minimize2 /> : <Maximize2 />}
-                {diagramOnly ? 'Exit Diagram Only Mode' : 'Diagram Only Mode'}
+                <DIAGRAM_VIEW_ICON />
+                {mode.longLabel ?? mode.label}
               </CommandItem>
+            ))}
+          </CommandGroup>
+        ))}
+
+        <CommandSeparator />
+
+        {GENERATE_ONLY_TARGET_GROUPS.map((group) => (
+          <CommandGroup key={group.label} heading={group.label}>
+            {group.targets.map((target) => (
               <CommandItem
+                key={target.id}
+                onSelect={() => handleGenerate(target.id)}
+                data-testid={`command-item-gen-${target.id}`}
+              >
+                <Code />
+                {target.label}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        ))}
+
+        <CommandSeparator />
+        <CommandGroup heading="View">
+          {canToggleRenderer && (
+            <CommandItem
+              onSelect={() => {
+                setRenderMode(renderMode === 'editable' ? 'graphviz' : 'editable')
+                closeCommandPalette()
+              }}
+              data-testid="command-item-view-renderer"
+            >
+              <Layers />
+              Switch to {renderMode === 'editable' ? 'Graphviz' : 'Editable'} Rendering
+            </CommandItem>
+          )}
+          <CommandItem
+            onSelect={() => {
+              setDiagramOnly(!diagramOnly)
+              closeCommandPalette()
+            }}
+            data-testid="command-item-view-diagram-only"
+          >
+            {diagramOnly ? <Minimize2 /> : <Maximize2 />}
+            {diagramOnly ? 'Exit Diagram Only Mode' : 'Diagram Only Mode'}
+          </CommandItem>
+          <CommandItem
+            onSelect={() => {
+              toggleOutputPanel()
+              closeCommandPalette()
+            }}
+            data-testid="command-item-view-output-panel"
+          >
+            <Terminal />
+            Toggle Output Panel
+            <CommandShortcut>Ctrl+'</CommandShortcut>
+          </CommandItem>
+        </CommandGroup>
+
+        <CommandSeparator />
+        <CommandGroup heading="Examples">
+          {loading ? (
+            <div className="py-2 text-center text-xs text-muted-foreground">Loading examples...</div>
+          ) : (
+            exampleItems.map((item) => (
+              <CommandItem
+                key={`${item.categoryId}:${item.exampleName}`}
+                value={`${item.exampleLabel} ${item.exampleName} ${item.categoryLabel}`}
                 onSelect={() => {
-                  toggleOutputPanel()
                   closeCommandPalette()
+                  loadExample(item.exampleName, {
+                    categoryId: item.categoryId,
+                    switchToDefaultView: true,
+                  })
                 }}
-                data-testid="command-item-view-output-panel"
+                data-testid={`command-item-example-${item.categoryLabel}-${item.exampleName}`}
               >
-                <Terminal />
-                Toggle Output Panel
-                <CommandShortcut>Ctrl+'</CommandShortcut>
-              </CommandItem>
-            </CommandGroup>
-
-            <CommandSeparator />
-            <CommandGroup heading="Examples">
-              {loading ? (
-                <div className="py-2 text-center text-xs text-muted-foreground">Loading examples...</div>
-              ) : categories.length > 0 ? (
-                <CommandItem
-                  onSelect={() => pushPage('examples')}
-                  data-testid="command-item-examples-browse"
-                >
-                  <BookOpen />
-                  Browse Examples...
-                  <ChevronRight className="ml-auto size-4 text-muted-foreground" />
-                </CommandItem>
-              ) : null}
-            </CommandGroup>
-          </>
-        )}
-
-        {/* Examples: category list */}
-        {page === 'examples' && (
-          <CommandGroup heading="Categories">
-            {categories.map((cat) => (
-              <CommandItem
-                key={cat.id}
-                onSelect={() => pushPage(cat.id)}
-                data-testid={`command-item-category-${cat.label}`}
-              >
-                {CATEGORY_ICONS[cat.id] ?? <FolderOpen />}
-                {cat.label}
+                {CATEGORY_ICONS[item.categoryId] ?? <FileCode />}
+                {item.exampleLabel}
                 <span className="ml-auto text-xs text-muted-foreground">
-                  {cat.examples.length}
+                  {item.categoryLabel}
                 </span>
               </CommandItem>
-            ))}
-          </CommandGroup>
-        )}
-
-        {/* Examples: example list within a category */}
-        {currentCategory && (
-          <CommandGroup heading={currentCategory.label}>
-            {currentCategory.examples.map((ex) => (
-                <CommandItem
-                  key={ex.name}
-                  onSelect={() => {
-                    closeCommandPalette()
-                    loadExample(ex.name, {
-                      categoryId: currentCategory.id,
-                      switchToDefaultView: true,
-                    })
-                  }}
-                  data-testid={`command-item-example-${ex.name}`}
-                >
-                  <FileCode />
-                  {ex.label || ex.name}
-                </CommandItem>
-              ))}
-          </CommandGroup>
-        )}
+            ))
+          )}
+        </CommandGroup>
       </CommandList>
     </CommandDialog>
   )

--- a/frontend/src/stores/ephemeralStore.ts
+++ b/frontend/src/stores/ephemeralStore.ts
@@ -85,7 +85,6 @@ interface EphemeralState {
   showEditor: boolean
   outputView: OutputView
   commandPaletteOpen: boolean
-  commandPaletteInitialPage: string[] | null
   diagramOnly: boolean
   readOnly: boolean
   rightPanelView: 'diagram' | 'generated'
@@ -182,7 +181,6 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
   showEditor: true,
   outputView: 'hidden',
   commandPaletteOpen: false,
-  commandPaletteInitialPage: null,
   diagramOnly: false,
   readOnly: false,
   rightPanelView: 'diagram',
@@ -241,15 +239,12 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
   toggleOutputPanel: () => set((s) => ({ outputView: s.outputView === 'hidden' ? 'panel' : 'hidden' })),
   openCommandPalette: () => set({
     commandPaletteOpen: true,
-    commandPaletteInitialPage: null,
   }),
   openExamplesPalette: () => set({
     commandPaletteOpen: true,
-    commandPaletteInitialPage: ['examples'],
   }),
   closeCommandPalette: () => set({
     commandPaletteOpen: false,
-    commandPaletteInitialPage: null,
   }),
   setDiagramOnly: (diagramOnly) => set({ diagramOnly, showEditor: !diagramOnly }),
   setReadOnly: (readOnly) => set({ readOnly }),

--- a/frontend/tests/e2e/app-smoke.spec.ts
+++ b/frontend/tests/e2e/app-smoke.spec.ts
@@ -76,12 +76,10 @@ test('renders empty editor and compiles when an example is loaded', async ({ pag
   await expect(page.getByTestId('diagram-panel')).toBeVisible()
   await expect(page.getByTestId('compile-button')).toHaveCount(0)
 
-  // Navigate through hierarchical example palette (sidebar collapsed by default, use Ctrl+K)
+  // Load an example from the first-layer command palette (sidebar collapsed by default, use Ctrl+K)
   await page.keyboard.press('Control+k')
   await expect(page.getByTestId('command-palette')).toBeVisible()
-  await page.getByTestId('command-item-examples-browse').click()
-  await page.getByTestId('command-item-category-Samples').click()
-  await page.getByTestId('command-item-example-Banking').click()
+  await page.getByTestId('command-item-example-Samples-Banking').click()
 
   await expect(page.getByTestId('class-node-Account')).toBeVisible({ timeout: 10_000 })
 })
@@ -119,12 +117,10 @@ test('uses the selected diagram type for the first diagram request', async ({ pa
   await page.goto('/')
   await expect(page.getByTestId('app-shell')).toBeVisible()
 
-  // Load an example via hierarchical navigation (sidebar collapsed by default, use Ctrl+K)
+  // Load an example via the first-layer command palette (sidebar collapsed by default, use Ctrl+K)
   await page.keyboard.press('Control+k')
   await expect(page.getByTestId('command-palette')).toBeVisible()
-  await page.getByTestId('command-item-examples-browse').click()
-  await page.getByTestId('command-item-category-Samples').click()
-  await page.getByTestId('command-item-example-Banking').click()
+  await page.getByTestId('command-item-example-Samples-Banking').click()
   await expect(page.getByTestId('class-node-Account')).toBeVisible({ timeout: 10_000 })
 
   // Switch diagram view — should trigger a diagram request with the new type
@@ -175,9 +171,7 @@ test('command palette lists all supported diagram commands and diagram commands 
   await expect(page.getByTestId('app-shell')).toBeVisible()
 
   await page.keyboard.press('Control+k')
-  await page.getByTestId('command-item-examples-browse').click()
-  await page.getByTestId('command-item-category-Samples').click()
-  await page.getByTestId('command-item-example-Banking').click()
+  await page.getByTestId('command-item-example-Samples-Banking').click()
   await expect(page.getByTestId('class-node-Account')).toBeVisible({ timeout: 10_000 })
 
   await page.keyboard.press('Control+k')
@@ -203,9 +197,7 @@ test('command palette view commands toggle renderer, output panel, and diagram-o
   await expect(page.getByTestId('app-shell')).toBeVisible()
 
   await page.keyboard.press('Control+k')
-  await page.getByTestId('command-item-examples-browse').click()
-  await page.getByTestId('command-item-category-Samples').click()
-  await page.getByTestId('command-item-example-Banking').click()
+  await page.getByTestId('command-item-example-Samples-Banking').click()
   await expect(page.getByTestId('class-node-Account')).toBeVisible({ timeout: 10_000 })
 
   await page.keyboard.press('Control+k')
@@ -241,9 +233,7 @@ test('ERD selection sends GvEntityRelationshipDiagram to backend', async ({ page
   // Load example to trigger compile + diagram
   await page.keyboard.press('Control+k')
   await expect(page.getByTestId('command-palette')).toBeVisible()
-  await page.getByTestId('command-item-examples-browse').click()
-  await page.getByTestId('command-item-category-Samples').click()
-  await page.getByTestId('command-item-example-Banking').click()
+  await page.getByTestId('command-item-example-Samples-Banking').click()
   await expect(page.getByTestId('class-node-Account')).toBeVisible({ timeout: 10_000 })
 
   // Switch to ERD
@@ -269,9 +259,7 @@ test('Event Sequence renders iframe with mocked HTML response', async ({ page })
   // Load example
   await page.keyboard.press('Control+k')
   await expect(page.getByTestId('command-palette')).toBeVisible()
-  await page.getByTestId('command-item-examples-browse').click()
-  await page.getByTestId('command-item-category-Samples').click()
-  await page.getByTestId('command-item-example-Banking').click()
+  await page.getByTestId('command-item-example-Samples-Banking').click()
   await expect(page.getByTestId('class-node-Account')).toBeVisible({ timeout: 10_000 })
 
   // Switch to Event Sequence
@@ -306,9 +294,7 @@ test('Feature view renders SVG diagram from backend', async ({ page }) => {
   await expect(page.getByTestId('app-shell')).toBeVisible()
   await page.keyboard.press('Control+k')
   await expect(page.getByTestId('command-palette')).toBeVisible()
-  await page.getByTestId('command-item-examples-browse').click()
-  await page.getByTestId('command-item-category-Samples').click()
-  await page.getByTestId('command-item-example-Banking').click()
+  await page.getByTestId('command-item-example-Samples-Banking').click()
   await expect(page.getByTestId('class-node-Account')).toBeVisible({ timeout: 10_000 })
 
   await page.getByLabel('Diagram view').click()
@@ -360,9 +346,7 @@ test('loading a composite structure example switches to structure view and rende
   await expect(page.getByTestId('app-shell')).toBeVisible()
   await page.keyboard.press('Control+k')
   await expect(page.getByTestId('command-palette')).toBeVisible()
-  await page.getByTestId('command-item-examples-browse').click()
-  await page.getByTestId('command-item-category-Composite Structure').click()
-  await page.getByTestId('command-item-example-PingPong').click()
+  await page.getByTestId('command-item-example-Composite Structure-PingPong').click()
 
   await expect.poll(() => diagramTypes[diagramTypes.length - 1]).toBe('StructureDiagram')
   await expect(page.getByLabel('Diagram view')).toContainText('Structure')

--- a/frontend/tests/e2e/display-options.spec.ts
+++ b/frontend/tests/e2e/display-options.spec.ts
@@ -449,10 +449,8 @@ test.describe('Sidebar examples display options parity', () => {
     // Load a class diagram example from the sidebar
     await page.keyboard.press('Control+k')
     await expect(page.getByTestId('command-palette')).toBeVisible()
-    await page.getByTestId('command-item-examples-browse').click()
-    await page.getByTestId('command-item-category-Class Diagrams').click()
     // Pick the first example
-    const firstExample = page.locator('[data-testid^="command-item-example-"]').first()
+    const firstExample = page.locator('[data-testid^="command-item-example-Class Diagrams-"]').first()
     await firstExample.click()
 
     // Wait for compile
@@ -512,9 +510,7 @@ test.describe('Sidebar examples display options parity', () => {
     // Load a state machine example
     await page.keyboard.press('Control+k')
     await expect(page.getByTestId('command-palette')).toBeVisible()
-    await page.getByTestId('command-item-examples-browse').click()
-    await page.getByTestId('command-item-category-State Machines').click()
-    const firstExample = page.locator('[data-testid^="command-item-example-"]').first()
+    const firstExample = page.locator('[data-testid^="command-item-example-State Machines-"]').first()
     await firstExample.click()
 
     await compileAndWait(page)

--- a/frontend/tests/e2e/live-backend.spec.ts
+++ b/frontend/tests/e2e/live-backend.spec.ts
@@ -23,9 +23,7 @@ test.skip(
 async function loadExample(page: Page, category: string, name: string) {
   await page.keyboard.press('Control+k')
   await expect(page.getByTestId('command-palette')).toBeVisible()
-  await page.getByTestId('command-item-examples-browse').click()
-  await page.getByTestId(`command-item-category-${category}`).click()
-  await page.getByTestId(`command-item-example-${name}`).click()
+  await page.getByTestId(`command-item-example-${category}-${name}`).click()
 }
 
 /** Wait for compilation to finish (compile button becomes enabled again). */


### PR DESCRIPTION
## Summary
- flatten the command palette so examples are available on the first layer
- remove the extra examples navigation state from the palette flow
- update mocked e2e coverage for the new first-layer example entries

## Test plan
- bun run build
- bun run test:e2e tests/e2e/app-smoke.spec.ts
- bun run test:e2e tests/e2e/display-options.spec.ts (21 skipped in current suite setup)

Refs #93