### PR TITLE
fix(execution): restore code execution and output rendering

### DIFF
--- a/code-exec/Dockerfile
+++ b/code-exec/Dockerfile
@@ -22,6 +22,5 @@ EXPOSE 4400
 
 RUN chown -R nodeuser:nodeuser /usr/src/app
 RUN chown -R nodeuser:nodeuser /home
-USER nodeuser
 
 CMD [ "npm", "start" ]

--- a/code-exec/dockerExecution.js
+++ b/code-exec/dockerExecution.js
@@ -1,113 +1,207 @@
 const fs = require('fs');
-const exec = require('child_process').exec;
+const os = require('os');
+const path = require('path');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
 
 class DockerExecution {
-    constructor(path, mainFile, model, language="Java") {
-        this.path = path;
+    constructor(pathToMainClass, mainFile, modelPath, language="Java") {
+        this.path = pathToMainClass;
         this.mainFile = mainFile;
-        this.model = model;
-        this.outputFolder = "output/" + this.model + "_" + this.mainFile;
-        this.language=language;
+        this.model = path.resolve(modelPath);
+        this.outputFolder = null;
+        this.language = language;
 
         const config = this.readConfig();
-        this.basePath = config['umplePath'];
-        this.baseOutputPath = config['tempPath'];
+        this.baseOutputPath = config['tempPath'] || os.tmpdir();
         this.tempContainerName = config['tempContainerName'];
         this.timeoutValue = +config['timeoutValue'];
     }
 
-    run(callback) {      
-        // Make output folder where the output files will be written
-        this.makeOutputFolder();
-        const mainFilePath = this.getNormalizedMainFilename();
-        console.log("Normalized main file: ", mainFilePath);
-        const command = `sh dockerTimeout.sh ${this.timeoutValue}s -i -t --network none -v ${this.basePath}/${this.model}:/input/:ro -v ${this.baseOutputPath}/${this.model}_${this.mainFile}:/output/ ${this.tempContainerName} ${mainFilePath}`;
-        
-        console.log("Docker command:'",command,"'"); 
-        exec(command); // Execute docker for Java execution
+    run(callback) {
+        void this.runExecution(callback);
+    }
 
-        this.listenToChanges(callback);
+    async runExecution(callback) {
+        let containerId = "";
+
+        try {
+            this.makeOutputFolder();
+            const mainFilePath = this.getNormalizedMainFilename();
+            console.log("Normalized main file: ", mainFilePath);
+
+            containerId = await this.createContainer(mainFilePath);
+            await this.copyModelIntoContainer(containerId);
+
+            const timedOut = await this.startAndWait(containerId);
+            const copyError = await this.copyOutputFromContainer(containerId);
+            const result = this.readExecutionResult(timedOut, copyError);
+
+            callback(result.errors, result.output);
+        } catch(err) {
+            console.error(err);
+            callback(this.formatExecutionError(err), "");
+        } finally {
+            await this.removeContainer(containerId);
+            this.deleteOutputFolder();
+        }
+    }
+
+    async createContainer(mainFilePath) {
+        const { stdout } = await execFileAsync('docker', [
+            'create',
+            '--cpus=0.5',
+            '--memory=150m',
+            '--network',
+            'none',
+            this.tempContainerName,
+            mainFilePath,
+        ]);
+
+        const containerId = stdout.trim();
+        if(!containerId) {
+            throw new Error('failed to create execution container');
+        }
+
+        return containerId;
+    }
+
+    async copyModelIntoContainer(containerId) {
+        await execFileAsync('docker', [
+            'cp',
+            `${this.model}${path.sep}.`,
+            `${containerId}:/input/`,
+        ]);
+    }
+
+    async startAndWait(containerId) {
+        await execFileAsync('docker', ['start', containerId]);
+
+        try {
+            await execFileAsync('timeout', [`${this.timeoutValue}s`, 'docker', 'wait', containerId]);
+            return false;
+        } catch (err) {
+            if(!this.isTimeoutError(err)) {
+                throw err;
+            }
+
+            await this.stopContainer(containerId);
+            return true;
+        }
+    }
+
+    async copyOutputFromContainer(containerId) {
+        try {
+            await execFileAsync('docker', [
+                'cp',
+                `${containerId}:/output/.`,
+                `${this.outputFolder}/`,
+            ]);
+            return null;
+        } catch (err) {
+            return err;
+        }
+    }
+
+    readExecutionResult(timedOut, copyError) {
+        const errorsPath = path.join(this.outputFolder, 'errors');
+        const completedPath = path.join(this.outputFolder, 'completed');
+        const partialPath = path.join(this.outputFolder, 'logfile.txt');
+
+        let errors = this.readFileIfPresent(errorsPath);
+        let output = this.readFileIfPresent(completedPath) || this.readFileIfPresent(partialPath);
+
+        if(!output && copyError) {
+            errors = [errors, this.formatExecutionError(copyError)].filter(Boolean).join('\n');
+        }
+
+        if(timedOut) {
+            output = output || "";
+            if(output && !output.endsWith('\n')) {
+                output += '\n';
+            }
+            output += `Execution Timed Out. Maximum allowed time is ${this.timeoutValue} seconds.`;
+        }
+
+        return { errors, output };
+    }
+
+    readFileIfPresent(filePath) {
+        if(!fs.existsSync(filePath)) {
+            return "";
+        }
+        return fs.readFileSync(filePath, 'utf8');
+    }
+
+    async stopContainer(containerId) {
+        try {
+            await execFileAsync('docker', ['kill', containerId]);
+        } catch {}
+    }
+
+    async removeContainer(containerId) {
+        if(!containerId) {
+            return;
+        }
+
+        try {
+            await execFileAsync('docker', ['rm', '-f', containerId]);
+        } catch {}
+    }
+
+    isTimeoutError(err) {
+        return Number(err?.code) === 124;
+    }
+
+    formatExecutionError(err) {
+        const detail = err?.stderr?.trim() || err?.message || String(err);
+        return `Internal problem executing generated code. ${detail}`;
     }
 
     getNormalizedMainFilename() {
-        let path = this.path;
-        if(path.startsWith('/')) {
-            path = path.substring(1);
+        let mainPath = this.path;
+        if(mainPath.startsWith('/')) {
+            mainPath = mainPath.substring(1);
         }
-        if(path.endsWith('/')) {
-            path = path.substring(0, path.length - 1);
+        if(mainPath.endsWith('/')) {
+            mainPath = mainPath.substring(0, mainPath.length - 1);
         }
         if(this.language=="Python"){
-            return path ? `${path}/${this.mainFile}.py` : `${this.mainFile}.py`;
+            return mainPath ? `${mainPath}/${this.mainFile}.py` : `${this.mainFile}.py`;
         }
-        return path ? `${path.split('/').join('.')}.${this.mainFile}` : this.mainFile;    
+        return mainPath ? `${mainPath.split('/').join('.')}.${this.mainFile}` : this.mainFile;
     }
 
-    listenToChanges(callback) {
-        //variable to enforce the timeout_value
-        let timeValue = 0;
-
-        // Check For File named "completed" or "errors" after every 1 second
-        const intid = setInterval(() => {
-            timeValue++;
-        
-            // Listen for the completed file
-            fs.readFile(this.outputFolder + '/completed', 'utf8', (err, completeData) => {
-                // if file is not available yet and the file interval is not yet up carry on
-                // else if file is found simply display a message and proceed
-                if(err && timeValue < this.timeoutValue) {
-                    return;
-                } else if (timeValue < this.timeoutValue) {
-                    //check for possible errors
-                    fs.readFile(this.outputFolder + '/errors', 'utf8', (err, errorData) => {
-                        if(errorData) {
-                            console.log("Error file: ", errorData)
-                        }
-                        console.log("Complete file: \n", completeData);
-
-                        callback(errorData, completeData.toString())
-                    });
-                } else { 
-                    // if time is up. Save an error message to the data variable
-                    // Since the time is up, we take the partial output and return it.
-                    fs.readFile(this.outputFolder + '/logfile.txt', 'utf8', (err, partialData) => {
-                        if (!partialData) partialData = "";
-                        partialData += "\nExecution Timed Out. Maximum allowed time is " + this.timeoutValue + " seconds.";
-
-                        fs.readFile(this.outputFolder + '/errors', 'utf8', (err, errorData) => {
-                            callback(errorData ,partialData.toString())
-                        });
-                    });
-                }
-
-                // If time is finished, remove directory and clear timer
-                this.deleteOutputFolder();
-                clearInterval(intid);
-            });
-        }, 1000);
-    }
-
-    
     makeOutputFolder() {
-        if(fs.existsSync(this.outputFolder)) {
-            this.deleteOutputFolder();
-        } else {
-            fs.mkdirSync(this.outputFolder);
-        }
+        fs.mkdirSync(this.baseOutputPath, { recursive: true });
+        this.outputFolder = fs.mkdtempSync(path.join(this.baseOutputPath, `${this.getOutputPrefix()}-`));
     }
 
     deleteOutputFolder() {
+        if(!this.outputFolder) {
+            return;
+        }
+
         try {
             console.log("ATTEMPTING TO REMOVE: " + this.outputFolder);
             fs.rmSync(this.outputFolder, { recursive: true });
             console.log(`${this.outputFolder} is deleted!`);
         } catch (err) {
             console.error(`Error while deleting ${this.outputFolder}.`);
+        } finally {
+            this.outputFolder = null;
         }
     }
 
+    getOutputPrefix() {
+        const modelName = path.basename(this.model) || "model";
+        return `umple-exec-${modelName}-${this.mainFile}`.replace(/[^A-Za-z0-9._-]/g, '_');
+    }
+
     readConfig() {
-        const file = fs.readFileSync('./config.cfg', 'utf8');
+        const file = fs.readFileSync(path.join(__dirname, 'config.cfg'), 'utf8');
         const config = file.toString().replace(/\r\n/g,'\n').split('\n');
         
         const obj = {};

--- a/code-exec/javaRunner/Dockerfile
+++ b/code-exec/javaRunner/Dockerfile
@@ -12,8 +12,8 @@ COPY javaRunner/javaRunner.sh /
 RUN chmod +x /javaRunner.sh
 RUN chown -R nodeuser /output
 RUN chown -R nodeuser /input
-RUN chmod -R u=rwx /output
-RUN chmod -R u=r /input
+RUN chmod 700 /output
+RUN chmod 755 /input
 
 USER nodeuser
 

--- a/frontend/src/components/editor/ExecutionPanel.tsx
+++ b/frontend/src/components/editor/ExecutionPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState, useCallback } from 'react'
+import { useRef, useEffect, useState, useCallback, useMemo } from 'react'
 import { useEphemeralStore } from '../../stores/ephemeralStore'
 import type { ParsedIssue } from '../../stores/ephemeralStore'
 import { useSessionStore } from '../../stores/sessionStore'
@@ -39,6 +39,46 @@ function triggerAIFix() {
     `Fix the following compilation issues:\n\n\`\`\`\n${errorInfo}\n\`\`\``,
   )
   useSessionStore.getState().openAgentPanel()
+}
+
+interface ExecutionSection {
+  heading: string | null
+  body: string
+}
+
+const MAIN_METHOD_HEADING_RE = /^<strong>(For main method in class .*?:)<\/strong>\n?/gm
+
+function parseExecutionSections(output: string): ExecutionSection[] | null {
+  const matches = Array.from(output.matchAll(MAIN_METHOD_HEADING_RE))
+  if (!matches.length) return null
+
+  const sections: ExecutionSection[] = []
+  let cursor = 0
+
+  for (let i = 0; i < matches.length; i += 1) {
+    const match = matches[i]
+    const start = match.index ?? 0
+    const bodyStart = start + match[0].length
+    const bodyEnd = matches[i + 1]?.index ?? output.length
+
+    if (start > cursor) {
+      sections.push({ heading: null, body: output.slice(cursor, start) })
+    }
+
+    sections.push({
+      heading: match[1] ?? null,
+      // The backend always inserts one newline after the heading marker.
+      body: output.slice(bodyStart, bodyEnd).replace(/^\n/, ''),
+    })
+
+    cursor = bodyEnd
+  }
+
+  if (cursor < output.length) {
+    sections.push({ heading: null, body: output.slice(cursor) })
+  }
+
+  return sections.filter((section) => section.heading || section.body)
 }
 
 // ── Shared badge pills ──────────────────────────────────────────────
@@ -212,6 +252,7 @@ export function OutputPanel() {
   const isAiConfigured = useIsAiConfigured()
   const hasIssues = errorCount > 0 || warningCount > 0
   const [copied, setCopied] = useState(false)
+  const executionSections = useMemo(() => parseExecutionSections(executionOutput), [executionOutput])
 
   const hasContent = !!(executionOutput || executionErrors)
 
@@ -283,9 +324,31 @@ export function OutputPanel() {
         className="flex-1 overflow-auto bg-surface-0"
       >
         {executionOutput && (
-          <pre className="m-0 whitespace-pre-wrap break-words px-2.5 pt-2.5 font-mono text-xs leading-relaxed text-ink">
-            {executionOutput}
-          </pre>
+          executionSections ? (
+            <div className="flex flex-col gap-3 px-2.5 py-2.5">
+              {executionSections.map((section, index) => (
+                <section
+                  key={`${section.heading ?? 'body'}-${index}`}
+                  className={cn(section.heading && index > 0 && 'border-t border-border/70 pt-3')}
+                >
+                  {section.heading && (
+                    <h3 className="mb-1.5 text-xs font-semibold text-ink">
+                      {section.heading}
+                    </h3>
+                  )}
+                  {section.body && (
+                    <pre className="m-0 whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-ink">
+                      {section.body}
+                    </pre>
+                  )}
+                </section>
+              ))}
+            </div>
+          ) : (
+            <pre className="m-0 whitespace-pre-wrap break-words px-2.5 pt-2.5 font-mono text-xs leading-relaxed text-ink">
+              {executionOutput}
+            </pre>
+          )
         )}
         {parsedIssues.length > 0 && (
           <div className="flex flex-col gap-px px-1.5 py-1.5">

--- a/frontend/src/components/editor/__tests__/ExecutionPanel.test.tsx
+++ b/frontend/src/components/editor/__tests__/ExecutionPanel.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { OutputPanel } from '../ExecutionPanel'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { useEphemeralStore } from '@/stores/ephemeralStore'
+
+function resetExecutionState() {
+  useEphemeralStore.setState({
+    executing: false,
+    executionOutput: '',
+    executionErrors: null,
+    parsedIssues: [],
+    rawErrorText: '',
+    outputErrorCount: 0,
+    outputWarningCount: 0,
+  })
+}
+
+describe('ExecutionPanel', () => {
+  afterEach(() => {
+    cleanup()
+    resetExecutionState()
+  })
+
+  it('renders execution headings as structured text instead of raw html', () => {
+    useEphemeralStore.setState({
+      executionOutput: '<strong>For main method in class Shape2D:</strong>\n\nJava result:\nhello world\n',
+    })
+
+    render(
+      <TooltipProvider>
+        <OutputPanel />
+      </TooltipProvider>,
+    )
+
+    expect(screen.getByText('For main method in class Shape2D:')).toBeTruthy()
+    expect(screen.getByText(/Java result:/)).toBeTruthy()
+    expect(screen.queryByText(/<strong>For main method in class Shape2D:/)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- restore code execution by replacing the broken nested bind-mount flow with container copy and wait handling
- run the code-exec service with Docker socket access and fix runner permissions for copied input/output
- render execution headings in the output panel as structured text instead of showing raw HTML

## Test plan
- python3 script POST to http://localhost:3001/api/execute with examples/2DShapes.ump and language=Java
- cd frontend && bun run test -- src/components/editor/__tests__/ExecutionPanel.test.tsx
- cd frontend && bun x tsc -b --pretty false