### PR TITLE
feat(agent): add assistant launcher

### DIFF
--- a/frontend/src/components/agent/AgentPanel.tsx
+++ b/frontend/src/components/agent/AgentPanel.tsx
@@ -5,13 +5,17 @@ import {
   useEffect,
   useLayoutEffect,
   useCallback,
+  type MouseEvent,
 } from 'react'
 import {
   ChevronDown,
   ChevronUp,
+  LoaderCircle,
   Maximize2,
   Minimize2,
+  PanelBottomClose,
   RotateCcw,
+  Sparkles,
 } from 'lucide-react'
 import { useSessionStore } from '@/stores/sessionStore'
 import { useEphemeralStore } from '@/stores/ephemeralStore'
@@ -21,6 +25,8 @@ import { useDiffPreviewSync } from '@/ai/useDiffPreviewSync'
 import { useResizablePanel } from './useResizablePanel'
 import { InputBar } from './InputBar'
 import { MessageBubble } from './MessageBubble'
+import { Button } from '@/components/ui/button'
+import { Tip } from '@/components/ui/tooltip'
 import { UmpleSpinner } from '@/components/UmpleSpinner'
 import { SPINNER_VERBS } from '@/constants/spinnerVerbs'
 
@@ -36,12 +42,22 @@ const FOLD_THRESHOLD = 80
 function AgentPanel() {
   const { messages, status, error, send, stop, reset, approveToolCall, rejectToolCall } =
     useAgent()
-  const { showAgentPanel, openAgentPanel, closeAgentPanel } = useSessionStore()
+  const {
+    showAgentPanel,
+    showAgentBar,
+    openAgentPanel,
+    closeAgentPanel,
+    revealAgentBar,
+    hideAgentBar,
+  } = useSessionStore()
   const code = useSessionStore((s) => s.code)
   const selection = useEphemeralStore((s) => s.selection)
   const clearSelection = useEphemeralStore((s) => s.setSelection)
   const activeTabName = useSessionStore((s) => s.tabs.find((t) => t.id === s.activeTabId)?.name) ?? 'Model.ump'
   const expanded = showAgentPanel
+  const collapsedBarVisible = showAgentBar && !expanded
+  const launcherVisible = !showAgentBar && !expanded
+  const [focusCollapsedInput, setFocusCollapsedInput] = useState(false)
   const [focusExpandedInput, setFocusExpandedInput] = useState(false)
 
   /* ── Resize ── */
@@ -176,8 +192,25 @@ function AgentPanel() {
     openAgentPanel()
   }, [openAgentPanel])
 
+  const handleLauncherClick = useCallback(() => {
+    if (messages.length > 0) {
+      handleExpandPanel(true)
+      return
+    }
+
+    setFocusCollapsedInput(true)
+    revealAgentBar()
+  }, [handleExpandPanel, messages.length, revealAgentBar])
+
+  const handleHideAgentBar = useCallback((e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setFocusCollapsedInput(false)
+    hideAgentBar()
+  }, [hideAgentBar])
+
   const handleCollapsedClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: MouseEvent<HTMLDivElement>) => {
       if (shouldSuppressClick()) {
         e.preventDefault()
         e.stopPropagation()
@@ -199,8 +232,26 @@ function AgentPanel() {
     setInput('')
   }, [reset])
 
+  if (launcherVisible) {
+    return (
+      <Tip content="Show AI assistant" side="left">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-lg"
+          className="absolute bottom-3 right-3 z-20 rounded-full shadow-[var(--shadow-elevated)]"
+          data-testid="agent-panel-launcher"
+          aria-label="Show AI assistant"
+          onClick={handleLauncherClick}
+        >
+          {isStreaming ? <LoaderCircle className="animate-spin" /> : <Sparkles />}
+        </Button>
+      </Tip>
+    )
+  }
+
   /* ── Collapsed: just the input bar ── */
-  if (!expanded) {
+  if (collapsedBarVisible) {
     return (
       <div
         className="absolute bottom-0 left-1/2 z-20 w-full max-w-3xl -translate-x-1/2 px-2 pb-2"
@@ -219,17 +270,37 @@ function AgentPanel() {
           isStreaming={isStreaming}
           canSend={canSend}
           textareaMaxHeight={60}
+          autoFocus={focusCollapsedInput}
+          onAutoFocus={() => setFocusCollapsedInput(false)}
           selectionBadge={selectionBadge}
           onClearSelection={() => clearSelection(null)}
         >
-          {messages.length > 0 && (
-            <button
-              onClick={() => handleExpandPanel(true)}
-              className="flex size-8 cursor-pointer items-center justify-center rounded-full text-ink-muted transition-colors hover:bg-surface-2 hover:text-ink"
-              aria-label="Expand chat"
+          <Tip content="Collapse this bar into the AI button" side="top">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleHideAgentBar}
+              className="shrink-0 rounded-full px-3 text-ink-muted"
+              aria-label="Hide AI assistant"
             >
-              <ChevronUp className="size-4" />
-            </button>
+              <PanelBottomClose data-icon="inline-start" />
+              Hide
+            </Button>
+          </Tip>
+          {messages.length > 0 && (
+            <Tip content="Open chat history" side="top">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => handleExpandPanel(true)}
+                className="shrink-0 rounded-full text-ink-muted"
+                aria-label="Expand chat"
+              >
+                <ChevronUp />
+              </Button>
+            </Tip>
           )}
         </InputBar>
       </div>
@@ -257,15 +328,30 @@ function AgentPanel() {
 
       {/* Header */}
       <div className="flex shrink-0 items-center justify-between border-b border-border px-3 pb-2">
-        <button
-          onClick={closeAgentPanel}
-          className="cursor-pointer rounded-full p-2 text-ink-muted transition-colors hover:bg-surface-2 hover:text-ink"
-          aria-label="Collapse chat panel"
-        >
-          <ChevronDown className="size-4" />
-        </button>
+        <Tip content="Collapse to the input bar" side="bottom">
+          <button
+            onClick={closeAgentPanel}
+            className="cursor-pointer rounded-full p-2 text-ink-muted transition-colors hover:bg-surface-2 hover:text-ink"
+            aria-label="Collapse chat panel"
+          >
+            <ChevronDown className="size-4" />
+          </button>
+        </Tip>
 
         <div className="flex items-center gap-1">
+          <Tip content="Hide assistant until reopened from the AI button" side="bottom">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleHideAgentBar}
+              className="shrink-0 rounded-full px-3 text-ink-muted"
+              aria-label="Hide AI assistant"
+            >
+              <PanelBottomClose data-icon="inline-start" />
+              Hide
+            </Button>
+          </Tip>
           <button
             onClick={toggleMaximize}
             className="cursor-pointer rounded-full p-2 text-ink-muted transition-colors hover:bg-surface-2 hover:text-ink"

--- a/frontend/src/components/agent/__tests__/AgentPanel.test.tsx
+++ b/frontend/src/components/agent/__tests__/AgentPanel.test.tsx
@@ -6,6 +6,7 @@ import AgentPanel from '../AgentPanel'
 import { createDefaultProviderConfigs, usePreferencesStore } from '@/stores/preferencesStore'
 import { useSessionStore } from '@/stores/sessionStore'
 import { useEphemeralStore } from '@/stores/ephemeralStore'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 const mockSend = vi.fn()
 const mockStop = vi.fn()
@@ -55,9 +56,17 @@ afterEach(() => {
     activeProvider: 'openai',
     configs: createDefaultProviderConfigs(),
   })
-  useSessionStore.setState({ showAgentPanel: false, code: '' })
+  useSessionStore.setState({ showAgentPanel: false, showAgentBar: false, code: '' })
   useEphemeralStore.setState({ diffPreview: null })
 })
+
+function renderAgentPanel() {
+  return render(
+    <TooltipProvider>
+      <AgentPanel />
+    </TooltipProvider>,
+  )
+}
 
 describe('AgentPanel', () => {
   it('renders approval UI for static tool parts', async () => {
@@ -89,7 +98,7 @@ describe('AgentPanel', () => {
       ],
     }
 
-    render(<AgentPanel />)
+    renderAgentPanel()
 
     expect(screen.getByText('Edit proposed')).toBeDefined()
     expect(screen.getByText('Rename Student to Person')).toBeDefined()
@@ -110,6 +119,14 @@ describe('AgentPanel', () => {
     expect(mockRejectToolCall).toHaveBeenCalledWith('approval-1', 'call-1', 'editCode')
   })
 
+  it('starts minimized with the launcher visible', () => {
+    renderAgentPanel()
+
+    expect(screen.getByTestId('agent-panel-launcher')).toBeDefined()
+    expect(screen.queryByTestId('agent-panel-collapsed')).toBeNull()
+    expect(screen.queryByTestId('agent-panel')).toBeNull()
+  })
+
   it('keeps the panel collapsed after drag-fold release', () => {
     useSessionStore.setState({ showAgentPanel: true })
 
@@ -124,7 +141,7 @@ describe('AgentPanel', () => {
       ],
     }
 
-    render(<AgentPanel />)
+    renderAgentPanel()
 
     const panel = screen.getByTestId('agent-panel')
     Object.defineProperty(panel, 'offsetHeight', {
@@ -149,6 +166,7 @@ describe('AgentPanel', () => {
 
   it('keeps focus on the input when expanding from the collapsed textarea', async () => {
     const user = userEvent.setup()
+    useSessionStore.setState({ showAgentBar: true })
 
     mockAgentState = {
       ...mockAgentState,
@@ -161,7 +179,7 @@ describe('AgentPanel', () => {
       ],
     }
 
-    render(<AgentPanel />)
+    renderAgentPanel()
 
     await user.click(screen.getByRole('textbox'))
 
@@ -170,5 +188,60 @@ describe('AgentPanel', () => {
     await waitFor(() => {
       expect(screen.getByRole('textbox')).toBe(document.activeElement)
     })
+  })
+
+  it('minimizes the collapsed bar into a launcher and restores focus when reopened', async () => {
+    const user = userEvent.setup()
+    useSessionStore.setState({ showAgentBar: true })
+
+    renderAgentPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Hide AI assistant' }))
+
+    expect(screen.queryByTestId('agent-panel-collapsed')).toBeNull()
+    expect(screen.getByTestId('agent-panel-launcher')).toBeDefined()
+
+    await user.click(screen.getByTestId('agent-panel-launcher'))
+
+    expect(screen.getByTestId('agent-panel-collapsed')).toBeDefined()
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toBe(document.activeElement)
+    })
+  })
+
+  it('hides the expanded panel into the launcher', async () => {
+    const user = userEvent.setup()
+    useSessionStore.setState({ showAgentPanel: true })
+
+    renderAgentPanel()
+
+    await user.click(screen.getByRole('button', { name: 'Hide AI assistant' }))
+
+    expect(screen.queryByTestId('agent-panel')).toBeNull()
+    expect(screen.queryByTestId('agent-panel-collapsed')).toBeNull()
+    expect(screen.getByTestId('agent-panel-launcher')).toBeDefined()
+  })
+
+  it('reopens the expanded panel from the launcher when conversation history exists', async () => {
+    const user = userEvent.setup()
+
+    mockAgentState = {
+      ...mockAgentState,
+      messages: [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Hello again' }],
+        },
+      ],
+    }
+
+    renderAgentPanel()
+
+    await user.click(screen.getByTestId('agent-panel-launcher'))
+
+    expect(screen.getByTestId('agent-panel')).toBeDefined()
+    expect(screen.queryByTestId('agent-panel-collapsed')).toBeNull()
   })
 })

--- a/frontend/src/stores/__tests__/uiStore.test.ts
+++ b/frontend/src/stores/__tests__/uiStore.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
     outputErrorCount: 0,
     outputWarningCount: 0,
   })
-  useSessionStore.setState({ showAgentPanel: false })
+  useSessionStore.setState({ showAgentPanel: false, showAgentBar: false })
 })
 
 describe('uiStore', () => {

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -99,6 +99,7 @@ interface SessionState {
 
   // Agent panel
   showAgentPanel: boolean;
+  showAgentBar: boolean;
   chatMessages: ChatMessage[];
 
   // Editor actions
@@ -151,6 +152,8 @@ interface SessionState {
   openAgentPanel: () => void;
   closeAgentPanel: () => void;
   toggleAgentPanel: () => void;
+  revealAgentBar: () => void;
+  hideAgentBar: () => void;
   setChatMessages: (messages: ChatMessage[]) => void;
 }
 
@@ -212,6 +215,7 @@ export const useSessionStore = create<SessionState>()(
 
       // ── Agent panel ──
       showAgentPanel: false,
+      showAgentBar: false,
       chatMessages: [],
 
       // ── Editor actions ──
@@ -792,15 +796,29 @@ export const useSessionStore = create<SessionState>()(
 
       // ── Agent panel actions ──
 
-      openAgentPanel: () => set({ showAgentPanel: true }),
-      closeAgentPanel: () => set({ showAgentPanel: false }),
+      openAgentPanel: () => set({ showAgentPanel: true, showAgentBar: true }),
+      closeAgentPanel: () => set({ showAgentPanel: false, showAgentBar: true }),
       toggleAgentPanel: () =>
-        set((s) => ({ showAgentPanel: !s.showAgentPanel })),
+        set((s) => ({ showAgentPanel: !s.showAgentPanel, showAgentBar: true })),
+      revealAgentBar: () => set({ showAgentBar: true, showAgentPanel: false }),
+      hideAgentBar: () => set({ showAgentBar: false, showAgentPanel: false }),
       setChatMessages: (chatMessages) => set({ chatMessages }),
     }),
     {
       name: "umple-session-v1",
+      version: 2,
       storage: createJSONStorage(() => sessionStorage),
+      migrate: (persisted, version) => {
+        const state = (persisted ?? {}) as Record<string, unknown>;
+        if (version < 2) {
+          return {
+            ...state,
+            showAgentPanel: false,
+            showAgentBar: false,
+          } as any;
+        }
+        return state as any;
+      },
       partialize: (state) => ({
         modelId: state.modelId,
         selectedExample: state.selectedExample,
@@ -809,6 +827,7 @@ export const useSessionStore = create<SessionState>()(
         generateTargetId: state.generateTargetId,
         viewMode: state.viewMode,
         showAgentPanel: state.showAgentPanel,
+        showAgentBar: state.showAgentBar,
         chatMessages: state.chatMessages,
       }),
     },


### PR DESCRIPTION
## Summary
- add a separate hidden launcher state for the AI assistant alongside the collapsed input bar
- preserve chat history and restore the right surface when reopening the assistant from the launcher
- cover the new launcher visibility flows in the AgentPanel and uiStore tests

Related to #93.

## Test plan
- cd frontend && bun run test src/components/agent/__tests__/AgentPanel.test.tsx src/stores/__tests__/uiStore.test.ts
- cd frontend && bun run build