### PR TITLE
fix(collab): snapshot compile sources across tabs

### DIFF
--- a/frontend/src/components/diagram/DiagramPanel.tsx
+++ b/frontend/src/components/diagram/DiagramPanel.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/components/ui/button'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { cn } from '@/lib/utils'
 import { api } from '@/api/client'
+import { getCompileSourceSnapshot } from '@/lib/compileSource'
 
 function triggerDownload(href: string, filename: string) {
   const link = document.createElement('a')
@@ -32,10 +33,9 @@ export function DiagramPanel() {
   const umpleModel = useSessionStore((s) => s.umpleModel)
   const classLayout = useSessionStore((s) => s.classLayout)
   const storedLayout = useSessionStore((s) => s.storedLayout)
-  const code = useSessionStore((s) => s.code)
   const modelId = useSessionStore((s) => s.modelId)
-  const activeTabId = useSessionStore((s) => s.activeTabId)
   const generateTargetId = useSessionStore((s) => s.generateTargetId)
+  const tabsVersion = useSessionStore((s) => s.tabsVersion)
   const dynamicGeneration = usePreferencesStore((s) => s.dynamicGeneration)
   const renderMode = useEphemeralStore((s) => s.renderMode)
   const generatingOutput = useEphemeralStore((s) => s.generatingOutput)
@@ -48,18 +48,17 @@ export function DiagramPanel() {
   const generatedDownloads = useEphemeralStore((s) => s.generatedDownloads)
   const generatedTargetId = useEphemeralStore((s) => s.generatedTargetId)
   const generatedLanguage = useEphemeralStore((s) => s.generatedLanguage)
-  const generatedSourceCode = useEphemeralStore((s) => s.generatedSourceCode)
-  const generatedSourceTabId = useEphemeralStore((s) => s.generatedSourceTabId)
-  const diagramSourceCode = useEphemeralStore((s) => s.diagramSourceCode)
-  const diagramSourceTabId = useEphemeralStore((s) => s.diagramSourceTabId)
+  const generatedSourceSignature = useEphemeralStore((s) => s.generatedSourceSignature)
+  const diagramSourceSignature = useEphemeralStore((s) => s.diagramSourceSignature)
   const diagramTargetId = useEphemeralStore((s) => s.diagramTargetId)
   const generatingCode = useEphemeralStore((s) => s.generatingCode)
   const generatedError = useEphemeralStore((s) => s.generatedError)
   const generationRequested = useEphemeralStore((s) => s.generationRequested)
   const generationSuspendedByError = useEphemeralStore((s) => s.generationSuspendedByError)
-  const generationErrorSourceCode = useEphemeralStore((s) => s.generationErrorSourceCode)
-  const generationErrorSourceTabId = useEphemeralStore((s) => s.generationErrorSourceTabId)
+  const generationErrorSourceSignature = useEphemeralStore((s) => s.generationErrorSourceSignature)
   const openExamplesPalette = useEphemeralStore((s) => s.openExamplesPalette)
+  const currentSource = getCompileSourceSnapshot()
+  void tabsVersion
 
 
   const currentSvg = svgCache[viewMode] ?? ''
@@ -83,8 +82,7 @@ export function DiagramPanel() {
   const showEmptyCanvasState = viewMode === 'class' && !generatingOutput && !hasEditableModel && !currentSvg
   const generationErrorMatchesCurrentInput = Boolean(
     generationSuspendedByError &&
-    generationErrorSourceTabId === activeTabId &&
-    generationErrorSourceCode === code,
+    generationErrorSourceSignature === currentSource.signature,
   )
   const staleOutputDescription = generationErrorMatchesCurrentInput
     ? 'Fix the error in the code.'
@@ -94,10 +92,9 @@ export function DiagramPanel() {
     hasVisibleDiagramOutput &&
     !generatingOutput &&
     (!dynamicGeneration || generationErrorMatchesCurrentInput) &&
-    diagramSourceTabId &&
+    diagramSourceSignature &&
     (
-      diagramSourceTabId !== activeTabId ||
-      diagramSourceCode !== code ||
+      diagramSourceSignature !== currentSource.signature ||
       diagramTargetId !== generateTargetId
     ),
   )
@@ -107,22 +104,21 @@ export function DiagramPanel() {
     hasGeneratedOutput &&
     !generatingCode &&
     (!dynamicGeneration || generationErrorMatchesCurrentInput) &&
-    generatedSourceTabId &&
+    generatedSourceSignature &&
     (
-      generatedSourceTabId !== activeTabId ||
-      generatedSourceCode !== code ||
+      generatedSourceSignature !== currentSource.signature ||
       generatedTargetId !== generateTargetId
     ),
   )
 
   const handleExport = useCallback(async (format: string) => {
+    const latestSource = getCompileSourceSnapshot()
+
     // Umple source code — zip all tabs client-side
     if (format === 'ump') {
-      const { tabs, activeTabId } = useSessionStore.getState()
       const zip = new JSZip()
-      for (const tab of tabs) {
-        const content = tab.id === activeTabId ? code : tab.code
-        zip.file(tab.name, content)
+      for (const tab of latestSource.tabs) {
+        zip.file(tab.name, tab.code)
       }
       const blob = await zip.generateAsync({ type: 'blob' })
       const url = URL.createObjectURL(blob)
@@ -149,11 +145,16 @@ export function DiagramPanel() {
 
     // GV mode or fallback: use backend export
     const activeTabId = useSessionStore.getState().activeTabId
-    const blob = await api.export({ code, format, modelId: modelId ?? undefined, activeTabId })
+    const blob = await api.export({
+      code: latestSource.activeCode,
+      format,
+      modelId: modelId ?? undefined,
+      activeTabId,
+    })
     const url = URL.createObjectURL(blob)
     triggerDownload(url, filename)
     URL.revokeObjectURL(url)
-  }, [code, modelId, viewMode, showGv])
+  }, [modelId, viewMode, showGv])
 
   return (
     <div className="h-full flex flex-col" data-testid="diagram-panel">

--- a/frontend/src/components/diagram/__tests__/DiagramPanel.test.tsx
+++ b/frontend/src/components/diagram/__tests__/DiagramPanel.test.tsx
@@ -6,6 +6,7 @@ import { useEphemeralStore } from '@/stores/ephemeralStore'
 import { usePreferencesStore } from '@/stores/preferencesStore'
 import { useSessionStore } from '@/stores/sessionStore'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { buildCompileSourceSignature } from '@/lib/compileSource'
 
 const rendererProps = vi.hoisted(() => ({
   umpleEditable: [] as boolean[],
@@ -73,6 +74,10 @@ afterEach(() => {
   useSessionStore.setState({
     code: '',
     modelId: null,
+    activeTabId: 'main',
+    tabs: [{ id: 'main', name: 'Model.ump', code: '', dirty: false, savedCode: '', undoStack: [], redoStack: [] }],
+    tabsVersion: 0,
+    generateTargetId: 'classDiagram',
     viewMode: 'class',
     diagramData: {},
     svgCache: {},
@@ -93,14 +98,17 @@ afterEach(() => {
     generatedLanguage: 'Java',
     generatedSourceCode: null,
     generatedSourceTabId: null,
+    generatedSourceSignature: null,
     generatingCode: false,
     generatedError: null,
     generationRequested: false,
     generationSuspendedByError: false,
     generationErrorSourceCode: null,
     generationErrorSourceTabId: null,
+    generationErrorSourceSignature: null,
     diagramSourceCode: null,
     diagramSourceTabId: null,
+    diagramSourceSignature: null,
     diagramTargetId: null,
   })
   usePreferencesStore.setState({ dynamicGeneration: true })
@@ -225,6 +233,10 @@ describe('DiagramPanel', () => {
 
   it('greys and freezes generated output when manual generation becomes stale', () => {
     usePreferencesStore.setState({ dynamicGeneration: false })
+    const staleSignature = buildCompileSourceSignature(
+      [{ id: 'main', name: 'Model.ump', code: 'class Invoice { number; }' }],
+      'main',
+    )
     useSessionStore.setState({
       code: 'class UpdatedInvoice { number; }',
       activeTabId: 'main',
@@ -234,6 +246,7 @@ describe('DiagramPanel', () => {
       generatedCode: 'class InvoiceGenerated {}',
       generatedSourceCode: 'class Invoice { number; }',
       generatedSourceTabId: 'main',
+      generatedSourceSignature: staleSignature,
       generationRequested: true,
     })
 
@@ -250,6 +263,10 @@ describe('DiagramPanel', () => {
 
   it('greys and freezes diagram output when manual generation becomes stale', () => {
     usePreferencesStore.setState({ dynamicGeneration: false })
+    const staleSignature = buildCompileSourceSignature(
+      [{ id: 'main', name: 'Model.ump', code: 'class Invoice { number; }' }],
+      'main',
+    )
     useSessionStore.setState({
       code: 'class UpdatedInvoice { number; }',
       activeTabId: 'main',
@@ -263,6 +280,7 @@ describe('DiagramPanel', () => {
       rightPanelView: 'diagram',
       diagramSourceCode: 'class Invoice { number; }',
       diagramSourceTabId: 'main',
+      diagramSourceSignature: staleSignature,
       diagramTargetId: 'classDiagram',
     })
 
@@ -280,6 +298,14 @@ describe('DiagramPanel', () => {
 
   it('keeps diagram output stale in dynamic mode after a compile error', () => {
     usePreferencesStore.setState({ dynamicGeneration: true })
+    const freshSignature = buildCompileSourceSignature(
+      [{ id: 'main', name: 'Model.ump', code: 'class Invoice { number; }' }],
+      'main',
+    )
+    const erroredSignature = buildCompileSourceSignature(
+      [{ id: 'main', name: 'Model.ump', code: 'class Invoice { number }' }],
+      'main',
+    )
     useSessionStore.setState({
       code: 'class Invoice { number }',
       activeTabId: 'main',
@@ -293,10 +319,12 @@ describe('DiagramPanel', () => {
       rightPanelView: 'diagram',
       diagramSourceCode: 'class Invoice { number; }',
       diagramSourceTabId: 'main',
+      diagramSourceSignature: freshSignature,
       diagramTargetId: 'classDiagram',
       generationSuspendedByError: true,
       generationErrorSourceCode: 'class Invoice { number }',
       generationErrorSourceTabId: 'main',
+      generationErrorSourceSignature: erroredSignature,
     })
 
     render(
@@ -313,6 +341,14 @@ describe('DiagramPanel', () => {
 
   it('does not freeze the current dynamic output because another input failed to compile', () => {
     usePreferencesStore.setState({ dynamicGeneration: true })
+    const currentSignature = buildCompileSourceSignature(
+      [{ id: 'main', name: 'Model.ump', code: 'class UpdatedInvoice { number; }' }],
+      'main',
+    )
+    const otherSignature = buildCompileSourceSignature(
+      [{ id: 'main', name: 'Model.ump', code: 'class Broken { number }' }],
+      'other-tab',
+    )
     useSessionStore.setState({
       code: 'class UpdatedInvoice { number; }',
       activeTabId: 'main',
@@ -326,10 +362,12 @@ describe('DiagramPanel', () => {
       rightPanelView: 'diagram',
       diagramSourceCode: 'class Invoice { number; }',
       diagramSourceTabId: 'main',
+      diagramSourceSignature: currentSignature,
       diagramTargetId: 'classDiagram',
       generationSuspendedByError: true,
       generationErrorSourceCode: 'class Broken { number }',
       generationErrorSourceTabId: 'other-tab',
+      generationErrorSourceSignature: otherSignature,
     })
 
     render(
@@ -344,6 +382,10 @@ describe('DiagramPanel', () => {
 
   it('keeps the current diagram visible and stale after a manual-mode target switch', () => {
     usePreferencesStore.setState({ dynamicGeneration: false })
+    const currentSignature = buildCompileSourceSignature(
+      [{ id: 'main', name: 'Model.ump', code: 'class Invoice { number; }' }],
+      'main',
+    )
     useSessionStore.setState({
       code: 'class Invoice { number; }',
       activeTabId: 'main',
@@ -357,6 +399,7 @@ describe('DiagramPanel', () => {
       rightPanelView: 'diagram',
       diagramSourceCode: 'class Invoice { number; }',
       diagramSourceTabId: 'main',
+      diagramSourceSignature: currentSignature,
       diagramTargetId: 'classDiagram',
     })
 

--- a/frontend/src/components/layout/AppToolbar.tsx
+++ b/frontend/src/components/layout/AppToolbar.tsx
@@ -10,6 +10,7 @@ import {
   APP_TOOLBAR_GENERATE_TARGET_GROUPS,
   getGenerateTarget,
 } from "../../generation/targets";
+import { getCompileSourceSnapshot } from "@/lib/compileSource";
 import { AiConfigForm } from "@/components/sidebar/AiConfigForm";
 import { useTaskStore } from "../../stores/taskStore";
 import {
@@ -87,12 +88,10 @@ export function AppToolbar() {
   const errorCount = useEphemeralStore((s) => s.outputErrorCount);
   const dynamicGeneration = usePreferencesStore((s) => s.dynamicGeneration);
   const generateTargetId = useSessionStore((s) => s.generateTargetId);
-  const code = useSessionStore((s) => s.code);
-  const activeTabId = useSessionStore((s) => s.activeTabId);
+  const tabsVersion = useSessionStore((s) => s.tabsVersion);
   const selectedExampleId = useSessionStore((s) => s.selectedExampleId);
   const selectedExampleSetId = useSessionStore((s) => s.selectedExampleSetId);
-  const generationErrorSourceCode = useEphemeralStore((s) => s.generationErrorSourceCode);
-  const generationErrorSourceTabId = useEphemeralStore((s) => s.generationErrorSourceTabId);
+  const generationErrorSourceSignature = useEphemeralStore((s) => s.generationErrorSourceSignature);
   const handleGenerate = useSelectGenerateTarget();
   const {
     sets: exampleSets,
@@ -103,14 +102,15 @@ export function AppToolbar() {
   const selectedGenerateTarget = getGenerateTarget(generateTargetId);
   const canExecuteGenerateTarget = Boolean(selectedGenerateTarget?.executable);
   const regeneratingOutput = regenerating || generatingOutput;
+  const currentSource = getCompileSourceSnapshot();
   const generationSuspendedForCurrentInput =
-    generationErrorSourceTabId === activeTabId &&
-    generationErrorSourceCode === code;
+    generationErrorSourceSignature === currentSource.signature;
   const showTemporaryRegenerate = dynamicGeneration && generationSuspendedForCurrentInput;
   const [examplePickerOpen, setExamplePickerOpen] = useState(false);
   const [activeExampleSetId, setActiveExampleSetId] =
     useState<ExampleSetId | null>(null);
   const [exampleQuery, setExampleQuery] = useState("");
+  void tabsVersion;
 
   const selectedExampleSet = useMemo(
     () =>

--- a/frontend/src/hooks/__tests__/useCollabTabs.test.tsx
+++ b/frontend/src/hooks/__tests__/useCollabTabs.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import * as Y from 'yjs'
+
+import { useCollabTabs } from '../useCollabTabs'
+import { useCollabStore } from '@/stores/collabStore'
+import { useSessionStore } from '@/stores/sessionStore'
+
+const { getYDocMock } = vi.hoisted(() => ({
+  getYDocMock: vi.fn(),
+}))
+
+vi.mock('../useCollab', () => ({
+  getYDoc: getYDocMock,
+}))
+
+function TestHarness() {
+  useCollabTabs()
+  return null
+}
+
+describe('useCollabTabs', () => {
+  afterEach(() => {
+    cleanup()
+    getYDocMock.mockReset()
+    useCollabStore.setState({
+      isCollaborating: false,
+      roomId: null,
+      connected: false,
+      ready: false,
+      connectedUsers: [],
+    })
+    useSessionStore.setState({
+      code: '',
+      activeTabId: 'main',
+      tabsVersion: 0,
+      tabs: [{ id: 'main', name: 'Model.ump', code: '', dirty: false, savedCode: '', undoStack: [], redoStack: [] }],
+    })
+  })
+
+  it('syncs remote non-active tab text edits into session state and bumps tabsVersion', async () => {
+    const doc = new Y.Doc()
+    const ytabs = doc.getMap('tabs')
+
+    doc.transact(() => {
+      const mainMeta = new Y.Map<unknown>()
+      mainMeta.set('name', 'Model.ump')
+      mainMeta.set('order', 0)
+      ytabs.set('main', mainMeta)
+      doc.getText('tab:main').insert(0, 'class Invoice {}')
+
+      const helperMeta = new Y.Map<unknown>()
+      helperMeta.set('name', 'Helper.ump')
+      helperMeta.set('order', 1)
+      ytabs.set('helper', helperMeta)
+      doc.getText('tab:helper').insert(0, 'class Helper {}')
+    })
+
+    getYDocMock.mockReturnValue(doc)
+    useCollabStore.setState({ isCollaborating: true, ready: true })
+    useSessionStore.setState({
+      code: 'class Invoice {}',
+      activeTabId: 'main',
+      tabsVersion: 0,
+      tabs: [
+        { id: 'main', name: 'Model.ump', code: 'class Invoice {}', dirty: false, savedCode: 'class Invoice {}', undoStack: [], redoStack: [] },
+        { id: 'helper', name: 'Helper.ump', code: 'class Helper {}', dirty: false, savedCode: 'class Helper {}', undoStack: [], redoStack: [] },
+      ],
+    })
+
+    render(<TestHarness />)
+
+    act(() => {
+      doc.transact(() => {
+        const helperText = doc.getText('tab:helper')
+        helperText.delete(0, helperText.length)
+        helperText.insert(0, 'class Helper { String name; }')
+      })
+    })
+
+    await waitFor(() => {
+      expect(
+        useSessionStore.getState().tabs.find((tab) => tab.id === 'helper')?.code,
+      ).toBe('class Helper { String name; }')
+    })
+
+    expect(useSessionStore.getState().tabsVersion).toBe(1)
+    expect(useSessionStore.getState().code).toBe('class Invoice {}')
+  })
+})

--- a/frontend/src/hooks/useCollabTabs.ts
+++ b/frontend/src/hooks/useCollabTabs.ts
@@ -41,20 +41,46 @@ export function replaceYText(ytext: Y.Text, content: string) {
 function syncToLocal(doc: Y.Doc) {
   const collabTabs = readYTabs(doc);
   const store = useSessionStore.getState();
+  let shouldUpdate = false;
+  let shouldBumpTabsVersion =
+    collabTabs.length !== store.tabs.length ||
+    collabTabs.some((tab, index) => store.tabs[index]?.id !== tab.id);
 
   // Build lookup of local tabs
   const localById = new Map(store.tabs.map((t) => [t.id, t]));
 
   const nextTabs = collabTabs.map((ct) => {
     const local = localById.get(ct.id);
+    const nextCode = ct.id === store.activeTabId ? store.code : ct.code;
+
     if (local) {
+      const sharedFieldsChanged = local.name !== ct.name;
+      const nonActiveCodeChanged =
+        ct.id !== store.activeTabId && local.code !== ct.code;
+      const nextTab =
+        sharedFieldsChanged || local.code !== nextCode
+          ? {
+              ...local,
+              name: ct.name,
+              code: nextCode,
+            }
+          : local;
+
+      shouldUpdate =
+        shouldUpdate ||
+        nextTab !== local;
+      shouldBumpTabsVersion =
+        shouldBumpTabsVersion ||
+        sharedFieldsChanged ||
+        nonActiveCodeChanged;
+
       // Preserve local-only fields; update shared fields
-      return {
-        ...local,
-        name: ct.name,
-        code: ct.id === store.activeTabId ? store.code : ct.code,
-      };
+      return nextTab;
     }
+
+    shouldUpdate = true;
+    shouldBumpTabsVersion = true;
+
     // New tab from remote
     return {
       id: ct.id,
@@ -72,15 +98,23 @@ function syncToLocal(doc: Y.Doc) {
   const activeStillExists = nextTabs.some((t) => t.id === nextActiveTabId);
   if (!activeStillExists && nextTabs.length > 0) {
     nextActiveTabId = nextTabs[0].id;
+    shouldUpdate = true;
+    shouldBumpTabsVersion = true;
   }
 
   const nextCode = nextTabs.find((t) => t.id === nextActiveTabId)?.code ?? "";
+  if (nextCode !== store.code || nextActiveTabId !== store.activeTabId) {
+    shouldUpdate = true;
+  }
 
-  useSessionStore.setState({
+  if (!shouldUpdate && !shouldBumpTabsVersion) return;
+
+  useSessionStore.setState((state) => ({
     tabs: nextTabs,
     activeTabId: nextActiveTabId,
     code: nextCode,
-  });
+    ...(shouldBumpTabsVersion ? { tabsVersion: state.tabsVersion + 1 } : {}),
+  }));
 }
 
 // ── Observer hook ────────────────────────────────────────────────────
@@ -100,15 +134,13 @@ export function useCollabTabs() {
     const doc = getYDoc();
     if (!doc) return;
 
-    const ytabs = doc.getMap("tabs");
-
-    // Deep observer: fires on changes to the map itself (add/delete keys)
-    // AND on changes within nested Y.Maps (name, order updates).
+    // Transaction observer: fires on tab metadata changes AND tab text edits
+    // so non-active collaborative changes still refresh local state/output.
     const observer = () => syncToLocal(doc);
-    ytabs.observeDeep(observer);
+    doc.on('afterTransaction', observer);
 
     return () => {
-      ytabs.unobserveDeep(observer);
+      doc.off('afterTransaction', observer);
     };
   }, [isCollaborating, ready]);
 }

--- a/frontend/src/hooks/useCompiler.ts
+++ b/frontend/src/hooks/useCompiler.ts
@@ -2,8 +2,6 @@ import { useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 import { useSessionStore, type DiagramView } from '../stores/sessionStore'
 import { useEphemeralStore } from '../stores/ephemeralStore'
-import { useCollabStore } from '../stores/collabStore'
-import { getYDoc } from './useCollab'
 import { urlModelResolved } from './useModelFromURL'
 import {
   usePreferencesStore,
@@ -15,6 +13,7 @@ import { useIsDark } from './useIsDark'
 import { api } from '../api/client'
 import type { UmpleModel, GvLayout, StoredLayoutMetadata } from '../api/types'
 import { getGenerateTarget, resolveGenerateRequestLanguage } from '../generation/targets'
+import { getCompileSourceSnapshot } from '../lib/compileSource'
 
 /** Diagram-only messages that are transient (not real compilation errors).
  *  Matched via exact equality (case-insensitive, trimmed) to avoid
@@ -60,7 +59,7 @@ export async function generateAndRefresh(
   signal?: AbortSignal,
   targetId?: string,
 ): Promise<{ success: boolean; model: UmpleModel | null }> {
-  const { code, modelId, setModelId, setUmpleModel, tabs, activeTabId, generateTargetId, viewMode, setViewMode } = useSessionStore.getState()
+  const { modelId, setModelId, setUmpleModel, activeTabId, generateTargetId, viewMode, setViewMode } = useSessionStore.getState()
   const { clearSvgCache, clearHtmlCache, setSvgForView, setHtmlForView } = useSessionStore.getState()
   const {
     clearGenerationError,
@@ -74,9 +73,10 @@ export async function generateAndRefresh(
     setRightPanelView,
   } = useEphemeralStore.getState()
   const target = getGenerateTarget(targetId ?? generateTargetId)
-  const sourceSnapshot = { code, tabId: activeTabId }
+  const { activeCode, signature, tabs: compileTabs } = getCompileSourceSnapshot()
+  const sourceSnapshot = { code: activeCode, tabId: activeTabId, signature }
 
-  if (!code.trim() || !target) return { success: false, model: null }
+  if (!activeCode.trim() || !target) return { success: false, model: null }
 
   setGeneratingOutput(true)
   setExecutionOutput('')
@@ -91,27 +91,18 @@ export async function generateAndRefresh(
   try {
     const activeView = target.action === 'diagram' ? target.diagramView ?? viewMode : viewMode
 
-    // In collab mode, read tab content from Y.Text (authoritative) instead
-    // of the possibly-stale sessionStore cache for non-active tabs.
-    const doc = useCollabStore.getState().isCollaborating ? getYDoc() : null
-    const compileTabs = tabs.map(({ id, name, code: localCode }) => ({
-      id,
-      name,
-      code: doc ? doc.getText(`tab:${id}`).toString() : localCode,
-    }))
-
     // Single request: compile + diagram generation
     const request =
       target.action === 'diagram'
         ? {
-            code,
+            code: activeCode,
             modelId: modelId ?? undefined,
             ...getDiagramRequestParams(activeView, isDark),
             tabs: compileTabs,
             activeTabId,
           }
         : {
-            code,
+            code: activeCode,
             modelId: modelId ?? undefined,
             language: resolveGenerateRequestLanguage(target, viewMode),
             tabs: compileTabs,
@@ -332,7 +323,7 @@ export function useCompiler() {
     const activeTarget = getGenerateTarget(generateTargetIdRef.current)
     if (activeTarget?.action !== 'diagram') return
     if (viewModeRef.current === 'crud') return // CRUD UI is a local component, no backend diagram
-    const currentCode = codeRef.current
+    const { activeCode: currentCode } = getCompileSourceSnapshot()
     const currentModelId = modelIdRef.current
     if (!currentCode?.trim() || !currentModelId) return
 

--- a/frontend/src/hooks/useDiagramSync.ts
+++ b/frontend/src/hooks/useDiagramSync.ts
@@ -9,6 +9,7 @@ import { getYDoc } from './useCollab'
 import { replaceYText } from './useCollabTabs'
 import { generateAndRefresh } from './useCompiler'
 import { getGenerateTargetIdForView } from '../generation/targets'
+import { getCompileSourceSnapshot } from '../lib/compileSource'
 
 interface SyncResult {
   success: boolean
@@ -105,6 +106,15 @@ export function useDiagramSync() {
         const diagramTargetId =
           getGenerateTargetIdForView(session.viewMode) ?? session.generateTargetId
 
+        // In collab mode, also write to Y.Text so the change propagates
+        // to other collaborators. The editor effect no longer does this.
+        if (useCollabStore.getState().isCollaborating) {
+          const doc = getYDoc()
+          if (doc) {
+            replaceYText(doc.getText(`tab:${session.activeTabId}`), response.code!)
+          }
+        }
+
         // Editable class-diagram actions already mutate the visible diagram in-place,
         // so in manual mode they should not immediately mark that same diagram stale.
         if (
@@ -113,19 +123,12 @@ export function useDiagramSync() {
           rightPanelView === 'diagram' &&
           diagramTargetId
         ) {
+          const source = getCompileSourceSnapshot()
           markDiagramFresh(diagramTargetId, {
-            code: response.code,
-            tabId: session.activeTabId,
+            code: source.activeCode,
+            tabId: source.activeTabId,
+            signature: source.signature,
           })
-        }
-
-        // In collab mode, also write to Y.Text so the change propagates
-        // to other collaborators. The editor effect no longer does this.
-        if (useCollabStore.getState().isCollaborating) {
-          const doc = getYDoc()
-          if (doc) {
-            replaceYText(doc.getText(`tab:${session.activeTabId}`), response.code!)
-          }
         }
       }
 

--- a/frontend/src/lib/compileSource.ts
+++ b/frontend/src/lib/compileSource.ts
@@ -1,0 +1,59 @@
+import type { ApiTab } from '@/api/types'
+import { getYDoc } from '@/hooks/useCollab'
+import { useCollabStore } from '@/stores/collabStore'
+import { useSessionStore } from '@/stores/sessionStore'
+
+export interface CompileSourceSnapshot {
+  activeCode: string
+  activeTabId: string
+  signature: string
+  tabs: ApiTab[]
+}
+
+export function buildCompileSourceSignature(tabs: ApiTab[], activeTabId: string): string {
+  let hash = 0x811c9dc5
+
+  const feed = (value: string) => {
+    for (let index = 0; index < value.length; index += 1) {
+      hash ^= value.charCodeAt(index)
+      hash = Math.imul(hash, 0x01000193)
+    }
+  }
+
+  feed(activeTabId)
+  feed('\u0000')
+
+  for (const tab of tabs) {
+    feed(tab.id)
+    feed('\u0001')
+    feed(tab.name)
+    feed('\u0002')
+    feed(tab.code)
+    feed('\u0003')
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+export function getCompileSourceSnapshot(): CompileSourceSnapshot {
+  const { tabs, activeTabId, code } = useSessionStore.getState()
+  const doc = useCollabStore.getState().isCollaborating ? getYDoc() : null
+
+  const compileTabs = tabs.map(({ id, name, code: localCode }) => ({
+    id,
+    name,
+    code:
+      id === activeTabId
+        ? (doc ? doc.getText(`tab:${id}`).toString() : code)
+        : (doc ? doc.getText(`tab:${id}`).toString() : localCode),
+  }))
+
+  const activeCode = compileTabs.find((tab) => tab.id === activeTabId)?.code ?? code
+
+  return {
+    activeCode,
+    activeTabId,
+    signature: buildCompileSourceSignature(compileTabs, activeTabId),
+    tabs: compileTabs,
+  }
+}

--- a/frontend/src/stores/ephemeralStore.ts
+++ b/frontend/src/stores/ephemeralStore.ts
@@ -108,16 +108,19 @@ interface EphemeralState {
   generatedLanguage: string
   generatedSourceCode: string | null
   generatedSourceTabId: string | null
+  generatedSourceSignature: string | null
   generatingCode: boolean
   generatedError: string | null
   generationRequested: boolean
   generationSuspendedByError: boolean
   generationErrorSourceCode: string | null
   generationErrorSourceTabId: string | null
+  generationErrorSourceSignature: string | null
 
   // Diagram ephemeral
   diagramSourceCode: string | null
   diagramSourceTabId: string | null
+  diagramSourceSignature: string | null
   diagramTargetId: string | null
   renderMode: 'editable' | 'graphviz'
   selectedNodeId: string | null
@@ -161,16 +164,16 @@ interface EphemeralState {
   setGeneratedOutput: (
     result: GenerateResponse,
     targetId: string,
-    source: { code: string; tabId: string },
+    source: { code: string; tabId: string; signature: string },
   ) => void
-  markGenerationErrored: (source: { code: string; tabId: string }) => void
+  markGenerationErrored: (source: { code: string; tabId: string; signature: string }) => void
   clearGenerationError: () => void
   setGeneratingCode: (generating: boolean, targetId?: string) => void
   setGeneratedError: (error: string | null) => void
   clearGenerated: () => void
 
   // Diagram ephemeral actions
-  markDiagramFresh: (targetId: string, source: { code: string; tabId: string }) => void
+  markDiagramFresh: (targetId: string, source: { code: string; tabId: string; signature: string }) => void
   setRenderMode: (mode: 'editable' | 'graphviz') => void
   setSelectedNode: (id: string | null) => void
   setSelectedEdge: (id: string | null) => void
@@ -219,16 +222,19 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
   generatedLanguage: 'Java',
   generatedSourceCode: null,
   generatedSourceTabId: null,
+  generatedSourceSignature: null,
   generatingCode: false,
   generatedError: null,
   generationRequested: false,
   generationSuspendedByError: false,
   generationErrorSourceCode: null,
   generationErrorSourceTabId: null,
+  generationErrorSourceSignature: null,
 
   // Diagram ephemeral
   diagramSourceCode: null,
   diagramSourceTabId: null,
+  diagramSourceSignature: null,
   diagramTargetId: null,
   renderMode: 'graphviz',
   selectedNodeId: null,
@@ -301,6 +307,7 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
       generatedLanguage: result.language,
       generatedSourceCode: source.code,
       generatedSourceTabId: source.tabId,
+      generatedSourceSignature: source.signature,
       rightPanelView: 'generated',
       generatedError: result.errors ?? null,
     }),
@@ -308,11 +315,13 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
     generationSuspendedByError: true,
     generationErrorSourceCode: source.code,
     generationErrorSourceTabId: source.tabId,
+    generationErrorSourceSignature: source.signature,
   }),
   clearGenerationError: () => set({
     generationSuspendedByError: false,
     generationErrorSourceCode: null,
     generationErrorSourceTabId: null,
+    generationErrorSourceSignature: null,
   }),
   setGeneratingCode: (generatingCode, targetId) => set(generatingCode
     ? { generatingCode, generationRequested: true, ...(targetId ? { generatedTargetId: targetId } : {}) }
@@ -327,12 +336,14 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
     generatedDownloads: [],
     generatedSourceCode: null,
     generatedSourceTabId: null,
+    generatedSourceSignature: null,
     generatedError: null,
     rightPanelView: 'diagram',
     generationRequested: false,
     generationSuspendedByError: false,
     generationErrorSourceCode: null,
     generationErrorSourceTabId: null,
+    generationErrorSourceSignature: null,
   }),
 
   // Diagram ephemeral actions
@@ -340,6 +351,7 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
     diagramTargetId,
     diagramSourceCode: source.code,
     diagramSourceTabId: source.tabId,
+    diagramSourceSignature: source.signature,
   }),
   setRenderMode: (renderMode) => set({ renderMode }),
   setSelectedNode: (selectedNodeId) => set({ selectedNodeId }),


### PR DESCRIPTION
## Summary
- add a shared compile-source snapshot helper for authoritative active-tab and multi-tab inputs
- store compile source signatures for generated output, diagram freshness, and compile-error retry state
- sync collaborative non-active tab edits back into local state and cover the new behavior with tests

## Test plan
- cd frontend && bun run test -- src/components/diagram/__tests__/DiagramPanel.test.tsx src/hooks/__tests__/useCollabTabs.test.tsx