### PR TITLE
fix: restore legacy generation target list

### DIFF
--- a/frontend/src/components/layout/AppToolbar.tsx
+++ b/frontend/src/components/layout/AppToolbar.tsx
@@ -7,7 +7,7 @@ import { useGenerate } from "../../hooks/useGenerate";
 import { useExamples } from "../../hooks/useExamples";
 import type { ExampleSetId } from "../../api/types";
 import {
-  GENERATE_TARGET_GROUPS,
+  APP_TOOLBAR_GENERATE_TARGET_GROUPS,
   getGenerateTarget,
 } from "../../generation/targets";
 import { AiConfigForm } from "@/components/sidebar/AiConfigForm";
@@ -144,7 +144,7 @@ export function AppToolbar() {
 
   const generateGroups = useMemo<ComboboxGroup[]>(
     () =>
-      GENERATE_TARGET_GROUPS.map((group) => ({
+      APP_TOOLBAR_GENERATE_TARGET_GROUPS.map((group) => ({
         label: group.label,
         options: group.targets.map((target) => ({
           value: target.id,

--- a/frontend/src/generation/targets.test.ts
+++ b/frontend/src/generation/targets.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  APP_TOOLBAR_GENERATE_TARGET_GROUPS,
+  GENERATE_TARGET_GROUPS,
+  getGenerateTarget,
+} from './targets'
+
+function groupContainsDiagram(group: { targets: { action: 'generate' | 'diagram' }[] }) {
+  return group.targets.some((target) => target.action === 'diagram')
+}
+
+describe('APP_TOOLBAR_GENERATE_TARGET_GROUPS', () => {
+  it('starts with diagram-capable groups before code-generation-only groups', () => {
+    const firstNonDiagramGroupIndex = APP_TOOLBAR_GENERATE_TARGET_GROUPS.findIndex(
+      (group) => !groupContainsDiagram(group),
+    )
+
+    expect(firstNonDiagramGroupIndex).toBeGreaterThan(0)
+    expect(
+      APP_TOOLBAR_GENERATE_TARGET_GROUPS.slice(0, firstNonDiagramGroupIndex).every(groupContainsDiagram),
+    ).toBe(true)
+    expect(APP_TOOLBAR_GENERATE_TARGET_GROUPS[firstNonDiagramGroupIndex]?.label).toBe(
+      'Programming Language Code',
+    )
+  })
+
+  it('keeps the same group count as the canonical target list', () => {
+    expect(APP_TOOLBAR_GENERATE_TARGET_GROUPS).toHaveLength(GENERATE_TARGET_GROUPS.length)
+  })
+
+  it('puts diagram entries first inside mixed groups', () => {
+    const specialViewsGroup = APP_TOOLBAR_GENERATE_TARGET_GROUPS.find(
+      (group) => group.label === 'Special Views',
+    )
+
+    expect(specialViewsGroup?.targets.slice(0, 2).map((target) => target.id)).toEqual([
+      'featureDiagram',
+      'StructureDiagram',
+    ])
+  })
+
+  it('keeps legacy generate-menu labels for targets that still exist', () => {
+    expect(getGenerateTarget('crud')?.label).toBe('CRUD User Interface')
+    expect(getGenerateTarget('SimpleCpp')?.label).toBe('Simple C++ (under development)')
+  })
+})

--- a/frontend/src/generation/targets.ts
+++ b/frontend/src/generation/targets.ts
@@ -14,6 +14,22 @@ export interface GenerateTargetGroup {
   targets: GenerateTarget[]
 }
 
+function groupContainsDiagram(group: GenerateTargetGroup): boolean {
+  return group.targets.some((target) => target.action === 'diagram')
+}
+
+function sortGroupTargetsDiagramsFirst(group: GenerateTargetGroup): GenerateTargetGroup {
+  if (!groupContainsDiagram(group)) return group
+
+  return {
+    ...group,
+    targets: [
+      ...group.targets.filter((target) => target.action === 'diagram'),
+      ...group.targets.filter((target) => target.action !== 'diagram'),
+    ],
+  }
+}
+
 export const GENERATE_TARGET_GROUPS: GenerateTargetGroup[] = [
   {
     label: 'Programming Language Code',
@@ -25,7 +41,7 @@ export const GENERATE_TARGET_GROUPS: GenerateTargetGroup[] = [
       { id: 'RTCpp', label: 'C++ Code (Beta)', action: 'generate' },
       { id: 'Ruby', label: 'Ruby Code', action: 'generate' },
       { id: 'Cpp', label: 'C++ Code', action: 'generate' },
-      { id: 'SimpleCpp', label: 'Simple C++', action: 'generate' },
+      { id: 'SimpleCpp', label: 'Simple C++ (under development)', action: 'generate' },
     ],
   },
   {
@@ -33,7 +49,7 @@ export const GENERATE_TARGET_GROUPS: GenerateTargetGroup[] = [
     targets: [
       { id: 'classDiagram', label: 'GraphViz Class Diagram (SVG)', action: 'diagram', diagramView: 'class' },
       { id: 'entityRelationshipDiagram', label: 'Entity Relationship Diagram (GraphViz SVG)', action: 'diagram', diagramView: 'erd' },
-      { id: 'crud', label: 'Objects (CRUD)', action: 'diagram', diagramView: 'crud' },
+      { id: 'crud', label: 'CRUD User Interface', action: 'diagram', diagramView: 'crud' },
       { id: 'Sql', label: 'Sql', action: 'generate' },
     ],
   },
@@ -88,6 +104,10 @@ export const GENERATE_TARGET_GROUPS: GenerateTargetGroup[] = [
 ]
 
 export const GENERATE_TARGETS: GenerateTarget[] = GENERATE_TARGET_GROUPS.flatMap((g) => g.targets)
+export const APP_TOOLBAR_GENERATE_TARGET_GROUPS: GenerateTargetGroup[] = [
+  ...GENERATE_TARGET_GROUPS.filter(groupContainsDiagram).map(sortGroupTargetsDiagramsFirst),
+  ...GENERATE_TARGET_GROUPS.filter((group) => !groupContainsDiagram(group)),
+]
 export const GENERATE_ONLY_TARGET_GROUPS: GenerateTargetGroup[] = GENERATE_TARGET_GROUPS
   .map((group) => ({
     ...group,


### PR DESCRIPTION
## Summary
- restore the toolbar generation dropdown to start with categorized diagram targets
- align surviving generation labels with the legacy UmpleOnline menu naming
- add a focused test covering toolbar ordering and legacy target labels

## Test plan
- bun run test src/generation/targets.test.ts
- bun run build