### PR TITLE
fix: refine fullscreen output controls

### DIFF
--- a/backend/internal/api/handlers/diagram.go
+++ b/backend/internal/api/handlers/diagram.go
@@ -274,6 +274,7 @@ var validSuboptions = map[string]bool{
 	"showguardlabels":       true,
 	"hidenaturallanguage":   true,
 	"showFeatureDependency": true,
+	"gvortho":               true,
 	"gvdot":                 true,
 	"gvsfdp":                true,
 	"gvcirco":               true,

--- a/backend/internal/api/handlers/diagram_test.go
+++ b/backend/internal/api/handlers/diagram_test.go
@@ -16,6 +16,12 @@ func TestDiagramTypeInfoIncludesStructureDiagram(t *testing.T) {
 	}
 }
 
+func TestValidSuboptionsIncludesLegacyGvortho(t *testing.T) {
+	if !validSuboptions["gvortho"] {
+		t.Fatal("gvortho should remain supported for legacy Graphviz parity")
+	}
+}
+
 func TestBuildStructureDiagramHTMLWrapsGeneratedScript(t *testing.T) {
 	got := buildStructureDiagramHTML(`ShapesRegistry.paint({ args: { container: "##CANVAS_ID##" } });`)
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -21,6 +21,7 @@
         "@codemirror/lang-java": "^6.0.1",
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/lang-python": "^6.1.6",
+        "@codemirror/lang-sql": "^6.10.0",
         "@codemirror/language": "^6.10.0",
         "@codemirror/lsp-client": "6.2.2",
         "@codemirror/merge": "^6.12.1",
@@ -165,6 +166,8 @@
     "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
 
     "@codemirror/lang-python": ["@codemirror/lang-python@6.2.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.3.2", "@codemirror/language": "^6.8.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/python": "^1.1.4" } }, "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw=="],
+
+    "@codemirror/lang-sql": ["@codemirror/lang-sql@6.10.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w=="],
 
     "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "@codemirror/lang-java": "^6.0.1",
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/lang-python": "^6.1.6",
+    "@codemirror/lang-sql": "^6.10.0",
     "@codemirror/language": "^6.10.0",
     "@codemirror/lsp-client": "6.2.2",
     "@codemirror/merge": "^6.12.1",

--- a/frontend/src/components/command/CommandPalette.tsx
+++ b/frontend/src/components/command/CommandPalette.tsx
@@ -41,6 +41,7 @@ export function CommandPalette() {
     closeCommandPalette,
     setDiagramOnly,
     diagramOnly,
+    rightPanelView,
     toggleOutputPanel,
     setRenderMode,
     renderMode,
@@ -98,6 +99,8 @@ export function CommandPalette() {
   );
   const canToggleRenderer =
     viewMode === "class" && !!umpleModel?.umpleClasses?.length;
+  const fullscreenLabel =
+    rightPanelView === "generated" ? "Output Only Mode" : "Diagram Only Mode";
 
   return (
     <CommandDialog
@@ -161,7 +164,7 @@ export function CommandPalette() {
             data-testid="command-item-view-diagram-only"
           >
             {diagramOnly ? <Minimize2 /> : <Maximize2 />}
-            {diagramOnly ? "Exit Diagram Only Mode" : "Diagram Only Mode"}
+            {diagramOnly ? "Exit Fullscreen Output" : fullscreenLabel}
           </CommandItem>
           <CommandItem
             onSelect={() => {

--- a/frontend/src/components/diagram/CanvasToolbar.tsx
+++ b/frontend/src/components/diagram/CanvasToolbar.tsx
@@ -6,6 +6,7 @@ import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuRadioGroup, DropdownMenuRadioItem } from '@/components/ui/dropdown-menu'
 import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
 
 const btnBase =
   'px-1.5 py-0.5 text-xs cursor-pointer transition-colors rounded focus-visible:outline-2 focus-visible:outline-brand focus-visible:outline-offset-1 text-ink-muted hover:text-ink hover:bg-surface-2 flex items-center gap-1'
@@ -17,6 +18,7 @@ interface CanvasToolbarProps {
   renderMode: 'editable' | 'graphviz'
   onRenderModeChange: (mode: 'editable' | 'graphviz') => void
   showDisplayOptions?: boolean
+  variant?: 'overlay' | 'banner'
 }
 
 export function CanvasToolbar({
@@ -26,6 +28,7 @@ export function CanvasToolbar({
   renderMode,
   onRenderModeChange,
   showDisplayOptions = true,
+  variant = 'overlay',
 }: CanvasToolbarProps) {
   const viewMode = useSessionStore((s) => s.viewMode)
   const toggles = DISPLAY_TOGGLES[viewMode]
@@ -35,7 +38,12 @@ export function CanvasToolbar({
 
   return (
     <div
-      className="pointer-events-auto flex items-center bg-surface-0/90 backdrop-blur-sm border border-border rounded-lg px-1 py-1 shadow-sm"
+      className={cn(
+        'pointer-events-auto flex items-center rounded-lg',
+        variant === 'overlay'
+          ? 'bg-surface-0/90 backdrop-blur-sm border border-border px-1 py-1 shadow-sm'
+          : 'gap-1'
+      )}
       data-testid="canvas-toolbar"
     >
       {canToggleRenderer && (

--- a/frontend/src/components/diagram/DiagramPanel.tsx
+++ b/frontend/src/components/diagram/DiagramPanel.tsx
@@ -11,13 +11,13 @@ import { ObjectExplorer } from '../crud/ObjectExplorer'
 import { CanvasBanner } from '../layout/CanvasBanner'
 import { useSessionStore, VIEW_OUTPUT_KIND } from '../../stores/sessionStore'
 import { useEphemeralStore } from '../../stores/ephemeralStore'
-import { usePreferencesStore } from '../../stores/preferencesStore'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { cn } from '@/lib/utils'
 import { api } from '@/api/client'
 import { getCompileSourceSnapshot } from '@/lib/compileSource'
+import { useEffectiveDynamicGeneration } from '@/lib/effectiveDynamicGeneration'
 
 function triggerDownload(href: string, filename: string) {
   const link = document.createElement('a')
@@ -36,7 +36,7 @@ export function DiagramPanel() {
   const modelId = useSessionStore((s) => s.modelId)
   const generateTargetId = useSessionStore((s) => s.generateTargetId)
   const tabsVersion = useSessionStore((s) => s.tabsVersion)
-  const dynamicGeneration = usePreferencesStore((s) => s.dynamicGeneration)
+  const dynamicGeneration = useEffectiveDynamicGeneration()
   const renderMode = useEphemeralStore((s) => s.renderMode)
   const generatingOutput = useEphemeralStore((s) => s.generatingOutput)
   const setRenderMode = useEphemeralStore((s) => s.setRenderMode)
@@ -75,6 +75,7 @@ export function DiagramPanel() {
   const showHtml = !showEditable && !editableLoading && outputKind === 'html' && !!currentHtml
   const showGv = !showEditable && !editableLoading && !showHtml && !!currentSvg
   const hasDiagram = showEditable || showHtml || showGv
+  const showDiagramToolbar = rightPanelView === 'diagram' && hasDiagram
   const mountEditable = canToggleRenderer
   const mountHtml = outputKind === 'html' && !!currentHtml
   const mountGv = outputKind === 'gv' && !!currentSvg
@@ -158,7 +159,21 @@ export function DiagramPanel() {
 
   return (
     <div className="h-full flex flex-col" data-testid="diagram-panel">
-      <CanvasBanner />
+      <CanvasBanner
+        operationsContent={
+          showDiagramToolbar ? (
+            <CanvasToolbar
+              hasDiagram={hasDiagram}
+              onExport={handleExport}
+              canToggleRenderer={canToggleRenderer}
+              renderMode={renderMode}
+              onRenderModeChange={setRenderMode}
+              showDisplayOptions={!showHtml}
+              variant="banner"
+            />
+          ) : null
+        }
+      />
       <div className="flex-1 relative" data-testid="diagram-canvas">
         <div className={cn('absolute inset-0', rightPanelView !== 'diagram' && 'invisible')}>
           <div
@@ -167,16 +182,6 @@ export function DiagramPanel() {
               diagramOutputStale && 'pointer-events-none opacity-60 grayscale',
             )}
           >
-            <div className="absolute top-2 left-0 right-0 z-10 flex justify-center pointer-events-none">
-              <CanvasToolbar
-                hasDiagram={hasDiagram}
-                onExport={handleExport}
-                canToggleRenderer={canToggleRenderer}
-                renderMode={renderMode}
-                onRenderModeChange={setRenderMode}
-                showDisplayOptions={!showHtml}
-              />
-            </div>
             {mountEditable && (
               <DiagramLayer active={showEditable}>
                 <UmpleDiagram model={umpleModel!} layout={classLayout ?? undefined} storedLayout={storedLayout ?? undefined} editable={showEditable} />

--- a/frontend/src/components/diagram/__tests__/DiagramPanel.test.tsx
+++ b/frontend/src/components/diagram/__tests__/DiagramPanel.test.tsx
@@ -46,7 +46,7 @@ vi.mock('../HtmlDiagramView', () => ({
 }))
 
 vi.mock('../../layout/CanvasBanner', () => ({
-  CanvasBanner: () => <div data-testid="canvas-banner" />,
+  CanvasBanner: ({ operationsContent }: any) => <div data-testid="canvas-banner">{operationsContent}</div>,
 }))
 
 vi.mock('../../generation/GeneratedOutputView', () => ({
@@ -87,6 +87,7 @@ afterEach(() => {
     storedLayout: null,
   })
   useEphemeralStore.setState({
+    diagramOnly: false,
     rightPanelView: 'diagram',
     renderMode: 'graphviz',
     generatingOutput: false,
@@ -242,6 +243,37 @@ describe('DiagramPanel', () => {
       activeTabId: 'main',
     })
     useEphemeralStore.setState({
+      rightPanelView: 'generated',
+      generatedCode: 'class InvoiceGenerated {}',
+      generatedSourceCode: 'class Invoice { number; }',
+      generatedSourceTabId: 'main',
+      generatedSourceSignature: staleSignature,
+      generationRequested: true,
+    })
+
+    render(
+      <TooltipProvider>
+        <DiagramPanel />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByTestId('generated-output-view')).toBeDefined()
+    expect(screen.getByTestId('generated-output-stale-overlay')).toBeDefined()
+    expect(screen.getByText('Output is out of date. Use Regenerate above to refresh it.')).toBeDefined()
+  })
+
+  it('treats fullscreen generated output like manual mode for staleness', () => {
+    usePreferencesStore.setState({ dynamicGeneration: true })
+    const staleSignature = buildCompileSourceSignature(
+      [{ id: 'main', name: 'Model.ump', code: 'class Invoice { number; }' }],
+      'main',
+    )
+    useSessionStore.setState({
+      code: 'class UpdatedInvoice { number; }',
+      activeTabId: 'main',
+    })
+    useEphemeralStore.setState({
+      diagramOnly: true,
       rightPanelView: 'generated',
       generatedCode: 'class InvoiceGenerated {}',
       generatedSourceCode: 'class Invoice { number; }',

--- a/frontend/src/components/generation/CodeOutput.tsx
+++ b/frontend/src/components/generation/CodeOutput.tsx
@@ -4,6 +4,7 @@ import { EditorState } from '@codemirror/state'
 import { basicSetup } from 'codemirror'
 import { java } from '@codemirror/lang-java'
 import { python } from '@codemirror/lang-python'
+import { sql } from '@codemirror/lang-sql'
 import { getEditorTheme } from '../../codemirror/theme'
 import { useIsDark } from '../../hooks/useIsDark'
 
@@ -12,12 +13,14 @@ interface CodeOutputProps {
   language: string
 }
 
-function getLanguageExtension(language: string) {
+export function getLanguageExtension(language: string) {
   switch (language.toLowerCase()) {
     case 'java':
       return java()
     case 'python':
       return python()
+    case 'sql':
+      return sql()
     case 'php':
     case 'ruby':
     case 'cpp':
@@ -26,7 +29,7 @@ function getLanguageExtension(language: string) {
       // Use Java as a reasonable fallback for C-like / curly-brace languages
       return java()
     default:
-      // No language extension for JSON, SQL, Alloy, NuSMV, USE, Ecore, etc.
+      // No language extension for JSON, Alloy, NuSMV, USE, Ecore, etc.
       return null
   }
 }

--- a/frontend/src/components/generation/__tests__/CodeOutput.test.tsx
+++ b/frontend/src/components/generation/__tests__/CodeOutput.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@codemirror/lang-java', () => ({
+  java: () => 'java-extension',
+}))
+
+vi.mock('@codemirror/lang-python', () => ({
+  python: () => 'python-extension',
+}))
+
+vi.mock('@codemirror/lang-sql', () => ({
+  sql: () => 'sql-extension',
+}))
+
+import { getLanguageExtension } from '../CodeOutput'
+
+describe('getLanguageExtension', () => {
+  it('returns the SQL extension for Sql output', () => {
+    expect(getLanguageExtension('Sql')).toBe('sql-extension')
+    expect(getLanguageExtension('sql')).toBe('sql-extension')
+  })
+
+  it('keeps existing language mappings intact', () => {
+    expect(getLanguageExtension('Java')).toBe('java-extension')
+    expect(getLanguageExtension('Python')).toBe('python-extension')
+  })
+
+  it('falls back to no extension for unsupported languages', () => {
+    expect(getLanguageExtension('Alloy')).toBeNull()
+  })
+})

--- a/frontend/src/components/layout/AppToolbar.tsx
+++ b/frontend/src/components/layout/AppToolbar.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui/popover";
 import { Tip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { useEffectiveDynamicGeneration } from "@/lib/effectiveDynamicGeneration";
 
 const shellBtn =
   "inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-xs font-medium text-ink-muted transition-colors hover:bg-surface-2 hover:text-ink";
@@ -87,6 +88,9 @@ export function AppToolbar() {
   const executing = useEphemeralStore((s) => s.executing);
   const errorCount = useEphemeralStore((s) => s.outputErrorCount);
   const dynamicGeneration = usePreferencesStore((s) => s.dynamicGeneration);
+  const effectiveDynamicGeneration = useEffectiveDynamicGeneration();
+  const diagramOnly = useEphemeralStore((s) => s.diagramOnly);
+  const rightPanelView = useEphemeralStore((s) => s.rightPanelView);
   const generateTargetId = useSessionStore((s) => s.generateTargetId);
   const tabsVersion = useSessionStore((s) => s.tabsVersion);
   const selectedExampleId = useSessionStore((s) => s.selectedExampleId);
@@ -105,7 +109,10 @@ export function AppToolbar() {
   const currentSource = getCompileSourceSnapshot();
   const generationSuspendedForCurrentInput =
     generationErrorSourceSignature === currentSource.signature;
-  const showTemporaryRegenerate = dynamicGeneration && generationSuspendedForCurrentInput;
+  const generationPausedForFullscreen =
+    dynamicGeneration && !effectiveDynamicGeneration && diagramOnly && rightPanelView === "generated";
+  const showTemporaryRegenerate =
+    generationPausedForFullscreen || (dynamicGeneration && generationSuspendedForCurrentInput);
   const [examplePickerOpen, setExamplePickerOpen] = useState(false);
   const [activeExampleSetId, setActiveExampleSetId] =
     useState<ExampleSetId | null>(null);
@@ -469,11 +476,13 @@ export function AppToolbar() {
             </Popover>
           </div>
 
-          {(!dynamicGeneration || showTemporaryRegenerate) && (
+          {(!effectiveDynamicGeneration || showTemporaryRegenerate) && (
             <Tip
               content={
-                showTemporaryRegenerate
-                  ? "Temporary retry while auto-generation is paused by an error"
+                generationPausedForFullscreen
+                  ? "Auto-generation is paused while output is fullscreen"
+                  : showTemporaryRegenerate
+                    ? "Temporary retry while auto-generation is paused by an error"
                   : "Regenerate output (Ctrl+Enter)"
               }
               side="bottom"

--- a/frontend/src/components/layout/CanvasBanner.tsx
+++ b/frontend/src/components/layout/CanvasBanner.tsx
@@ -1,12 +1,18 @@
-import { useEffect } from 'react'
+import { type ReactNode, useEffect } from 'react'
 import { useEphemeralStore } from '../../stores/ephemeralStore'
 import { useSessionStore } from '../../stores/sessionStore'
 import { getGenerateTarget, getGenerateTargetIdForView } from '../../generation/targets'
 import { Maximize2, Minimize2 } from 'lucide-react'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
 import { Tip } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
-export function CanvasBanner() {
+interface CanvasBannerProps {
+  operationsContent?: ReactNode
+}
+
+export function CanvasBanner({ operationsContent }: CanvasBannerProps) {
   const diagramOnly = useEphemeralStore((s) => s.diagramOnly)
   const setDiagramOnly = useEphemeralStore((s) => s.setDiagramOnly)
   const rightPanelView = useEphemeralStore((s) => s.rightPanelView)
@@ -18,6 +24,8 @@ export function CanvasBanner() {
     ? generatedTargetId
     : diagramTargetId ?? getGenerateTargetIdForView(viewMode) ?? generateTargetId
   const currentOutputLabel = getGenerateTarget(currentOutputTargetId)?.label ?? 'Output'
+  const fullscreenLabel = rightPanelView === 'generated' ? 'Output only' : 'Diagram only'
+  const fullscreenAriaLabel = diagramOnly ? 'Show editor' : fullscreenLabel
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -32,23 +40,39 @@ export function CanvasBanner() {
   }, [])
 
   return (
-    <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center h-[var(--toolbar-h)] px-3 shrink-0 border-b border-border" data-testid="canvas-banner">
-      <div />
-      <div className="flex items-center justify-center gap-1.5 min-w-0 overflow-hidden">
-        <span className="truncate rounded-full border border-border bg-surface-0 px-2.5 py-1 text-xs text-ink-muted">
+    <div
+      className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 min-h-[var(--toolbar-h)] px-3 py-1.5 shrink-0 border-b border-border"
+      data-testid="canvas-banner"
+    >
+      <div
+        className="flex min-w-0 items-center justify-start overflow-hidden"
+        data-testid="canvas-banner-leading"
+      >
+        <Label className="min-w-0 truncate text-sm font-medium text-ink-muted">
           {currentOutputLabel}
-        </span>
+        </Label>
       </div>
 
-      <div className="flex items-center justify-end gap-1">
-        <Tip content={diagramOnly ? 'Show editor' : 'Diagram only'} side="bottom">
+      <div className="flex min-w-0 items-center justify-center" data-testid="canvas-banner-operations">
+        {operationsContent ? (
+          <div className="flex min-w-0 items-center justify-center gap-2" data-testid="canvas-banner-operations-content">
+            <Separator orientation="vertical" className="hidden h-5 md:block" />
+            <div className="flex min-w-0 items-center justify-center">
+              {operationsContent}
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex min-w-0 shrink-0 items-center justify-end gap-1">
+        <Tip content={diagramOnly ? 'Show editor' : fullscreenLabel} side="bottom">
           <button
             onClick={() => setDiagramOnly(!diagramOnly)}
             className={cn(
               'p-1.5 transition-colors cursor-pointer rounded-md',
               diagramOnly ? 'text-brand bg-brand-light' : 'text-ink-muted hover:text-ink hover:bg-surface-1'
             )}
-            aria-label={diagramOnly ? 'Show editor' : 'Diagram only'}
+            aria-label={fullscreenAriaLabel}
           >
             {diagramOnly ? <Minimize2 className="size-3.5" /> : <Maximize2 className="size-3.5" />}
           </button>

--- a/frontend/src/components/layout/__tests__/CanvasBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/CanvasBanner.test.tsx
@@ -38,6 +38,21 @@ describe('CanvasBanner', () => {
     expect(screen.getByText('Java Code')).toBeDefined()
   })
 
+  it('switches the fullscreen control copy for generated output', () => {
+    useEphemeralStore.setState({
+      rightPanelView: 'generated',
+      generatedTargetId: 'Java',
+    })
+
+    render(<CanvasBanner />)
+
+    const button = screen.getByRole('button', { name: 'Output only' })
+    fireEvent.click(button)
+
+    expect(useEphemeralStore.getState().diagramOnly).toBe(true)
+    expect(screen.getByRole('button', { name: 'Show editor' })).toBeDefined()
+  })
+
   it("keeps Ctrl+' bound to the output panel toggle", () => {
     render(<CanvasBanner />)
 
@@ -46,5 +61,15 @@ describe('CanvasBanner', () => {
 
     fireEvent.keyDown(window, { key: "'", ctrlKey: true })
     expect(useEphemeralStore.getState().outputView).toBe('hidden')
+  })
+
+  it('renders centered operations content while keeping the label separate', () => {
+    render(<CanvasBanner operationsContent={<div>Toolbar</div>} />)
+
+    expect(screen.getByText('GraphViz Class Diagram')).toBeDefined()
+    expect(screen.getByText('Toolbar')).toBeDefined()
+    expect(screen.getByTestId('canvas-banner-leading')).toBeDefined()
+    expect(screen.getByTestId('canvas-banner-operations')).toBeDefined()
+    expect(screen.getByTestId('canvas-banner-operations-content')).toBeDefined()
   })
 })

--- a/frontend/src/constants/diagram.ts
+++ b/frontend/src/constants/diagram.ts
@@ -16,6 +16,7 @@ export type DiagramOutputKind = 'gv' | 'html' | 'component'
 export type DisplayPrefKey =
   | 'showAttributes'
   | 'showMethods'
+  | 'showOrthogonalEdges'
   | 'showTraits'
   | 'showActions'
   | 'showTransitionLabels'
@@ -66,6 +67,7 @@ export type GvLayoutAlgorithm = (typeof LAYOUT_OPTIONS)[number]['value']
 export interface DiagramDisplayPrefs {
   showAttributes: boolean
   showMethods: boolean
+  showOrthogonalEdges: boolean
   showTraits: boolean
   showActions: boolean
   showTransitionLabels: boolean
@@ -79,6 +81,7 @@ export interface DiagramDisplayPrefs {
 const CLASS_TOGGLES: DiagramDisplayToggle[] = [
   { key: 'showAttributes', label: 'Attributes', disabledSuboption: 'hideattributes' },
   { key: 'showMethods', label: 'Methods', enabledSuboption: 'showmethods' },
+  { key: 'showOrthogonalEdges', label: 'Orthogonal Edges', enabledSuboption: 'gvortho' },
   { key: 'showTraits', label: 'Traits' },
 ]
 
@@ -208,6 +211,7 @@ export const DISPLAY_TOGGLES = Object.fromEntries(
 export const DISPLAY_PREF_DEFAULTS: Record<DisplayPrefKey, boolean> = {
   showAttributes: true,
   showMethods: false,
+  showOrthogonalEdges: false,
   showTraits: false,
   showActions: true,
   showTransitionLabels: false,

--- a/frontend/src/generation/targets.ts
+++ b/frontend/src/generation/targets.ts
@@ -47,7 +47,7 @@ export const GENERATE_TARGET_GROUPS: GenerateTargetGroup[] = [
   {
     label: 'Data Model Views',
     targets: [
-      { id: 'classDiagram', label: 'GraphViz Class Diagram (SVG)', action: 'diagram', diagramView: 'class' },
+      { id: 'classDiagram', label: 'GraphViz Class Diagram', action: 'diagram', diagramView: 'class' },
       { id: 'entityRelationshipDiagram', label: 'Entity Relationship Diagram (GraphViz SVG)', action: 'diagram', diagramView: 'erd' },
       { id: 'crud', label: 'CRUD User Interface', action: 'diagram', diagramView: 'crud' },
       { id: 'Sql', label: 'Sql', action: 'generate' },

--- a/frontend/src/hooks/useCompiler.ts
+++ b/frontend/src/hooks/useCompiler.ts
@@ -14,6 +14,7 @@ import { api } from '../api/client'
 import type { UmpleModel, GvLayout, StoredLayoutMetadata } from '../api/types'
 import { getGenerateTarget, resolveGenerateRequestLanguage } from '../generation/targets'
 import { getCompileSourceSnapshot } from '../lib/compileSource'
+import { useEffectiveDynamicGeneration } from '../lib/effectiveDynamicGeneration'
 
 /** Diagram-only messages that are transient (not real compilation errors).
  *  Matched via exact equality (case-insensitive, trimmed) to avoid
@@ -242,7 +243,7 @@ export function useCompiler() {
   const tabsVersion = useSessionStore((s) => s.tabsVersion)
   const viewMode = useSessionStore((s) => s.viewMode)
   const generateTargetId = useSessionStore((s) => s.generateTargetId)
-  const dynamicGeneration = usePreferencesStore((s) => s.dynamicGeneration)
+  const dynamicGeneration = useEffectiveDynamicGeneration()
   const setSvgForView = useSessionStore((s) => s.setSvgForView)
   const setHtmlForView = useSessionStore((s) => s.setHtmlForView)
   const suboptionsKey = usePreferencesStore(selectSuboptionsKey)

--- a/frontend/src/hooks/useGenerate.ts
+++ b/frontend/src/hooks/useGenerate.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react'
 import { useSessionStore } from '../stores/sessionStore'
-import { usePreferencesStore } from '../stores/preferencesStore'
 import { getGenerateTarget } from '../generation/targets'
 import { generateAndRefresh } from './useCompiler'
 import { useIsDark } from './useIsDark'
+import { useEffectiveDynamicGeneration } from '../lib/effectiveDynamicGeneration'
 
 function selectGenerateTarget(targetId: string) {
   const target = getGenerateTarget(targetId)
@@ -27,7 +27,7 @@ export function useGenerate() {
 
 /** Target-picker behavior. Respects the dynamic generation preference. */
 export function useSelectGenerateTarget() {
-  const dynamicGeneration = usePreferencesStore((s) => s.dynamicGeneration)
+  const dynamicGeneration = useEffectiveDynamicGeneration()
   const isDark = useIsDark()
 
   return useCallback(async (targetId: string) => {

--- a/frontend/src/lib/effectiveDynamicGeneration.ts
+++ b/frontend/src/lib/effectiveDynamicGeneration.ts
@@ -1,0 +1,24 @@
+import { useEphemeralStore } from '@/stores/ephemeralStore'
+import { usePreferencesStore } from '@/stores/preferencesStore'
+
+function isOutputOnlyModeActive(layout: {
+  diagramOnly: boolean
+  rightPanelView: 'diagram' | 'generated'
+}) {
+  return layout.diagramOnly && layout.rightPanelView === 'generated'
+}
+
+export function getEffectiveDynamicGeneration() {
+  const dynamicGeneration = usePreferencesStore.getState().dynamicGeneration
+  const { diagramOnly, rightPanelView } = useEphemeralStore.getState()
+
+  return dynamicGeneration && !isOutputOnlyModeActive({ diagramOnly, rightPanelView })
+}
+
+export function useEffectiveDynamicGeneration() {
+  const dynamicGeneration = usePreferencesStore((s) => s.dynamicGeneration)
+  const diagramOnly = useEphemeralStore((s) => s.diagramOnly)
+  const rightPanelView = useEphemeralStore((s) => s.rightPanelView)
+
+  return dynamicGeneration && !isOutputOnlyModeActive({ diagramOnly, rightPanelView })
+}

--- a/frontend/src/stores/__tests__/preferencesStore.test.ts
+++ b/frontend/src/stores/__tests__/preferencesStore.test.ts
@@ -27,6 +27,7 @@ describe('buildSuboptions', () => {
     const suboptions = buildSuboptions({
       showAttributes: true,
       showMethods: true,
+      showOrthogonalEdges: true,
       showTraits: true,
       showActions: true,
       showTransitionLabels: false,
@@ -38,5 +39,6 @@ describe('buildSuboptions', () => {
     }, 'class', false)
 
     expect(suboptions).toContain('showmethods')
+    expect(suboptions).toContain('gvortho')
   })
 })

--- a/frontend/src/stores/preferencesStore.ts
+++ b/frontend/src/stores/preferencesStore.ts
@@ -102,6 +102,7 @@ interface PreferencesState {
   // Diagram display preferences
   showAttributes: boolean
   showMethods: boolean
+  showOrthogonalEdges: boolean
   showTraits: boolean
   showActions: boolean
   showTransitionLabels: boolean
@@ -252,6 +253,7 @@ export function selectDiagramDisplayPrefs(
   return {
     showAttributes: s.showAttributes,
     showMethods: s.showMethods,
+    showOrthogonalEdges: s.showOrthogonalEdges,
     showTraits: s.showTraits,
     showActions: s.showActions,
     showTransitionLabels: s.showTransitionLabels,


### PR DESCRIPTION
## Summary
- pause effective auto-generation while generated output is fullscreen so stale output shows an explicit regenerate path
- move diagram controls into the canvas banner, clarify fullscreen labels, and add SQL highlighting for generated Sql output
- restore legacy `gvortho` diagram support and extend frontend/backend test coverage

Related to #93

## Test plan
- `cd frontend && bun run test src/components/layout/__tests__/CanvasBanner.test.tsx src/components/diagram/__tests__/DiagramPanel.test.tsx src/components/generation/__tests__/CodeOutput.test.tsx src/stores/__tests__/preferencesStore.test.ts`