### PR TITLE
Preserve example URL until share

### DIFF
--- a/frontend/src/components/editor/CollabButton.tsx
+++ b/frontend/src/components/editor/CollabButton.tsx
@@ -53,6 +53,7 @@ export function CollabButton() {
     // after render — too late for the clipboard copy below.
     if (roomId) {
       const url = new URL(window.location.href)
+      url.searchParams.delete('example')
       url.searchParams.set('model', roomId)
       window.history.replaceState({}, '', url.toString())
     }

--- a/frontend/src/hooks/useModelFromURL.ts
+++ b/frontend/src/hooks/useModelFromURL.ts
@@ -119,10 +119,6 @@ export function useModelFromURL() {
           );
           if (nextView) setViewMode(nextView);
         }
-
-        const url = new URL(window.location.href);
-        url.searchParams.delete("example");
-        window.history.replaceState({}, "", url.toString());
       })
       .catch(() => {
         if (cancelled) return;

--- a/frontend/tests/e2e/app-smoke.spec.ts
+++ b/frontend/tests/e2e/app-smoke.spec.ts
@@ -134,7 +134,49 @@ test("loads an example from the URL into the editor automatically", async ({
   await expect(page.getByTestId("class-node-Account")).toBeVisible({
     timeout: 10_000,
   });
-  await expect(page).toHaveURL(/\/\?model=playwright-model$/);
+  await expect
+    .poll(async () => {
+      const params = new URL(await page.url()).searchParams;
+      return {
+        example: params.get("example"),
+        model: params.get("model"),
+      };
+    })
+    .toEqual({ example: "banking", model: "playwright-model" });
+});
+
+test("share removes the example parameter after URL-based example loading", async ({
+  page,
+}) => {
+  await page.route("**/api/examples/resolve?*", async (route) => {
+    await route.fulfill({
+      json: {
+        id: "ex-banking",
+        name: "Banking",
+        label: "Banking",
+        code: `class Account {\n  balance;\n}\n`,
+        defaultCategoryId: "class",
+      },
+    });
+  });
+
+  await page.goto("/?example=banking");
+
+  await expect(page.getByTestId("app-shell")).toBeVisible();
+  await expect(page.locator(".cm-content")).toContainText("class Account");
+  await expect(page.getByTestId("class-node-Account")).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.getByTestId("collab-share-btn").click();
+  await expect
+    .poll(async () => {
+      const params = new URL(await page.url()).searchParams;
+      return {
+        example: params.get("example"),
+        model: params.get("model"),
+      };
+    })
+    .toEqual({ example: null, model: "playwright-model" });
 });
 
 test("manual compile button appears only when auto-compile is disabled in preferences", async ({


### PR DESCRIPTION
## Summary
- preserve the `example` URL parameter after URL-driven example loading
- remove the `example` parameter when generating a collaboration share link
- add smoke coverage for both URL behaviors

## Test plan
- bun run test:e2e:typecheck
- bun run build
- bun run test:e2e tests/e2e/app-smoke.spec.ts --grep "loads an example from the URL into the editor automatically|share removes the example parameter after URL-based example loading"

Related to issue93 (#93).