### PR TITLE
fix(editor): keep collab tabs synced on switch

### DIFF
--- a/frontend/src/components/editor/UmpleEditor.tsx
+++ b/frontend/src/components/editor/UmpleEditor.tsx
@@ -153,6 +153,7 @@ export const UmpleEditor = forwardRef<UmpleEditorHandle, UmpleEditorProps>(funct
   useEffect(() => {
     const view = viewRef.current
     if (!view || prevTabIdRef.current === activeTabId) return
+    const shouldSyncFromStoreCode = !collabConfig
 
     // Save current state for the outgoing tab
     stateCacheRef.current.set(prevTabIdRef.current, {
@@ -166,7 +167,7 @@ export const UmpleEditor = forwardRef<UmpleEditorHandle, UmpleEditorProps>(funct
     // Flag consumed by the code-sync effect (declared later in this file)
     // to skip redundant content replacement. Relies on React firing effects
     // in declaration order within the same render cycle.
-    isTabSwitchRef.current = true
+    isTabSwitchRef.current = shouldSyncFromStoreCode
 
     // Restore cached state or create fresh for the incoming tab
     const cached = stateCacheRef.current.get(activeTabId)
@@ -191,9 +192,9 @@ export const UmpleEditor = forwardRef<UmpleEditorHandle, UmpleEditorProps>(funct
       stateCacheRef.current.set(activeTabId, { ...fresh, state: view.state })
     }
 
-    // If the cached doc drifted from the store (e.g. external sync while away), patch it
+    // In non-collab mode, the store is authoritative. In collab mode, Y.Text is.
     const restoredDoc = view.state.doc.toString()
-    if (restoredDoc !== code) {
+    if (shouldSyncFromStoreCode && restoredDoc !== code) {
       isExternalUpdate.current = true
       view.dispatch({
         changes: { from: 0, to: restoredDoc.length, insert: code },

--- a/frontend/src/components/editor/__tests__/UmpleEditor.test.tsx
+++ b/frontend/src/components/editor/__tests__/UmpleEditor.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { createRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import * as Y from 'yjs'
+import { Awareness } from 'y-protocols/awareness'
+
+import { UmpleEditor, type UmpleEditorHandle } from '../UmpleEditor'
+import { usePreferencesStore } from '@/stores/preferencesStore'
+import { useSessionStore } from '@/stores/sessionStore'
+
+const originalMatchMedia = window.matchMedia
+
+describe('UmpleEditor', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: () => ({
+        matches: false,
+        media: '(prefers-color-scheme: dark)',
+        onchange: null,
+        addEventListener: () => { },
+        removeEventListener: () => { },
+        addListener: () => { },
+        removeListener: () => { },
+        dispatchEvent: () => false,
+      }),
+    })
+
+    usePreferencesStore.setState({ theme: 'light' })
+    useSessionStore.setState({
+      code: 'class Person {}',
+      activeTabId: 'tab-a',
+      tabs: [
+        {
+          id: 'tab-a',
+          name: 'Person.ump',
+          code: 'class Person {}',
+          dirty: false,
+          savedCode: 'class Person {}',
+          undoStack: [],
+          redoStack: [],
+        },
+        {
+          id: 'tab-b',
+          name: 'Order.ump',
+          code: 'class Order {}',
+          dirty: false,
+          savedCode: 'class Order {}',
+          undoStack: [],
+          redoStack: [],
+        },
+      ],
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    })
+  })
+
+  it('does not overwrite the shared tab document when switching back with stale code props in collab mode', async () => {
+    const doc = new Y.Doc()
+    const awareness = new Awareness(doc)
+    const personText = doc.getText('tab:tab-a')
+    personText.insert(0, 'class Person {}')
+    const orderText = doc.getText('tab:tab-b')
+    orderText.insert(0, 'class Order {}')
+
+    const ref = createRef<UmpleEditorHandle>()
+    const { rerender } = render(
+      <UmpleEditor
+        ref={ref}
+        code="class Person {}"
+        activeTabId="tab-a"
+        onChange={() => { }}
+        collabConfig={{ ytext: personText, awareness }}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(ref.current?.view?.state.doc.toString()).toBe('class Person {}')
+    })
+
+    useSessionStore.setState({ code: 'class Person {}', activeTabId: 'tab-b' })
+    rerender(
+      <UmpleEditor
+        ref={ref}
+        code="class Person {}"
+        activeTabId="tab-b"
+        onChange={() => { }}
+        collabConfig={{ ytext: orderText, awareness }}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(ref.current?.view?.state.doc.toString()).toBe('class Order {}')
+    })
+
+    useSessionStore.setState({ code: 'class Order {}', activeTabId: 'tab-a' })
+    rerender(
+      <UmpleEditor
+        ref={ref}
+        code="class Order {}"
+        activeTabId="tab-a"
+        onChange={() => { }}
+        collabConfig={{ ytext: personText, awareness }}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(ref.current?.view?.state.doc.toString()).toBe('class Person {}')
+    })
+    expect(personText.toString()).toBe('class Person {}')
+  })
+})


### PR DESCRIPTION
## Summary
- keep collab tab restores from patching the editor with stale session store code
- continue treating Y.Text as the source of truth when switching back to a shared tab
- add a regression test for the stale-props tab-switch case

## Test plan
- bun run test src/components/editor/__tests__/UmpleEditor.test.tsx
- bun run test src/hooks/__tests__/useLsp.test.tsx src/components/editor/__tests__/TabBar.test.tsx
- bun run build