### PR TITLE
fix(lsp): remove fallback completions

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -34,10 +34,19 @@ jobs:
         with:
           ref: ${{ inputs.commit || github.sha }}
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Read shared versions
         id: versions
         run: |
           echo "umplesync_version=$(cat .umplesync-version)" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve latest LSP version
+        id: lsp_version
+        run: |
+          echo "version=$(npm view umple-lsp-server version)" >> "$GITHUB_OUTPUT"
 
       - name: Resolve effective SHA
         id: resolve
@@ -182,6 +191,8 @@ jobs:
         with:
           context: .
           file: lsp-proxy/Dockerfile
+          build-args: |
+            UMPLE_LSP_VERSION=${{ steps.lsp_version.outputs.version }}
           push: true
           tags: |
             ${{ steps.meta.outputs.prefix }}/lsp-proxy:${{ steps.meta.outputs.sha_tag }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: dev dev-backend dev-frontend install up-prod down logs logs-backend clean tidy fetch-jar sync-examples test-e2e test-e2e-live test-e2e-ui check check-frontend check-backend
 
 UMPLESYNC_VERSION := $(shell cat .umplesync-version)
+export UMPLE_LSP_VERSION ?= $(shell npm view umple-lsp-server version 2>/dev/null || echo latest)
 export DOCKER_GID := $(shell stat -c '%g' /var/run/docker.sock 2>/dev/null || echo 0)
 LEGACY_UMPLE_GIT_URL ?= https://github.com/umple/umple.git
 LEGACY_UMPLE_REF ?= master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     build:
       context: .
       dockerfile: lsp-proxy/Dockerfile
+      args:
+        UMPLE_LSP_VERSION: ${UMPLE_LSP_VERSION:-latest}
     ports:
       - "9999:9999"
     volumes:

--- a/frontend/src/codemirror/lang-umple/index.ts
+++ b/frontend/src/codemirror/lang-umple/index.ts
@@ -1,1 +1,1 @@
-export { umple, umpleLanguage, umpleCompletion } from './umple'
+export { umple, umpleLanguage } from './umple'

--- a/frontend/src/codemirror/lang-umple/umple.ts
+++ b/frontend/src/codemirror/lang-umple/umple.ts
@@ -1,8 +1,6 @@
 import { parser } from "./parser.js"
 import { LRLanguage, indentNodeProp, continuedIndent, foldNodeProp, foldInside, LanguageSupport } from "@codemirror/language"
-import { snippetCompletion } from "@codemirror/autocomplete"
 import { styleTags, tags as t } from "@lezer/highlight"
-import { syntaxTree } from "@codemirror/language"
 
 const parserWithMetadata = parser.configure({
   props: [
@@ -64,96 +62,6 @@ export const umpleLanguage = LRLanguage.define({
   }
 })
 
-const classTag = snippetCompletion("class ${className} {\n\t${}\n}", {
-  label: "class", info: "Add a new top level class", type: "keyword", section: "Top Level", boost: 81
-})
-const traitTag = snippetCompletion("trait ${traitName} {\n\t${}\n}", {
-  label: "trait", info: "Add a trait with code to blend into classes", type: "keyword", section: "Top Level", boost: 75
-})
-const interfaceTag = snippetCompletion("interface ${interfaceName} {\n\t${}\n}", {
-  label: "interface", info: "Add an interface describing valid method signatures", type: "keyword", section: "Top Level", boost: 69
-})
-const useTag = snippetCompletion("use ${useName}${}", {
-  label: "useStatement", info: "Include Umple code from another file", type: "keyword", section: "Top Level", boost: 63
-})
-const associationTag = snippetCompletion("association {\n\t${}\n}", {
-  label: "association", info: "Specify an association between two classes", type: "keyword", section: "Top Level", boost: 57
-})
-const associationClassTag = snippetCompletion("associationClass {\n\t${}\n}", {
-  label: "associationClass", info: "Specify a class relating two other classes", type: "keyword", section: "Top Level", boost: 51
-})
-const mixsetTag = snippetCompletion("mixset ${mixsetName} {\n\t${}\n}", {
-  label: "mixset", info: "Specify optional code that could be mixed in", type: "keyword", section: "Top Level", boost: 45
-})
-const namespaceTag = snippetCompletion("namespace ${namespaceName};${}", {
-  label: "namespace", info: "Designate the package for generated code", type: "keyword", section: "Top Level", boost: 39
-})
-const generateTag = snippetCompletion("generate ${language};${}", {
-  label: "generate", info: "Specify output to generate", type: "keyword", section: "Top Level", boost: 33
-})
-
-const attributeTag = snippetCompletion("${const} ${type} ${attributeName} = ${\"value\"};${}", {
-  label: "attribute", info: "Specify data to be contained in all instances", type: "keyword", section: "Class Content", boost: 81
-})
-const inlineAssociationTag = snippetCompletion("${0..1} ${roleName1} ${<@>-} ${*} ${type} ${roleName2};${}", {
-  label: "inlineAssociation", info: "Specify an association to another class", type: "keyword", section: "Class Content", boost: 75
-})
-const stateMachineTag = snippetCompletion("${stateMachineName} {\n\t${}\n}", {
-  label: "stateMachine", info: "Define behaviour for this class", type: "keyword", section: "Class Content", boost: 69
-})
-const concreteMethodTag = snippetCompletion("${type} ${methodDeclarator}(${}) {\n\t${}\n}", {
-  label: "concreteMethod", info: "Specify a method", type: "function", section: "Class Content", boost: 63
-})
-const subClassTag = snippetCompletion("class ${className} {\n\t${}\n}", {
-  label: "subClass", info: "Specify a subclass", type: "keyword", section: "Class Content", boost: 57
-})
-
-const stateTag = snippetCompletion("${stateName} {\n\t${}\n}", {
-  label: "state", info: "One of the states this object can be in", type: "keyword", boost: 30
-})
-const standAloneTransitionTag = snippetCompletion("${eventName()} ${fromState} -> ${destination};${}", {
-  label: "standAloneTransition", info: "Indicate a transition event", type: "function", boost: 24
-})
-const transitionTag = snippetCompletion("${eventName()} -> ${stateName};${}", {
-  label: "transition", info: "Indicate a transition event", type: "function", boost: 69
-})
-const abstractMethodTag = snippetCompletion("${type} ${methodDeclarator}(${});", {
-  label: "abstractMethod", info: "Specify a method signature", type: "function", section: "Interface", boost: 60
-})
-
-const topLeveltagOptions = [classTag, traitTag, interfaceTag, useTag, associationTag, associationClassTag, mixsetTag, namespaceTag, generateTag]
-const classContentTagOptions = [attributeTag, inlineAssociationTag, stateMachineTag, subClassTag]
-const inlineStateMachineTagOptions = [stateTag, standAloneTransitionTag]
-const stateInternalTagOptions = [transitionTag, concreteMethodTag]
-const interfaceBodyTagOptions = [abstractMethodTag]
-
-function completeUmple(context: any) {
-  const nodeBefore = syntaxTree(context.state).resolveInner(context.pos, -1)
-
-  let options: any[] | null = null
-  if (nodeBefore.name === "Program") options = topLeveltagOptions
-  else if (nodeBefore.name === "ClassBody") options = classContentTagOptions
-  else if (nodeBefore.name === "InlineStateMachineBody") options = inlineStateMachineTagOptions
-  else if (nodeBefore.name === "StateBody") options = stateInternalTagOptions
-  else if (nodeBefore.name === "InterfaceDefinitionBody") options = interfaceBodyTagOptions
-
-  if (!options) return null
-
-  const textBefore = context.state.sliceDoc(nodeBefore.from, context.pos)
-  const tagBefore = /\w*$/.exec(textBefore)
-  if (!tagBefore && !context.explicit) return null
-
-  return {
-    from: tagBefore ? nodeBefore.from + tagBefore.index : context.pos,
-    options,
-    validFor: /^(\w*)?$/,
-  }
-}
-
-export const umpleCompletion = umpleLanguage.data.of({
-  autocomplete: completeUmple,
-})
-
 export function umple() {
-  return new LanguageSupport(umpleLanguage, [umpleCompletion])
+  return new LanguageSupport(umpleLanguage)
 }

--- a/lsp-proxy/Dockerfile
+++ b/lsp-proxy/Dockerfile
@@ -1,8 +1,10 @@
 FROM node:22-alpine
 
+ARG UMPLE_LSP_VERSION=latest
+
 RUN apk add --no-cache openjdk17-jre-headless
 
-RUN npm install -g umple-lsp-server@latest
+RUN npm install -g "umple-lsp-server@${UMPLE_LSP_VERSION}"
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- remove the hardcoded Umple CodeMirror completion source so the LSP is the only completion authority
- pass the resolved `umple-lsp-server` npm version into local and CI `lsp-proxy` builds so upstream LSP updates invalidate the right Docker layer
- relate this cleanup to #93 without closing it

## Test plan
- `cd frontend && bun run vitest run src/codemirror/__tests__/lsp.test.ts src/hooks/__tests__/useLsp.test.tsx`
- `cd frontend && bun run build`
- `make dev`, then verify `umple-lsp-server --version` inside `umpleonline-dev-lsp-proxy-1` matches `npm view umple-lsp-server version`
