### PR TITLE
fix: pin code runner image for execution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ EXECUTION_URL=http://code-exec:4400
 # CORS (comma-separated origins for production)
 ALLOWED_ORIGINS=https://your-domain.example.com
 
+# Published nested runner image used by code-exec for Java/Python execution
+CODE_RUNNER_IMAGE=ghcr.io/umple/umpleonline/code-runner:latest
+
 # Production frontend host bind
 FRONTEND_BIND_HOST=127.0.0.1
 FRONTEND_HOST_PORT=3100

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -133,6 +133,28 @@ jobs:
           sbom: true
           provenance: true
 
+      - name: Build and push code-runner
+        id: code_runner_build
+        uses: docker/build-push-action@v6
+        with:
+          context: code-exec
+          file: code-exec/javaRunner/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.prefix }}/code-runner:${{ steps.meta.outputs.sha_tag }}
+            ${{ steps.meta.outputs.prefix }}/code-runner:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.resolve.outputs.sha }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+            org.opencontainers.image.vendor=University of Ottawa
+            org.opencontainers.image.description=UmpleOnline sandbox runner image for code execution
+          cache-from: type=gha,scope=code-runner
+          cache-to: type=gha,mode=max,scope=code-runner
+          sbom: true
+          provenance: true
+
       - name: Build and push collab
         id: collab_build
         uses: docker/build-push-action@v6
@@ -206,6 +228,16 @@ jobs:
           severity: CRITICAL
           exit-code: '1'
 
+      - name: Scan code-runner image
+        uses: aquasecurity/trivy-action@v0.35.0
+        with:
+          image-ref: ${{ steps.meta.outputs.prefix }}/code-runner@${{ steps.code_runner_build.outputs.digest }}
+          version: v0.69.3
+          format: table
+          ignore-unfixed: true
+          severity: CRITICAL
+          exit-code: '1'
+
       - name: Scan collab image
         uses: aquasecurity/trivy-action@v0.35.0
         with:
@@ -234,6 +266,7 @@ jobs:
           cosign sign --yes "${{ steps.meta.outputs.prefix }}/backend@${{ steps.backend_build.outputs.digest }}"
           cosign sign --yes "${{ steps.meta.outputs.prefix }}/frontend@${{ steps.frontend_build.outputs.digest }}"
           cosign sign --yes "${{ steps.meta.outputs.prefix }}/code-exec@${{ steps.code_exec_build.outputs.digest }}"
+          cosign sign --yes "${{ steps.meta.outputs.prefix }}/code-runner@${{ steps.code_runner_build.outputs.digest }}"
           cosign sign --yes "${{ steps.meta.outputs.prefix }}/collab@${{ steps.collab_build.outputs.digest }}"
           cosign sign --yes "${{ steps.meta.outputs.prefix }}/lsp-proxy@${{ steps.lsp_proxy_build.outputs.digest }}"
 
@@ -245,11 +278,13 @@ jobs:
             echo "- Backend: \`${{ steps.meta.outputs.prefix }}/backend:${{ steps.meta.outputs.sha_tag }}\`"
             echo "- Frontend: \`${{ steps.meta.outputs.prefix }}/frontend:${{ steps.meta.outputs.sha_tag }}\`"
             echo "- Code Exec: \`${{ steps.meta.outputs.prefix }}/code-exec:${{ steps.meta.outputs.sha_tag }}\`"
+            echo "- Code Runner: \`${{ steps.meta.outputs.prefix }}/code-runner:${{ steps.meta.outputs.sha_tag }}\`"
             echo "- Collab: \`${{ steps.meta.outputs.prefix }}/collab:${{ steps.meta.outputs.sha_tag }}\`"
             echo "- LSP Proxy: \`${{ steps.meta.outputs.prefix }}/lsp-proxy:${{ steps.meta.outputs.sha_tag }}\`"
             echo "- Signed backend digest: \`${{ steps.meta.outputs.prefix }}/backend@${{ steps.backend_build.outputs.digest }}\`"
             echo "- Signed frontend digest: \`${{ steps.meta.outputs.prefix }}/frontend@${{ steps.frontend_build.outputs.digest }}\`"
             echo "- Signed code-exec digest: \`${{ steps.meta.outputs.prefix }}/code-exec@${{ steps.code_exec_build.outputs.digest }}\`"
+            echo "- Signed code-runner digest: \`${{ steps.meta.outputs.prefix }}/code-runner@${{ steps.code_runner_build.outputs.digest }}\`"
             echo "- Signed collab digest: \`${{ steps.meta.outputs.prefix }}/collab@${{ steps.collab_build.outputs.digest }}\`"
             echo "- Signed lsp-proxy digest: \`${{ steps.meta.outputs.prefix }}/lsp-proxy@${{ steps.lsp_proxy_build.outputs.digest }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
             echo "backend_image=${PREFIX}/backend:sha-${SHA}"
             echo "frontend_image=${PREFIX}/frontend:sha-${SHA}"
             echo "code_exec_image=${PREFIX}/code-exec:sha-${SHA}"
+            echo "code_runner_image=${PREFIX}/code-runner:sha-${SHA}"
             echo "collab_image=${PREFIX}/collab:sha-${SHA}"
             echo "lsp_proxy_image=${PREFIX}/lsp-proxy:sha-${SHA}"
           } >> "$GITHUB_OUTPUT"
@@ -122,6 +123,7 @@ jobs:
           docker buildx imagetools inspect "${{ steps.meta.outputs.backend_image }}" > /dev/null
           docker buildx imagetools inspect "${{ steps.meta.outputs.frontend_image }}" > /dev/null
           docker buildx imagetools inspect "${{ steps.meta.outputs.code_exec_image }}" > /dev/null
+          docker buildx imagetools inspect "${{ steps.meta.outputs.code_runner_image }}" > /dev/null
           docker buildx imagetools inspect "${{ steps.meta.outputs.collab_image }}" > /dev/null
           docker buildx imagetools inspect "${{ steps.meta.outputs.lsp_proxy_image }}" > /dev/null
 
@@ -155,6 +157,7 @@ jobs:
               "${{ steps.meta.outputs.backend_image }}" \
               "${{ steps.meta.outputs.frontend_image }}" \
               "${{ steps.meta.outputs.code_exec_image }}" \
+              "${{ steps.meta.outputs.code_runner_image }}" \
               "${{ steps.meta.outputs.collab_image }}" \
               "${{ steps.meta.outputs.lsp_proxy_image }}"
 
@@ -173,6 +176,7 @@ jobs:
           - \`${{ steps.meta.outputs.backend_image }}\`
           - \`${{ steps.meta.outputs.frontend_image }}\`
           - \`${{ steps.meta.outputs.code_exec_image }}\`
+          - \`${{ steps.meta.outputs.code_runner_image }}\`
           - \`${{ steps.meta.outputs.collab_image }}\`
           - \`${{ steps.meta.outputs.lsp_proxy_image }}\`
           EOF
@@ -210,6 +214,7 @@ jobs:
             echo "- Backend: \`${{ steps.meta.outputs.backend_image }}\`"
             echo "- Frontend: \`${{ steps.meta.outputs.frontend_image }}\`"
             echo "- Code Exec: \`${{ steps.meta.outputs.code_exec_image }}\`"
+            echo "- Code Runner: \`${{ steps.meta.outputs.code_runner_image }}\`"
             echo "- Collab: \`${{ steps.meta.outputs.collab_image }}\`"
             echo "- LSP Proxy: \`${{ steps.meta.outputs.lsp_proxy_image }}\`"
             echo "- Updated latest release pointer: \`${{ steps.latest.outputs.mark_latest }}\`"

--- a/backend/internal/api/handlers/compile.go
+++ b/backend/internal/api/handlers/compile.go
@@ -100,6 +100,7 @@ func (h *GenerateHandler) Generate(w http.ResponseWriter, r *http.Request) {
 
 	unlock := lockModelWorkspace(h.pool, h.store, req.ModelID)
 	defer unlock()
+	workspaceLocked := req.ModelID != ""
 
 	// Ensure model directory exists (single resolveModel for both compile + diagram)
 	modelID, dir, err := resolveModel(h.store, req.ModelID, entryCode, entryFile)
@@ -133,7 +134,11 @@ func (h *GenerateHandler) Generate(w http.ResponseWriter, r *http.Request) {
 
 	// Generate the authoritative JSON model using umplesync
 	command := fmt.Sprintf("-generate Json %s/%s", dir, entryFile)
-	result, err := h.pool.Execute(compiler.CompileRequest{
+	execute := h.pool.Execute
+	if workspaceLocked {
+		execute = h.pool.ExecuteLocked
+	}
+	result, err := execute(compiler.CompileRequest{
 		Command: command,
 		WorkDir: dir,
 	})
@@ -167,6 +172,7 @@ func (h *GenerateHandler) Generate(w http.ResponseWriter, r *http.Request) {
 			suboptions:  req.Suboptions,
 			needsLayout: needsLayout,
 			entryFile:   entryFile,
+			locked:      workspaceLocked,
 		})
 		if errMsg != "" {
 			log.Printf("diagram generation failed during output generation: %s", errMsg)

--- a/backend/internal/api/handlers/diagram.go
+++ b/backend/internal/api/handlers/diagram.go
@@ -314,6 +314,7 @@ type processDiagramParams struct {
 	suboptions  []string
 	needsLayout bool
 	entryFile   string
+	locked      bool
 }
 
 // processDiagram generates a diagram from a model directory that already
@@ -350,7 +351,11 @@ func processDiagram(p processDiagramParams) (*DiagramResponse, string) {
 			command += " -s " + opt
 		}
 	}
-	result, err := p.pool.Execute(compiler.CompileRequest{
+	execute := p.pool.Execute
+	if p.locked {
+		execute = p.pool.ExecuteLocked
+	}
+	result, err := execute(compiler.CompileRequest{
 		Command: command,
 		WorkDir: p.dir,
 	})

--- a/backend/internal/compiler/pool.go
+++ b/backend/internal/compiler/pool.go
@@ -44,11 +44,22 @@ func NewPool(jarPath string, port int) (*Pool, error) {
 // Execute sends a command to the umplesync server and returns the result.
 // It acquires a per-model lock to prevent concurrent writes.
 func (p *Pool) Execute(req CompileRequest) (*CompileResult, error) {
-	// Acquire per-model lock
 	mu := p.getModelMutex(req.WorkDir)
 	mu.Lock()
 	defer mu.Unlock()
 
+	return p.execute(req)
+}
+
+// ExecuteLocked sends a command while assuming the caller already holds the
+// per-model lock for req.WorkDir via LockModel. This avoids self-deadlocking
+// flows that need to hold the workspace lock across filesystem writes and the
+// compiler invocation as one atomic operation.
+func (p *Pool) ExecuteLocked(req CompileRequest) (*CompileResult, error) {
+	return p.execute(req)
+}
+
+func (p *Pool) execute(req CompileRequest) (*CompileResult, error) {
 	// Ensure server is running
 	if err := p.ensureRunning(); err != nil {
 		return nil, fmt.Errorf("compiler not available: %w", err)

--- a/code-exec/README.md
+++ b/code-exec/README.md
@@ -1,6 +1,6 @@
 # Umple Code Execution
 
-This code base provides the functionality to securely execute Java code using Docker containers.
+This code base provides the functionality to securely execute generated Java and Python code using Docker containers.
 
 # IMPORTANT
 
@@ -25,7 +25,7 @@ A directory where temporary files can be written. Suggested: /tmp
 Name of the always running container and image. Use the default unless you are running more than one instance.
 
 **tempContainerName**  
-Name of the temporary java container and image created for Java execution. Use the default unless you are running more than one instance.
+Default local runner image used for code execution in development. Production should prefer the `EXECUTION_RUNNER_IMAGE` environment variable so deploys can pin an immutable published runner image.
 
 **portToUse**  
 Port that the Umple Php code uses to communicate with the Docker image. Suggested: 4400. If you are running more than one instance, then each would need a new port.
@@ -41,3 +41,12 @@ This shell script contains commands to build docker images and to run the main d
 # Other Issues
 
 1. If timeout is coming even though the docker is running, make sure that umplePath in config.cfg does not start with '~'.
+
+## Production note
+
+In this repo's containerized deployment, the `code-exec` service is the coordinator and launches a separate runner image for each execution. Production should set:
+
+- `EXECUTION_RUNNER_IMAGE` to a published immutable image ref
+- `EXECUTION_RUNNER_AUTO_BUILD=0`
+
+Development may keep auto-build enabled to create the local runner image on first use.

--- a/code-exec/config.cfg
+++ b/code-exec/config.cfg
@@ -1,6 +1,6 @@
 umplePath=/data/models
 tempPath=/tmp
 mainContainerName=code_execution
-tempContainerName=java_execution
+tempContainerName=umple-code-runner:dev
 portToUse=4400
 timeoutValue=20

--- a/code-exec/dockerExecution.js
+++ b/code-exec/dockerExecution.js
@@ -5,6 +5,64 @@ const { execFile } = require('child_process');
 const { promisify } = require('util');
 
 const execFileAsync = promisify(execFile);
+const runnerImageBuilds = new Map();
+
+function readBooleanEnv(name, fallback) {
+    const value = process.env[name];
+    if(value == null || value === '') {
+        return fallback;
+    }
+
+    return ['1', 'true', 'yes', 'on'].includes(String(value).toLowerCase());
+}
+
+async function ensureRunnerImage(imageName, autoBuild) {
+    if(!imageName) {
+        throw new Error('execution runner image name is not configured');
+    }
+
+    const existing = runnerImageBuilds.get(imageName);
+    if(existing) {
+        await existing;
+        return;
+    }
+
+    const buildPromise = (async () => {
+        try {
+            await execFileAsync('docker', ['image', 'inspect', imageName]);
+            return;
+        } catch {}
+
+        if(!autoBuild) {
+            throw new Error(
+                `Execution runner image ${imageName} is not available locally. ` +
+                'Ensure the deployment pulled CODE_RUNNER_IMAGE before serving traffic.',
+            );
+        }
+
+        const dockerfilePath = path.join(__dirname, 'javaRunner', 'Dockerfile');
+        console.log(`Execution runner image ${imageName} not found locally. Building it now...`);
+
+        await execFileAsync(
+            'docker',
+            ['build', '-q', '-t', imageName, '-f', dockerfilePath, __dirname],
+            { maxBuffer: 10 * 1024 * 1024 },
+        );
+
+        await execFileAsync('docker', ['image', 'inspect', imageName]);
+        console.log(`Execution runner image ${imageName} is ready.`);
+    })();
+
+    runnerImageBuilds.set(imageName, buildPromise);
+
+    try {
+        await buildPromise;
+    } finally {
+        if(runnerImageBuilds.get(imageName) === buildPromise) {
+            runnerImageBuilds.delete(imageName);
+        }
+    }
+}
 
 class DockerExecution {
     constructor(pathToMainClass, mainFile, modelPath, language="Java") {
@@ -16,7 +74,11 @@ class DockerExecution {
 
         const config = this.readConfig();
         this.baseOutputPath = config['tempPath'] || os.tmpdir();
-        this.tempContainerName = config['tempContainerName'];
+        this.runnerImage = process.env.EXECUTION_RUNNER_IMAGE || config['tempContainerName'];
+        this.autoBuildRunner = readBooleanEnv(
+            'EXECUTION_RUNNER_AUTO_BUILD',
+            !Object.prototype.hasOwnProperty.call(process.env, 'EXECUTION_RUNNER_IMAGE'),
+        );
         this.timeoutValue = +config['timeoutValue'];
     }
 
@@ -50,13 +112,15 @@ class DockerExecution {
     }
 
     async createContainer(mainFilePath) {
+        await ensureRunnerImage(this.runnerImage, this.autoBuildRunner);
+
         const { stdout } = await execFileAsync('docker', [
             'create',
             '--cpus=0.5',
             '--memory=150m',
             '--network',
             'none',
-            this.tempContainerName,
+            this.runnerImage,
             mainFilePath,
         ]);
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -111,6 +111,9 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./data/models:/data/models
+    environment:
+      - EXECUTION_RUNNER_IMAGE=${CODE_RUNNER_IMAGE:-ghcr.io/umple/umpleonline/code-runner:latest}
+      - EXECUTION_RUNNER_AUTO_BUILD=0
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:4400/health"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,9 @@ services:
       context: ./code-exec
     ports:
       - "4400:4400"
+    environment:
+      - EXECUTION_RUNNER_IMAGE=${CODE_RUNNER_IMAGE:-umple-code-runner:dev}
+      - EXECUTION_RUNNER_AUTO_BUILD=1
     group_add:
       - "${DOCKER_GID:-0}"
     volumes:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-DEPLOY_PATH="${1:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <collab-image> <lsp-proxy-image>}"
-BACKEND_IMAGE="${2:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <collab-image> <lsp-proxy-image>}"
-FRONTEND_IMAGE="${3:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <collab-image> <lsp-proxy-image>}"
-CODE_EXEC_IMAGE="${4:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <collab-image> <lsp-proxy-image>}"
-COLLAB_IMAGE="${5:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <collab-image> <lsp-proxy-image>}"
-LSP_PROXY_IMAGE="${6:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <collab-image> <lsp-proxy-image>}"
+DEPLOY_PATH="${1:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
+BACKEND_IMAGE="${2:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
+FRONTEND_IMAGE="${3:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
+CODE_EXEC_IMAGE="${4:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
+CODE_RUNNER_IMAGE="${5:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
+COLLAB_IMAGE="${6:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
+LSP_PROXY_IMAGE="${7:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
 
 compose() {
   if docker compose version >/dev/null 2>&1; then
@@ -72,7 +73,7 @@ rollback_release() {
   ROLLBACK_ARMED=0
   echo "==> Release failed. Attempting automatic rollback..."
 
-  if [ -z "${PREVIOUS_BACKEND_IMAGE:-}" ] || [ -z "${PREVIOUS_FRONTEND_IMAGE:-}" ] || [ -z "${PREVIOUS_CODE_EXEC_IMAGE:-}" ] || [ -z "${PREVIOUS_COLLAB_IMAGE:-}" ] || [ -z "${PREVIOUS_LSP_PROXY_IMAGE:-}" ]; then
+  if [ -z "${PREVIOUS_BACKEND_IMAGE:-}" ] || [ -z "${PREVIOUS_FRONTEND_IMAGE:-}" ] || [ -z "${PREVIOUS_CODE_EXEC_IMAGE:-}" ] || [ -z "${PREVIOUS_CODE_RUNNER_IMAGE:-}" ] || [ -z "${PREVIOUS_COLLAB_IMAGE:-}" ] || [ -z "${PREVIOUS_LSP_PROXY_IMAGE:-}" ]; then
     echo "WARNING: No previous image references were found in .env. Manual rollback required."
     exit "$exit_code"
   fi
@@ -80,11 +81,13 @@ rollback_release() {
   upsert_env "BACKEND_IMAGE" "$PREVIOUS_BACKEND_IMAGE" .env
   upsert_env "FRONTEND_IMAGE" "$PREVIOUS_FRONTEND_IMAGE" .env
   upsert_env "CODE_EXEC_IMAGE" "$PREVIOUS_CODE_EXEC_IMAGE" .env
+  upsert_env "CODE_RUNNER_IMAGE" "$PREVIOUS_CODE_RUNNER_IMAGE" .env
   upsert_env "COLLAB_IMAGE" "$PREVIOUS_COLLAB_IMAGE" .env
   upsert_env "LSP_PROXY_IMAGE" "$PREVIOUS_LSP_PROXY_IMAGE" .env
   upsert_env "DOCKER_GID" "$DOCKER_GID" .env
 
   compose -f docker-compose.prod.yml pull || true
+  docker pull "$PREVIOUS_CODE_RUNNER_IMAGE" || true
   compose -f docker-compose.prod.yml up -d --remove-orphans || true
   compose -f docker-compose.prod.yml ps || true
 
@@ -189,12 +192,14 @@ DOCKER_GID="$(stat -c '%g' /var/run/docker.sock)"
 PREVIOUS_BACKEND_IMAGE="$(read_env_value "BACKEND_IMAGE" .env || true)"
 PREVIOUS_FRONTEND_IMAGE="$(read_env_value "FRONTEND_IMAGE" .env || true)"
 PREVIOUS_CODE_EXEC_IMAGE="$(read_env_value "CODE_EXEC_IMAGE" .env || true)"
+PREVIOUS_CODE_RUNNER_IMAGE="$(read_env_value "CODE_RUNNER_IMAGE" .env || true)"
 PREVIOUS_COLLAB_IMAGE="$(read_env_value "COLLAB_IMAGE" .env || true)"
 PREVIOUS_LSP_PROXY_IMAGE="$(read_env_value "LSP_PROXY_IMAGE" .env || true)"
 
 upsert_env "BACKEND_IMAGE" "$BACKEND_IMAGE" .env
 upsert_env "FRONTEND_IMAGE" "$FRONTEND_IMAGE" .env
 upsert_env "CODE_EXEC_IMAGE" "$CODE_EXEC_IMAGE" .env
+upsert_env "CODE_RUNNER_IMAGE" "$CODE_RUNNER_IMAGE" .env
 upsert_env "COLLAB_IMAGE" "$COLLAB_IMAGE" .env
 upsert_env "LSP_PROXY_IMAGE" "$LSP_PROXY_IMAGE" .env
 upsert_env "DOCKER_GID" "$DOCKER_GID" .env
@@ -203,6 +208,7 @@ echo "==> Releasing images:"
 echo "    BACKEND_IMAGE=$BACKEND_IMAGE"
 echo "    FRONTEND_IMAGE=$FRONTEND_IMAGE"
 echo "    CODE_EXEC_IMAGE=$CODE_EXEC_IMAGE"
+echo "    CODE_RUNNER_IMAGE=$CODE_RUNNER_IMAGE"
 echo "    COLLAB_IMAGE=$COLLAB_IMAGE"
 echo "    LSP_PROXY_IMAGE=$LSP_PROXY_IMAGE"
 echo "    DOCKER_GID=$DOCKER_GID"
@@ -224,6 +230,7 @@ ROLLBACK_ARMED=1
 
 echo "==> Pulling release images..."
 compose -f docker-compose.prod.yml pull
+docker pull "$CODE_RUNNER_IMAGE"
 
 echo "==> Restarting services..."
 compose -f docker-compose.prod.yml up -d --remove-orphans


### PR DESCRIPTION
## Summary
- publish the nested `code-runner` image alongside the other production images
- pass the pinned runner image through release and compose config so `code-exec` launches a deterministic runtime
- avoid self-deadlocking generate and diagram flows when they already hold the model workspace lock

## Test plan
- `node --check code-exec/dockerExecution.js`
- `bash -n scripts/release.sh`
- `docker-compose -f docker-compose.prod.yml config`
- `docker-compose config`
- `go test ./backend/internal/api/handlers/... ./backend/internal/compiler/...` *(blocked here: `go` is not installed in this environment)*
