### PR TITLE
fix(output): preserve regenerate retry after compile errors

### DIFF
--- a/frontend/src/components/diagram/DiagramPanel.tsx
+++ b/frontend/src/components/diagram/DiagramPanel.tsx
@@ -56,6 +56,9 @@ export function DiagramPanel() {
   const generatingCode = useEphemeralStore((s) => s.generatingCode)
   const generatedError = useEphemeralStore((s) => s.generatedError)
   const generationRequested = useEphemeralStore((s) => s.generationRequested)
+  const generationSuspendedByError = useEphemeralStore((s) => s.generationSuspendedByError)
+  const generationErrorSourceCode = useEphemeralStore((s) => s.generationErrorSourceCode)
+  const generationErrorSourceTabId = useEphemeralStore((s) => s.generationErrorSourceTabId)
   const openExamplesPalette = useEphemeralStore((s) => s.openExamplesPalette)
 
 
@@ -78,11 +81,19 @@ export function DiagramPanel() {
   const mountGv = outputKind === 'gv' && !!currentSvg
   const hasVisibleDiagramOutput = Boolean(hasDiagram || viewMode === 'crud')
   const showEmptyCanvasState = viewMode === 'class' && !generatingOutput && !hasEditableModel && !currentSvg
+  const generationErrorMatchesCurrentInput = Boolean(
+    generationSuspendedByError &&
+    generationErrorSourceTabId === activeTabId &&
+    generationErrorSourceCode === code,
+  )
+  const staleOutputDescription = generationErrorMatchesCurrentInput
+    ? 'Fix the error in the code.'
+    : 'Use Regenerate above to refresh it.'
   const diagramOutputStale = Boolean(
     rightPanelView === 'diagram' &&
     hasVisibleDiagramOutput &&
     !generatingOutput &&
-    !dynamicGeneration &&
+    (!dynamicGeneration || generationErrorMatchesCurrentInput) &&
     diagramSourceTabId &&
     (
       diagramSourceTabId !== activeTabId ||
@@ -95,7 +106,7 @@ export function DiagramPanel() {
     generationRequested &&
     hasGeneratedOutput &&
     !generatingCode &&
-    !dynamicGeneration &&
+    (!dynamicGeneration || generationErrorMatchesCurrentInput) &&
     generatedSourceTabId &&
     (
       generatedSourceTabId !== activeTabId ||
@@ -219,11 +230,11 @@ export function DiagramPanel() {
             >
               <Alert
                 variant="warning"
-                className="pointer-events-none absolute right-3 top-3 max-w-sm bg-surface-0/92 shadow-sm backdrop-blur-sm"
+                className="absolute right-3 top-3 max-w-sm bg-surface-0/92 shadow-sm backdrop-blur-sm"
               >
                 <AlertTriangle />
                 <AlertTitle>Diagram is out of date.</AlertTitle>
-                <AlertDescription>Regenerate to refresh it.</AlertDescription>
+                <AlertDescription>{staleOutputDescription}</AlertDescription>
               </Alert>
             </div>
           )}
@@ -268,8 +279,8 @@ export function DiagramPanel() {
                     className="absolute inset-0 z-10 bg-surface-1/20"
                     data-testid="generated-output-stale-overlay"
                   >
-                    <div className="pointer-events-none absolute right-3 top-3 rounded-md border border-border bg-surface-0/92 px-3 py-1.5 text-xs text-ink-muted shadow-sm backdrop-blur-sm">
-                      Output is out of date. Regenerate to refresh it.
+                    <div className="absolute right-3 top-3 rounded-md border border-border bg-surface-0/92 px-3 py-1.5 text-xs text-ink-muted shadow-sm backdrop-blur-sm">
+                      Output is out of date. {staleOutputDescription}
                     </div>
                   </div>
                 )}

--- a/frontend/src/components/diagram/__tests__/DiagramPanel.test.tsx
+++ b/frontend/src/components/diagram/__tests__/DiagramPanel.test.tsx
@@ -52,6 +52,20 @@ vi.mock('../../generation/GeneratedOutputView', () => ({
   GeneratedOutputView: () => <div data-testid="generated-output-view" />,
 }))
 
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
 afterEach(() => {
   cleanup()
   window.localStorage?.clear?.()
@@ -82,6 +96,9 @@ afterEach(() => {
     generatingCode: false,
     generatedError: null,
     generationRequested: false,
+    generationSuspendedByError: false,
+    generationErrorSourceCode: null,
+    generationErrorSourceTabId: null,
     diagramSourceCode: null,
     diagramSourceTabId: null,
     diagramTargetId: null,
@@ -228,7 +245,7 @@ describe('DiagramPanel', () => {
 
     expect(screen.getByTestId('generated-output-view')).toBeDefined()
     expect(screen.getByTestId('generated-output-stale-overlay')).toBeDefined()
-    expect(screen.getByText('Output is out of date. Regenerate to refresh it.')).toBeDefined()
+    expect(screen.getByText('Output is out of date. Use Regenerate above to refresh it.')).toBeDefined()
   })
 
   it('greys and freezes diagram output when manual generation becomes stale', () => {
@@ -258,7 +275,71 @@ describe('DiagramPanel', () => {
     expect(screen.getByTestId('smart-svg-view')).toBeDefined()
     expect(screen.getByTestId('diagram-output-stale-overlay')).toBeDefined()
     expect(screen.getByText('Diagram is out of date.')).toBeDefined()
-    expect(screen.getByText('Regenerate to refresh it.')).toBeDefined()
+    expect(screen.getByText('Use Regenerate above to refresh it.')).toBeDefined()
+  })
+
+  it('keeps diagram output stale in dynamic mode after a compile error', () => {
+    usePreferencesStore.setState({ dynamicGeneration: true })
+    useSessionStore.setState({
+      code: 'class Invoice { number }',
+      activeTabId: 'main',
+      viewMode: 'class',
+      generateTargetId: 'classDiagram',
+      svgCache: {
+        class: '<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" /></svg>',
+      },
+    })
+    useEphemeralStore.setState({
+      rightPanelView: 'diagram',
+      diagramSourceCode: 'class Invoice { number; }',
+      diagramSourceTabId: 'main',
+      diagramTargetId: 'classDiagram',
+      generationSuspendedByError: true,
+      generationErrorSourceCode: 'class Invoice { number }',
+      generationErrorSourceTabId: 'main',
+    })
+
+    render(
+      <TooltipProvider>
+        <DiagramPanel />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByTestId('smart-svg-view')).toBeDefined()
+    expect(screen.getByTestId('diagram-output-stale-overlay')).toBeDefined()
+    expect(screen.getByText('Diagram is out of date.')).toBeDefined()
+    expect(screen.getByText('Fix the error in the code.')).toBeDefined()
+  })
+
+  it('does not freeze the current dynamic output because another input failed to compile', () => {
+    usePreferencesStore.setState({ dynamicGeneration: true })
+    useSessionStore.setState({
+      code: 'class UpdatedInvoice { number; }',
+      activeTabId: 'main',
+      viewMode: 'class',
+      generateTargetId: 'classDiagram',
+      svgCache: {
+        class: '<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" /></svg>',
+      },
+    })
+    useEphemeralStore.setState({
+      rightPanelView: 'diagram',
+      diagramSourceCode: 'class Invoice { number; }',
+      diagramSourceTabId: 'main',
+      diagramTargetId: 'classDiagram',
+      generationSuspendedByError: true,
+      generationErrorSourceCode: 'class Broken { number }',
+      generationErrorSourceTabId: 'other-tab',
+    })
+
+    render(
+      <TooltipProvider>
+        <DiagramPanel />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByTestId('smart-svg-view')).toBeDefined()
+    expect(screen.queryByTestId('diagram-output-stale-overlay')).toBeNull()
   })
 
   it('keeps the current diagram visible and stale after a manual-mode target switch', () => {

--- a/frontend/src/components/layout/AppToolbar.tsx
+++ b/frontend/src/components/layout/AppToolbar.tsx
@@ -87,8 +87,12 @@ export function AppToolbar() {
   const errorCount = useEphemeralStore((s) => s.outputErrorCount);
   const dynamicGeneration = usePreferencesStore((s) => s.dynamicGeneration);
   const generateTargetId = useSessionStore((s) => s.generateTargetId);
+  const code = useSessionStore((s) => s.code);
+  const activeTabId = useSessionStore((s) => s.activeTabId);
   const selectedExampleId = useSessionStore((s) => s.selectedExampleId);
   const selectedExampleSetId = useSessionStore((s) => s.selectedExampleSetId);
+  const generationErrorSourceCode = useEphemeralStore((s) => s.generationErrorSourceCode);
+  const generationErrorSourceTabId = useEphemeralStore((s) => s.generationErrorSourceTabId);
   const handleGenerate = useSelectGenerateTarget();
   const {
     sets: exampleSets,
@@ -98,6 +102,11 @@ export function AppToolbar() {
   } = useExamples();
   const selectedGenerateTarget = getGenerateTarget(generateTargetId);
   const canExecuteGenerateTarget = Boolean(selectedGenerateTarget?.executable);
+  const regeneratingOutput = regenerating || generatingOutput;
+  const generationSuspendedForCurrentInput =
+    generationErrorSourceTabId === activeTabId &&
+    generationErrorSourceCode === code;
+  const showTemporaryRegenerate = dynamicGeneration && generationSuspendedForCurrentInput;
   const [examplePickerOpen, setExamplePickerOpen] = useState(false);
   const [activeExampleSetId, setActiveExampleSetId] =
     useState<ExampleSetId | null>(null);
@@ -460,38 +469,54 @@ export function AppToolbar() {
             </Popover>
           </div>
 
-          {!dynamicGeneration && (
-            <Tip content="Regenerate output (Ctrl+Enter)" side="bottom">
-              <button
-                onClick={regenerate}
-                disabled={regenerating}
-                aria-label={regenerating ? "Regenerating output" : "Regenerate output (Ctrl+Enter)"}
-                data-testid="regenerate-button"
-                className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border/70 bg-surface-0 px-2.5 text-xs font-medium text-ink-muted shadow-sm transition-colors hover:bg-surface-2 hover:text-ink disabled:cursor-not-allowed disabled:opacity-70"
-              >
-                {regenerating ? (
-                  <Loader2 className="size-3.5 shrink-0 animate-spin" />
-                ) : justRegenerated ? (
-                  <Check className="size-3.5 shrink-0 text-status-success animate-fade-in" />
-                ) : (
-                  <Hammer className="size-3.5 shrink-0" />
-                )}
-                <span className="truncate">
-                  {regenerating ? (
-                    "Regenerating..."
-                  ) : justRegenerated ? (
-                    <span className="text-status-success animate-fade-in">
-                      Regenerated
-                    </span>
-                  ) : (
-                    "Regenerate"
+          {(!dynamicGeneration || showTemporaryRegenerate) && (
+            <Tip
+              content={
+                showTemporaryRegenerate
+                  ? "Temporary retry while auto-generation is paused by an error"
+                  : "Regenerate output (Ctrl+Enter)"
+              }
+              side="bottom"
+            >
+              <span className="inline-flex" data-testid="regenerate-button-wrapper">
+                <button
+                  onClick={regenerate}
+                  disabled={regeneratingOutput}
+                  aria-label={
+                    regeneratingOutput
+                      ? "Regenerating output"
+                      : "Regenerate output (Ctrl+Enter)"
+                  }
+                  data-testid="regenerate-button"
+                  className={cn(
+                    "inline-flex h-8 items-center gap-1.5 rounded-lg border border-border/70 bg-surface-0 px-2.5 text-xs font-medium text-ink-muted shadow-sm transition-colors hover:bg-surface-2 hover:text-ink disabled:cursor-not-allowed disabled:opacity-70",
+                    showTemporaryRegenerate && "border-brand/70",
                   )}
-                </span>
-              </button>
+                >
+                  {regeneratingOutput ? (
+                    <Loader2 className="size-3.5 shrink-0 animate-spin" />
+                  ) : justRegenerated ? (
+                    <Check className="size-3.5 shrink-0 text-status-success animate-fade-in" />
+                  ) : (
+                    <Hammer className="size-3.5 shrink-0" />
+                  )}
+                  <span className="truncate">
+                    {regeneratingOutput ? (
+                      "Regenerating..."
+                    ) : justRegenerated ? (
+                      <span className="text-status-success animate-fade-in">
+                        Regenerated
+                      </span>
+                    ) : (
+                      "Regenerate"
+                    )}
+                  </span>
+                </button>
+              </span>
             </Tip>
           )}
 
-          <div data-tour="generate">
+          <span className="inline-flex" data-tour="generate" data-testid="generate-target-wrapper">
             <Combobox
               groups={generateGroups}
               value={generateTargetId}
@@ -521,7 +546,7 @@ export function AppToolbar() {
               }
               ariaLabel="Generate"
             />
-          </div>
+          </span>
 
           <Tip
             content={

--- a/frontend/src/hooks/useCompiler.ts
+++ b/frontend/src/hooks/useCompiler.ts
@@ -19,7 +19,8 @@ import { getGenerateTarget, resolveGenerateRequestLanguage } from '../generation
 /** Diagram-only messages that are transient (not real compilation errors).
  *  Matched via exact equality (case-insensitive, trimmed) to avoid
  *  accidentally swallowing unrelated errors that contain a substring. */
-const DIAGRAM_TOAST_MESSAGES = new Set([
+const DIAGRAM_TOAST_MESSAGES = new Set<string>([])
+const DIAGRAM_SUPPRESSED_MESSAGES = new Set([
   'no diagram output generated',
 ])
 
@@ -40,6 +41,9 @@ function splitDiagramToasts(errors: string): { panelErrors: string; toastMessage
   const toastMessages: string[] = []
   const remaining = errors.split('\n').filter((line) => {
     const trimmed = line.trim()
+    if (DIAGRAM_SUPPRESSED_MESSAGES.has(trimmed.toLowerCase())) {
+      return false
+    }
     if (DIAGRAM_TOAST_MESSAGES.has(trimmed.toLowerCase())) {
       toastMessages.push(trimmed)
       return false
@@ -59,25 +63,20 @@ export async function generateAndRefresh(
   const { code, modelId, setModelId, setUmpleModel, tabs, activeTabId, generateTargetId, viewMode, setViewMode } = useSessionStore.getState()
   const { clearSvgCache, clearHtmlCache, setSvgForView, setHtmlForView } = useSessionStore.getState()
   const {
-    setGeneratingOutput,
+    clearGenerationError,
+    markGenerationErrored,
+    markDiagramFresh,
     setExecutionOutput,
-    setGeneratingCode,
     setGeneratedError,
     setGeneratedOutput,
+    setGeneratingCode,
+    setGeneratingOutput,
     setRightPanelView,
-    markDiagramFresh,
   } = useEphemeralStore.getState()
   const target = getGenerateTarget(targetId ?? generateTargetId)
   const sourceSnapshot = { code, tabId: activeTabId }
 
   if (!code.trim() || !target) return { success: false, model: null }
-
-  if (target.action === 'diagram' && target.diagramView) {
-    setViewMode(target.diagramView)
-    setRightPanelView('diagram')
-  } else {
-    setRightPanelView('generated')
-  }
 
   setGeneratingOutput(true)
   setExecutionOutput('')
@@ -127,14 +126,6 @@ export async function generateAndRefresh(
       return { success: false, model: null }
     }
 
-    // Clear old caches only after the response arrives (not eagerly at the
-    // start) so that if the user switches tabs mid-compile, setActiveTab
-    // snapshots the previous diagram — not empty caches.
-    if (target.action === 'diagram') {
-      clearSvgCache()
-      clearHtmlCache()
-    }
-
     // Read current modelId from the store (not the stale closure value) to
     // avoid overwriting a modelId that was set by useModelFromURL while the
     // compile request was in flight.
@@ -147,11 +138,14 @@ export async function generateAndRefresh(
 
     // Handle diagram output from the merged response
     if (target.action === 'diagram') {
-      if (res.svg) setSvgForView(activeView, res.svg)
-      if (res.html) setHtmlForView(activeView, res.html)
-
       const gvLayout: GvLayout | undefined = res.layout
       const storedLayout: StoredLayoutMetadata | null = res.storedLayout ?? null
+      const hasDiagramPayload = Boolean(
+        res.svg ||
+        res.html ||
+        (activeView === 'class' && model),
+      )
+      let hasBlockingErrors = false
 
       if (res.errors) {
         // Separate transient diagram messages (shown as toasts) from real
@@ -160,15 +154,31 @@ export async function generateAndRefresh(
         for (const msg of toastMessages) toast.info(msg, { id: 'diagram-info' })
         if (panelErrors) {
           setExecutionOutput('', panelErrors)
-        } else {
-          success = true
+          hasBlockingErrors = useEphemeralStore.getState().outputErrorCount > 0
         }
-      } else {
-        success = true
       }
-  
+
+      if (hasBlockingErrors) {
+        markGenerationErrored(sourceSnapshot)
+      } else {
+        clearGenerationError()
+      }
+
+      if (!hasBlockingErrors && hasDiagramPayload) {
+        success = true
+
+        // Clear old caches only after a successful response has arrived so that
+        // stale diagrams stay visible when compilation fails.
+        clearSvgCache()
+        clearHtmlCache()
+        if (res.svg) setSvgForView(activeView, res.svg)
+        if (res.html) setHtmlForView(activeView, res.html)
+        setViewMode(activeView)
+        setRightPanelView('diagram')
+      }
+
       // Store the parsed model and layout for UmpleDiagram
-      if (model) {
+      if (model && success) {
         setUmpleModel(
           model,
           activeView === 'class' ? gvLayout ?? null : undefined,
@@ -198,10 +208,18 @@ export async function generateAndRefresh(
           downloads: res.generatedDownloads,
           modelId: res.modelId,
         }, target.id, sourceSnapshot)
+        setRightPanelView('generated')
 
+        let hasBlockingErrors = false
         if (res.errors) {
           setExecutionOutput('', res.errors)
+          hasBlockingErrors = useEphemeralStore.getState().outputErrorCount > 0
+        }
+
+        if (hasBlockingErrors) {
+          markGenerationErrored(sourceSnapshot)
         } else {
+          clearGenerationError()
           success = true
         }
       } else {
@@ -350,6 +368,9 @@ export function useCompiler() {
     } catch (err: any) {
       if (err.name === 'AbortError') return
       const msg = err.message || ''
+      if (DIAGRAM_SUPPRESSED_MESSAGES.has(msg.toLowerCase().trim())) {
+        return
+      }
       if (DIAGRAM_TOAST_MESSAGES.has(msg.toLowerCase().trim())) {
         toast.info(msg, { id: 'diagram-info' })
       } else {

--- a/frontend/src/hooks/useExecute.ts
+++ b/frontend/src/hooks/useExecute.ts
@@ -41,7 +41,8 @@ export function useRegenerate() {
   const isDark = useIsDark()
 
   const regenerate = useCallback(async () => {
-    if (regeneratingRef.current) return
+    const { generatingOutput, generatingCode } = useEphemeralStore.getState()
+    if (regeneratingRef.current || generatingOutput || generatingCode) return
     regeneratingRef.current = true
     setRegenerating(true)
 

--- a/frontend/src/hooks/useGenerate.ts
+++ b/frontend/src/hooks/useGenerate.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 import { useSessionStore } from '../stores/sessionStore'
-import { useEphemeralStore } from '../stores/ephemeralStore'
 import { usePreferencesStore } from '../stores/preferencesStore'
 import { getGenerateTarget } from '../generation/targets'
 import { generateAndRefresh } from './useCompiler'

--- a/frontend/src/stores/ephemeralStore.ts
+++ b/frontend/src/stores/ephemeralStore.ts
@@ -111,6 +111,9 @@ interface EphemeralState {
   generatingCode: boolean
   generatedError: string | null
   generationRequested: boolean
+  generationSuspendedByError: boolean
+  generationErrorSourceCode: string | null
+  generationErrorSourceTabId: string | null
 
   // Diagram ephemeral
   diagramSourceCode: string | null
@@ -160,6 +163,8 @@ interface EphemeralState {
     targetId: string,
     source: { code: string; tabId: string },
   ) => void
+  markGenerationErrored: (source: { code: string; tabId: string }) => void
+  clearGenerationError: () => void
   setGeneratingCode: (generating: boolean, targetId?: string) => void
   setGeneratedError: (error: string | null) => void
   clearGenerated: () => void
@@ -217,6 +222,9 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
   generatingCode: false,
   generatedError: null,
   generationRequested: false,
+  generationSuspendedByError: false,
+  generationErrorSourceCode: null,
+  generationErrorSourceTabId: null,
 
   // Diagram ephemeral
   diagramSourceCode: null,
@@ -296,8 +304,18 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
       rightPanelView: 'generated',
       generatedError: result.errors ?? null,
     }),
+  markGenerationErrored: (source) => set({
+    generationSuspendedByError: true,
+    generationErrorSourceCode: source.code,
+    generationErrorSourceTabId: source.tabId,
+  }),
+  clearGenerationError: () => set({
+    generationSuspendedByError: false,
+    generationErrorSourceCode: null,
+    generationErrorSourceTabId: null,
+  }),
   setGeneratingCode: (generatingCode, targetId) => set(generatingCode
-    ? { generatingCode, generationRequested: true, rightPanelView: 'generated', ...(targetId ? { generatedTargetId: targetId } : {}) }
+    ? { generatingCode, generationRequested: true, ...(targetId ? { generatedTargetId: targetId } : {}) }
     : { generatingCode }
   ),
   setGeneratedError: (generatedError) => set({ generatedError }),
@@ -312,6 +330,9 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
     generatedError: null,
     rightPanelView: 'diagram',
     generationRequested: false,
+    generationSuspendedByError: false,
+    generationErrorSourceCode: null,
+    generationErrorSourceTabId: null,
   }),
 
   // Diagram ephemeral actions

--- a/frontend/tests/e2e/generation.spec.ts
+++ b/frontend/tests/e2e/generation.spec.ts
@@ -68,6 +68,17 @@ async function installGenerationRoutes(page: Page, requests: GenerationRequest[]
     requests.push(body)
     const classModel = buildClassModel(body.code)
 
+    if (body.code.includes('number }')) {
+      await route.fulfill({
+        json: {
+          modelId: 'playwright-model',
+          result: JSON.stringify(classModel),
+          errors: '{"results":[{"severity":"1","message":"Syntax error","line":"1"}]}',
+        },
+      })
+      return
+    }
+
     if (body.language === 'Java') {
       const className = body.code.includes('UpdatedInvoice')
         ? 'UpdatedInvoiceGenerated'
@@ -159,6 +170,88 @@ test.describe('Generation UI', () => {
     await expect
       .poll(() => getLastRequest(requests)?.language ?? null)
       .toBe(null)
+  })
+
+  test('keeps the last diagram visible after a compile error in dynamic mode', async ({
+    page,
+  }) => {
+    const requests: GenerationRequest[] = []
+    await addPreferencesInitScript(page)
+    await installGenerationRoutes(page, requests)
+
+    await page.goto('/')
+    await expect(page.getByTestId('app-shell')).toBeVisible()
+
+    await setEditorCode(page, 'class Invoice { number; }')
+    await expect(page.getByTestId('class-node-Invoice')).toBeVisible({
+      timeout: 10_000,
+    })
+
+    await setEditorCode(page, 'class Invoice { number }')
+
+    await expect(page.getByTestId('diagram-output-stale-overlay')).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(page.getByTestId('class-node-Invoice')).toBeVisible()
+    await expect(page.getByText('Fix the error in the code.')).toBeVisible()
+    await expect(page.getByTestId('regenerate-button')).toBeVisible()
+
+    const retryResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/generate') && response.request().method() === 'POST',
+    )
+    await page.getByTestId('regenerate-button').click()
+    await retryResponse
+    expect(requests).toHaveLength(3)
+  })
+
+  test('keeps regenerate available after a compile error in manual mode', async ({
+    page,
+  }) => {
+    const requests: GenerationRequest[] = []
+    await addPreferencesInitScript(page, { dynamicGeneration: false })
+    await installGenerationRoutes(page, requests)
+
+    await page.goto('/')
+    await expect(page.getByTestId('app-shell')).toBeVisible()
+
+    await setEditorCode(page, 'class Invoice { number; }')
+    let regenerateResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/generate') && response.request().method() === 'POST',
+    )
+    await page.getByTestId('regenerate-button').click()
+    await regenerateResponse
+
+    await expect(page.getByTestId('class-node-Invoice')).toBeVisible({
+      timeout: 10_000,
+    })
+
+    await setEditorCode(page, 'class Invoice { number }')
+    await expect(page.getByTestId('diagram-output-stale-overlay')).toBeVisible()
+    await expect(page.getByText('Use Regenerate above to refresh it.')).toBeVisible()
+    await expect(page.getByTestId('regenerate-button')).toBeVisible()
+
+    regenerateResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/generate') && response.request().method() === 'POST',
+    )
+    await expect(page.getByTestId('regenerate-button')).toBeEnabled()
+    await page.getByTestId('regenerate-button').click()
+    await regenerateResponse
+
+    expect(requests).toHaveLength(2)
+    await expect(page.getByText('Fix the error in the code.')).toBeVisible()
+    await expect(page.getByTestId('regenerate-button')).toBeEnabled()
+
+    regenerateResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/generate') && response.request().method() === 'POST',
+    )
+    await page.getByTestId('regenerate-button').click()
+    await regenerateResponse
+
+    expect(requests).toHaveLength(3)
   })
 
   test('preserves stale generated code until manual regenerate when dynamic generation is off', async ({


### PR DESCRIPTION
## Summary
- preserve stale diagram and generated output while keeping explicit regenerate available after compile errors
- surface the same toolbar regenerate path temporarily when auto-generation is paused and clarify stale-output copy
- suppress the redundant "no diagram output generated" reminder
- related to issue93 (do not close yet)

## Test plan
- bun run test -- src/components/diagram/__tests__/DiagramPanel.test.tsx
- bun run test:e2e -- tests/e2e/generation.spec.ts