### PR TITLE
fix: contain umplesync runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,15 @@ test-results/
 *.tsbuildinfo
 
 # Runtime state
+versionRunning.txt
+commandcount.txt
+txl/
 backend/versionRunning.txt
 backend/commandcount.txt
+backend/txl/
+backend/internal/api/handlers/versionRunning.txt
+backend/internal/api/handlers/commandcount.txt
+backend/internal/api/handlers/txl/
 
 # Data — all model directories are runtime artifacts
 data/models/

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -25,7 +26,11 @@ func main() {
 		log.Fatalf("failed to initialize model store: %v", err)
 	}
 
-	pool, err := compiler.NewPool(cfg.UmpleSyncJar, cfg.UmplePort)
+	pool, err := compiler.NewPoolWithWorkDir(
+		cfg.UmpleSyncJar,
+		cfg.UmplePort,
+		filepath.Join(cfg.ModelStorePath, ".compiler"),
+	)
 	if err != nil {
 		log.Fatalf("failed to initialize compiler pool: %v", err)
 	}

--- a/backend/internal/compiler/pool.go
+++ b/backend/internal/compiler/pool.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -14,6 +16,10 @@ const (
 	restartDelay      = 2 * time.Second
 	startupMaxRetries = 20
 	startupPollDelay  = 250 * time.Millisecond
+
+	compilerVersionFilename      = "versionRunning.txt"
+	compilerCommandCountFilename = "commandcount.txt"
+	compilerTXLDir               = "txl"
 )
 
 // Pool manages a long-running umplesync.jar server process and provides
@@ -21,6 +27,7 @@ const (
 type Pool struct {
 	jarPath string
 	port    int
+	workDir string
 
 	mu      sync.Mutex
 	process *exec.Cmd
@@ -31,14 +38,30 @@ type Pool struct {
 }
 
 func NewPool(jarPath string, port int) (*Pool, error) {
+	return NewPoolWithWorkDir(jarPath, port, "")
+}
+
+// NewPoolWithWorkDir starts the compiler pool and pins the long-running
+// umplesync server to a dedicated working directory so helper artifacts stay
+// out of the caller's current directory.
+func NewPoolWithWorkDir(jarPath string, port int, workDir string) (*Pool, error) {
+	if workDir == "" {
+		workDir = defaultCompilerWorkDir(port)
+	}
+
 	p := &Pool{
 		jarPath: jarPath,
 		port:    port,
+		workDir: workDir,
 	}
 	if err := p.startServer(); err != nil {
 		log.Printf("warning: failed to start umplesync server: %v (will retry on first request)", err)
 	}
 	return p, nil
+}
+
+func defaultCompilerWorkDir(port int) string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("umpleonline-compiler-%d", port))
 }
 
 // Execute sends a command to the umplesync server and returns the result.
@@ -94,7 +117,12 @@ func (p *Pool) startServer() error {
 		p.process.Wait()
 	}
 
-	cmd := exec.Command("java", "-cp", p.jarPath, "cruise.umple.PlaygroundMain", "-server", fmt.Sprintf("%d", p.port))
+	if err := p.prepareWorkDir(); err != nil {
+		p.alive = false
+		return fmt.Errorf("prepare compiler work dir: %w", err)
+	}
+
+	cmd := p.serverCommand()
 	if err := cmd.Start(); err != nil {
 		p.alive = false
 		return fmt.Errorf("failed to start umplesync: %w", err)
@@ -126,6 +154,30 @@ func (p *Pool) startServer() error {
 	}
 
 	return fmt.Errorf("umplesync server did not become ready within %v", startupMaxRetries*startupPollDelay)
+}
+
+func (p *Pool) serverCommand() *exec.Cmd {
+	cmd := exec.Command("java", "-cp", p.jarPath, "cruise.umple.PlaygroundMain", "-server", fmt.Sprintf("%d", p.port))
+	cmd.Dir = p.workDir
+	return cmd
+}
+
+func (p *Pool) prepareWorkDir() error {
+	if err := os.MkdirAll(p.workDir, 0755); err != nil {
+		return err
+	}
+
+	for _, name := range []string{
+		compilerVersionFilename,
+		compilerCommandCountFilename,
+		compilerTXLDir,
+	} {
+		if err := os.RemoveAll(filepath.Join(p.workDir, name)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (p *Pool) ensureRunning() error {

--- a/backend/internal/compiler/pool_test.go
+++ b/backend/internal/compiler/pool_test.go
@@ -1,0 +1,57 @@
+package compiler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestServerCommandUsesConfiguredWorkDir(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "compiler")
+	pool := &Pool{
+		jarPath: "/tmp/umplesync.jar",
+		port:    5555,
+		workDir: workDir,
+	}
+
+	cmd := pool.serverCommand()
+
+	if cmd.Dir != workDir {
+		t.Fatalf("expected compiler server cwd %q, got %q", workDir, cmd.Dir)
+	}
+}
+
+func TestPrepareWorkDirClearsCompilerArtifacts(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "compiler")
+	if err := os.MkdirAll(filepath.Join(workDir, compilerTXLDir), 0755); err != nil {
+		t.Fatalf("mkdir txl dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, compilerVersionFilename), []byte("@UMPLE_VERSION@"), 0644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, compilerCommandCountFilename), []byte("1"), 0644); err != nil {
+		t.Fatalf("write command count file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "keep.txt"), []byte("keep"), 0644); err != nil {
+		t.Fatalf("write keep file: %v", err)
+	}
+
+	pool := &Pool{workDir: workDir}
+	if err := pool.prepareWorkDir(); err != nil {
+		t.Fatalf("prepare work dir: %v", err)
+	}
+
+	for _, name := range []string{
+		compilerVersionFilename,
+		compilerCommandCountFilename,
+		compilerTXLDir,
+	} {
+		if _, err := os.Stat(filepath.Join(workDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed, stat err=%v", name, err)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(workDir, "keep.txt")); err != nil {
+		t.Fatalf("expected keep.txt to remain: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- run the long-lived umplesync server from a dedicated scratch directory under the model store
- clean leaked compiler helper artifacts from that scratch directory on startup and restart
- add regression coverage for the compiler workdir behavior and ignore the known leaked repo paths as a backstop

## Test plan
- `docker-compose run --rm backend go test ./internal/compiler ./cmd/server`
