### PR TITLE
feat(diagram): restore legacy class filters

### DIFF
--- a/backend/internal/api/handlers/class_diagram_filters.go
+++ b/backend/internal/api/handlers/class_diagram_filters.go
@@ -1,0 +1,177 @@
+package handlers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type classDiagramOverlayParams struct {
+	classFilterQuery string
+	namedFilters     []string
+	mixsets          []string
+}
+
+var (
+	overlayIdentifierRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+	explicitFilterRe    = regexp.MustCompile(`(?m)^\s*filter\s*\{`)
+)
+
+func isValidDiagramSuboption(opt string) bool {
+	if validSuboptions[opt] {
+		return true
+	}
+	_, ok := parseGvSeparatorSuboption(opt)
+	return ok
+}
+
+func parseGvSeparatorSuboption(opt string) (float64, bool) {
+	if !strings.HasPrefix(opt, "gvseparator=") {
+		return 0, false
+	}
+
+	value, err := strconv.ParseFloat(strings.TrimPrefix(opt, "gvseparator="), 64)
+	if err != nil || value <= 0 {
+		return 0, false
+	}
+
+	return value, true
+}
+
+func buildTransientClassDiagramOverlay(
+	p processDiagramParams,
+	modelPath string,
+	modelSource string,
+) (string, func(), error) {
+	if !isClassDiagramType(p.diagramType) {
+		return "", func() {}, nil
+	}
+
+	overlay := classDiagramOverlayParams{
+		classFilterQuery: p.classFilterQuery,
+		namedFilters:     p.namedFilters,
+		mixsets:          p.mixsets,
+	}
+
+	hasExplicitFilter := workspaceHasExplicitFilter(p.dir)
+	nextSource, changed := applyClassDiagramOverlay(modelSource, overlay, hasExplicitFilter)
+	if !changed {
+		return "", func() {}, nil
+	}
+
+	tempName := fmt.Sprintf(".diagram-overlay-%s", filepath.Base(p.entryFile))
+	tempPath := filepath.Join(p.dir, tempName)
+	if err := os.WriteFile(tempPath, []byte(nextSource), 0o644); err != nil {
+		return "", nil, err
+	}
+
+	return tempPath, func() {
+		_ = os.Remove(tempPath)
+	}, nil
+}
+
+func isClassDiagramType(diagramType string) bool {
+	return diagramType == "GvClassDiagram" || diagramType == "GvClassTraitDiagram"
+}
+
+func applyClassDiagramOverlay(
+	modelSource string,
+	overlay classDiagramOverlayParams,
+	hasExplicitFilter bool,
+) (string, bool) {
+	userCode, hiddenLayout, hasDelimiter := splitModelSections(modelSource)
+	directives := buildClassDiagramOverlayDirectives(overlay, hasExplicitFilter)
+	if len(directives) == 0 {
+		return modelSource, false
+	}
+
+	nextUserCode := strings.TrimRight(userCode, "\n")
+	if nextUserCode != "" {
+		nextUserCode += "\n\n"
+	}
+	nextUserCode += strings.Join(directives, "\n")
+
+	return joinModelSections(nextUserCode, hiddenLayout, hasDelimiter), true
+}
+
+func buildClassDiagramOverlayDirectives(
+	overlay classDiagramOverlayParams,
+	hasExplicitFilter bool,
+) []string {
+	var directives []string
+
+	for _, mixset := range overlay.mixsets {
+		if isValidOverlayIdentifier(mixset) {
+			directives = append(directives, "use "+mixset+";")
+		}
+	}
+
+	for _, namedFilter := range overlay.namedFilters {
+		if isValidOverlayIdentifier(namedFilter) {
+			directives = append(directives, fmt.Sprintf("filter {includeFilter %s;}", namedFilter))
+		}
+	}
+
+	var includeParts []string
+	var hopParts []string
+	for _, token := range strings.Fields(strings.TrimSpace(overlay.classFilterQuery)) {
+		if token == "" {
+			continue
+		}
+		if _, ok := parseGvSeparatorSuboption(token); ok {
+			directives = append(directives, fmt.Sprintf("suboption %q;", token))
+			continue
+		}
+		if hopCount, err := strconv.Atoi(token); err == nil && hopCount > 0 {
+			hopParts = append(hopParts, fmt.Sprintf("hops { association %d;}", hopCount))
+			continue
+		}
+		if strings.HasPrefix(token, "gv") {
+			continue
+		}
+		includeParts = append(includeParts, "include "+token+";")
+	}
+
+	if !hasExplicitFilter && (len(includeParts) > 0 || len(hopParts) > 0) {
+		filterParts := append(includeParts, hopParts...)
+		directives = append(directives, "filter { "+strings.Join(filterParts, " ")+" }")
+	}
+
+	return directives
+}
+
+func isValidOverlayIdentifier(value string) bool {
+	return overlayIdentifierRe.MatchString(value)
+}
+
+func workspaceHasExplicitFilter(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".ump") || strings.HasPrefix(entry.Name(), ".diagram-overlay-") {
+			continue
+		}
+		source, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		if hasExplicitTopLevelFilter(string(source)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasExplicitTopLevelFilter(code string) bool {
+	userCode, _, _ := splitModelSections(code)
+	withoutBlockComments := regexp.MustCompile(`/\*[\s\S]*?\*/`).ReplaceAllString(userCode, "")
+	withoutLineComments := regexp.MustCompile(`(?m)//.*$`).ReplaceAllString(withoutBlockComments, "")
+	return explicitFilterRe.MatchString(withoutLineComments)
+}

--- a/backend/internal/api/handlers/class_diagram_filters_test.go
+++ b/backend/internal/api/handlers/class_diagram_filters_test.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsValidDiagramSuboptionAcceptsLegacySeparatorValue(t *testing.T) {
+	if !isValidDiagramSuboption("gvseparator=1.7") {
+		t.Fatal("expected gvseparator=1.7 to be accepted as a valid diagram suboption")
+	}
+	if isValidDiagramSuboption("gvseparator=0") {
+		t.Fatal("expected gvseparator=0 to be rejected")
+	}
+	if isValidDiagramSuboption("gvseparator=abc") {
+		t.Fatal("expected malformed gvseparator value to be rejected")
+	}
+}
+
+func TestApplyClassDiagramOverlayBuildsLegacyFilterDirectives(t *testing.T) {
+	source := "class Invoice {}\n\n//$?[End_of_model]$?\nclass Invoice {\n  position 1 2 3 4;\n}\n"
+
+	overlay, changed := applyClassDiagramOverlay(source, classDiagramOverlayParams{
+		classFilterQuery: "Invoice,Quote ~Archived 2 gvseparator=1.7 gvdot",
+		namedFilters:     []string{"Focus"},
+		mixsets:          []string{"Metrics"},
+	}, false)
+	if !changed {
+		t.Fatal("expected the overlay source to be modified")
+	}
+
+	if !strings.Contains(overlay, "use Metrics;") {
+		t.Fatalf("expected overlay to activate selected mixsets, got %q", overlay)
+	}
+	if !strings.Contains(overlay, "filter {includeFilter Focus;}") {
+		t.Fatalf("expected overlay to include named filters, got %q", overlay)
+	}
+	if !strings.Contains(overlay, `suboption "gvseparator=1.7";`) {
+		t.Fatalf("expected overlay to include gvseparator suboption, got %q", overlay)
+	}
+	if !strings.Contains(overlay, "include Invoice,Quote;") || !strings.Contains(overlay, "include ~Archived;") {
+		t.Fatalf("expected overlay to include legacy class patterns, got %q", overlay)
+	}
+	if !strings.Contains(overlay, "hops { association 2;}") {
+		t.Fatalf("expected overlay to include hop count filters, got %q", overlay)
+	}
+	if strings.Contains(overlay, "gvdot") {
+		t.Fatalf("expected non-separator gv tokens to stay out of the overlay text box path, got %q", overlay)
+	}
+	if !strings.Contains(overlay, modelDelimiter) {
+		t.Fatalf("expected hidden layout delimiter to be preserved, got %q", overlay)
+	}
+}
+
+func TestApplyClassDiagramOverlaySkipsFreeFormFilterWhenCodeAlreadyDefinesOne(t *testing.T) {
+	source := "filter Existing {\n  include Invoice;\n}\n\nclass Invoice {}\n"
+
+	overlay, changed := applyClassDiagramOverlay(source, classDiagramOverlayParams{
+		classFilterQuery: "Invoice 1 gvseparator=1.7",
+		namedFilters:     []string{"Focus"},
+	}, true)
+	if !changed {
+		t.Fatal("expected named filters and suboptions to still be applied")
+	}
+
+	if strings.Contains(overlay, "hops { association 1;}") || strings.Contains(overlay, "filter { include Invoice;") {
+		t.Fatalf("expected free-form filter overlay to be suppressed when code already defines a filter, got %q", overlay)
+	}
+	if !strings.Contains(overlay, "filter {includeFilter Focus;}") {
+		t.Fatalf("expected named filter activation to remain, got %q", overlay)
+	}
+	if !strings.Contains(overlay, `suboption "gvseparator=1.7";`) {
+		t.Fatalf("expected gvseparator to remain active, got %q", overlay)
+	}
+}
+
+func TestHasExplicitTopLevelFilterIgnoresCommentedFilters(t *testing.T) {
+	if hasExplicitTopLevelFilter("// filter Commented {\n//   include Invoice;\n// }\nclass Invoice {}\n") {
+		t.Fatal("expected commented filters to be ignored")
+	}
+	if !hasExplicitTopLevelFilter("filter Existing {\n  include Invoice;\n}\nclass Invoice {}\n") {
+		t.Fatal("expected unnamed filters in code to be detected")
+	}
+}
+
+func TestHasExplicitTopLevelFilterIgnoresNamedFilters(t *testing.T) {
+	if hasExplicitTopLevelFilter("filter Focus {\n  include Invoice;\n}\nclass Invoice {}\n") {
+		t.Fatal("expected named filters to remain compatible with legacy free-form filtering")
+	}
+}

--- a/backend/internal/api/handlers/compile.go
+++ b/backend/internal/api/handlers/compile.go
@@ -29,14 +29,17 @@ func NewGenerateHandler(pool *compiler.Pool, store *model.Store, cfg *config.Con
 }
 
 type GenerateRequest struct {
-	Code        string   `json:"code"`
-	ModelID     string   `json:"modelId,omitempty"`
-	Language    string   `json:"language,omitempty"`
-	DiagramType string   `json:"diagramType,omitempty"`
-	Suboptions  []string `json:"suboptions,omitempty"`
-	NeedsLayout *bool    `json:"needsLayout,omitempty"`
-	Tabs        []apiTab `json:"tabs,omitempty"`
-	ActiveTabID string   `json:"activeTabId,omitempty"`
+	Code             string   `json:"code"`
+	ModelID          string   `json:"modelId,omitempty"`
+	Language         string   `json:"language,omitempty"`
+	DiagramType      string   `json:"diagramType,omitempty"`
+	Suboptions       []string `json:"suboptions,omitempty"`
+	ClassFilterQuery string   `json:"classFilterQuery,omitempty"`
+	NamedFilters     []string `json:"namedFilters,omitempty"`
+	Mixsets          []string `json:"mixsets,omitempty"`
+	NeedsLayout      *bool    `json:"needsLayout,omitempty"`
+	Tabs             []apiTab `json:"tabs,omitempty"`
+	ActiveTabID      string   `json:"activeTabId,omitempty"`
 }
 
 type GenerateResponse struct {
@@ -165,14 +168,17 @@ func (h *GenerateHandler) Generate(w http.ResponseWriter, r *http.Request) {
 		needsLayout := req.NeedsLayout == nil || *req.NeedsLayout
 
 		diagResp, errMsg := processDiagram(processDiagramParams{
-			pool:        h.pool,
-			dir:         dir,
-			modelID:     modelID,
-			diagramType: req.DiagramType,
-			suboptions:  req.Suboptions,
-			needsLayout: needsLayout,
-			entryFile:   entryFile,
-			locked:      workspaceLocked,
+			pool:             h.pool,
+			dir:              dir,
+			modelID:          modelID,
+			diagramType:      req.DiagramType,
+			suboptions:       req.Suboptions,
+			classFilterQuery: req.ClassFilterQuery,
+			namedFilters:     req.NamedFilters,
+			mixsets:          req.Mixsets,
+			needsLayout:      needsLayout,
+			entryFile:        entryFile,
+			locked:           workspaceLocked,
 		})
 		if errMsg != "" {
 			log.Printf("diagram generation failed during output generation: %s", errMsg)

--- a/backend/internal/api/handlers/diagram.go
+++ b/backend/internal/api/handlers/diagram.go
@@ -27,12 +27,15 @@ func NewDiagramHandler(pool *compiler.Pool, store *model.Store) *DiagramHandler 
 }
 
 type DiagramRequest struct {
-	Code        string   `json:"code"`
-	DiagramType string   `json:"diagramType"`
-	ModelID     string   `json:"modelId,omitempty"`
-	Suboptions  []string `json:"suboptions,omitempty"`
-	NeedsLayout *bool    `json:"needsLayout,omitempty"`
-	ActiveTabID string   `json:"activeTabId,omitempty"`
+	Code             string   `json:"code"`
+	DiagramType      string   `json:"diagramType"`
+	ModelID          string   `json:"modelId,omitempty"`
+	Suboptions       []string `json:"suboptions,omitempty"`
+	ClassFilterQuery string   `json:"classFilterQuery,omitempty"`
+	NamedFilters     []string `json:"namedFilters,omitempty"`
+	Mixsets          []string `json:"mixsets,omitempty"`
+	NeedsLayout      *bool    `json:"needsLayout,omitempty"`
+	ActiveTabID      string   `json:"activeTabId,omitempty"`
 }
 
 type GvTextLine struct {
@@ -264,7 +267,7 @@ func extractTextLines(ops []gvDrawOp) []GvTextLine {
 	return lines
 }
 
-// validSuboptions lists the allowed -s flags for umplesync.jar diagram generation.
+// validSuboptions lists the fixed -s flags allowed for umplesync.jar diagram generation.
 var validSuboptions = map[string]bool{
 	"hideattributes":        true,
 	"showmethods":           true,
@@ -308,14 +311,17 @@ var diagramTypeInfo = map[string]diagramOutputKind{
 // processDiagramParams bundles everything needed to run diagram generation
 // against an already-resolved model directory.
 type processDiagramParams struct {
-	pool        *compiler.Pool
-	dir         string
-	modelID     string
-	diagramType string
-	suboptions  []string
-	needsLayout bool
-	entryFile   string
-	locked      bool
+	pool             *compiler.Pool
+	dir              string
+	modelID          string
+	diagramType      string
+	suboptions       []string
+	classFilterQuery string
+	namedFilters     []string
+	mixsets          []string
+	needsLayout      bool
+	entryFile        string
+	locked           bool
 }
 
 // processDiagram generates a diagram from a model directory that already
@@ -331,6 +337,14 @@ func processDiagram(p processDiagramParams) (*DiagramResponse, string) {
 	modelPath := filepath.Join(p.dir, p.entryFile)
 	modelData, _ := os.ReadFile(modelPath)
 	storedLayout := extractStoredLayoutMetadata(string(modelData))
+	commandModelPath := modelPath
+
+	if overlayPath, cleanupOverlay, err := buildTransientClassDiagramOverlay(p, modelPath, string(modelData)); err != nil {
+		return nil, fmt.Sprintf("failed to prepare diagram overlay: %v", err)
+	} else if overlayPath != "" {
+		commandModelPath = overlayPath
+		defer cleanupOverlay()
+	}
 
 	// Remove stale .gv files so the directory scan after generation
 	// always picks the newly generated file, not a leftover from a
@@ -346,9 +360,9 @@ func processDiagram(p processDiagramParams) (*DiagramResponse, string) {
 	}
 
 	// Generate .gv file using umple, appending validated suboptions as -s flags
-	command := fmt.Sprintf("-generate %s %s/%s", p.diagramType, p.dir, p.entryFile)
+	command := fmt.Sprintf("-generate %s %s", p.diagramType, commandModelPath)
 	for _, opt := range p.suboptions {
-		if validSuboptions[opt] {
+		if isValidDiagramSuboption(opt) {
 			command += " -s " + opt
 		}
 	}
@@ -506,13 +520,16 @@ func (h *DiagramHandler) Generate(w http.ResponseWriter, r *http.Request) {
 	needsLayout := req.NeedsLayout == nil || *req.NeedsLayout
 
 	resp, errMsg := processDiagram(processDiagramParams{
-		pool:        h.pool,
-		dir:         dir,
-		modelID:     modelID,
-		diagramType: req.DiagramType,
-		suboptions:  req.Suboptions,
-		needsLayout: needsLayout,
-		entryFile:   entryFile,
+		pool:             h.pool,
+		dir:              dir,
+		modelID:          modelID,
+		diagramType:      req.DiagramType,
+		suboptions:       req.Suboptions,
+		classFilterQuery: req.ClassFilterQuery,
+		namedFilters:     req.NamedFilters,
+		mixsets:          req.Mixsets,
+		needsLayout:      needsLayout,
+		entryFile:        entryFile,
 	})
 	if errMsg != "" {
 		writeError(w, http.StatusInternalServerError, errMsg)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -93,6 +93,9 @@ export const api = {
     diagramType: string;
     modelId?: string;
     suboptions?: string[];
+    classFilterQuery?: string;
+    namedFilters?: string[];
+    mixsets?: string[];
     needsLayout?: boolean;
     activeTabId?: string;
   }): Promise<DiagramResponse> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -6,6 +6,9 @@ export interface GenerationRequest {
   language?: string;
   diagramType?: string;
   suboptions?: string[];
+  classFilterQuery?: string;
+  namedFilters?: string[];
+  mixsets?: string[];
   needsLayout?: boolean;
   tabs?: ApiTab[];
   activeTabId?: string;

--- a/frontend/src/components/diagram/CanvasToolbar.tsx
+++ b/frontend/src/components/diagram/CanvasToolbar.tsx
@@ -1,15 +1,72 @@
-import { Eye, ChevronDown, Download, LayoutGrid } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { CircleHelp, Eye, ChevronDown, Download, LayoutGrid, ListFilter } from 'lucide-react'
 import { useSessionStore } from '../../stores/sessionStore'
 import { usePreferencesStore, type DisplayPrefKey, type GvLayoutAlgorithm } from '../../stores/preferencesStore'
 import { DISPLAY_TOGGLES, LAYOUT_OPTIONS } from '../../constants/diagram'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuRadioGroup, DropdownMenuRadioItem } from '@/components/ui/dropdown-menu'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
+import {
+  CLASS_FILTER_DEFAULT_QUERY,
+  discoverNamedClassDiagramOverlays,
+} from '@/lib/classDiagramFilters'
+import { getCompileSourceSnapshot } from '@/lib/compileSource'
 import { cn } from '@/lib/utils'
 
 const btnBase =
   'px-1.5 py-0.5 text-xs cursor-pointer transition-colors rounded focus-visible:outline-2 focus-visible:outline-brand focus-visible:outline-offset-1 text-ink-muted hover:text-ink hover:bg-surface-2 flex items-center gap-1'
+
+const LEGACY_FILTER_TOOLTIP = (
+  <>
+    You can choose to display a subset of classes by naming them, separated by spaces.
+    <br />
+    <br />
+    You can use glob wildcards to specify patterns matching several classes.
+    <br />
+    <br />
+    So * matches any number of characters in a class name and ? matches any single character.
+    <br />
+    <br />
+    Preceding a pattern with a ~ indicates to skip classes matching the pattern.
+    <br />
+    <br />
+    Superclasses of any selected classes will always also appear (even if ~ is used)
+    <br />
+    <br />
+    The above is a shortcut for including a filter directive in the code.
+    <br />
+    <br />
+    using the notation filter {'{'}include Classpattern;{'}'}
+    <br />
+    <br />
+    Filters in the code will take precedence.
+    <br />
+    <br />
+    No class pattern starting with 'gv' can be used as these match the suboptions below.
+    <br />
+    <br />
+    You can also use an integer such as 1 or 2 to also add classees that are connected by an association 1 or 2
+    (or any number of ) hops away from selected classes.
+    <br />
+    <br />
+    You can also widen (or narrow) the spacing of nodes by using an expression like gvseparator=1.7 , where 1.0 is
+    the default spacing.
+  </>
+)
+
+const LEGACY_NAMED_FILTER_TOOLTIP = 'Activate the named filter to show only the selected classes'
+const LEGACY_MIXSET_TOOLTIP = 'Activate the code contained in this named mixset'
 
 interface CanvasToolbarProps {
   hasDiagram: boolean
@@ -74,18 +131,31 @@ export function ToolbarDivider() {
 }
 
 function DisplayOptionsGroup({ toggles }: { toggles: { key: DisplayPrefKey; label: string }[] }) {
+  const viewMode = useSessionStore((s) => s.viewMode)
+  const showClassFilters = viewMode === 'class'
+
   return (
     <Popover>
       <Tip content="Display options" side="bottom">
         <PopoverTrigger asChild>
-          <button className={btnBase}>
+          <button className={btnBase} data-testid="canvas-display-options-button">
             <Eye className="size-3" />
             <ChevronDown className="size-2.5 text-ink-faint" />
           </button>
         </PopoverTrigger>
       </Tip>
-      <PopoverContent className="w-auto p-2" align="start">
+      <PopoverContent
+        className="w-auto p-2"
+        align="start"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
         <div className="flex flex-col gap-1">
+          {showClassFilters && (
+            <>
+              <ClassFilterSection />
+              <div className="my-1 h-px bg-border/70" />
+            </>
+          )}
           {toggles.map(({ key, label }) => (
             <ToggleItem key={key} prefKey={key} label={label} />
           ))}
@@ -121,6 +191,163 @@ function LayoutGroup() {
         </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>
+  )
+}
+
+function ClassFilterSection() {
+  const code = useSessionStore((s) => s.code)
+  const tabs = useSessionStore((s) => s.tabs)
+  const activeTabId = useSessionStore((s) => s.activeTabId)
+  const tabsVersion = useSessionStore((s) => s.tabsVersion)
+  const classFilterQuery = useSessionStore((s) => s.classFilterQuery)
+  const activeNamedFilters = useSessionStore((s) => s.activeNamedFilters)
+  const activeMixsets = useSessionStore((s) => s.activeMixsets)
+  const setClassFilterQuery = useSessionStore((s) => s.setClassFilterQuery)
+  const toggleNamedFilter = useSessionStore((s) => s.toggleNamedFilter)
+  const toggleMixset = useSessionStore((s) => s.toggleMixset)
+  const [draftQuery, setDraftQuery] = useState(classFilterQuery)
+
+  useEffect(() => {
+    setDraftQuery(classFilterQuery)
+  }, [classFilterQuery])
+
+  const availableOptions = useMemo(
+    () => discoverNamedClassDiagramOverlays(getCompileSourceSnapshot().tabs),
+    [tabs, activeTabId, code, tabsVersion],
+  )
+  const activeOptionCount = activeNamedFilters.length + activeMixsets.length
+  const availableOptionCount = availableOptions.namedFilters.length + availableOptions.mixsets.length
+  const filterHelpContent = (
+    <>
+      {LEGACY_FILTER_TOOLTIP}
+      {availableOptions.namedFilters.length > 0 ? (
+        <>
+          <br />
+          <br />
+          Named Filters: {LEGACY_NAMED_FILTER_TOOLTIP}
+        </>
+      ) : null}
+      {availableOptions.mixsets.length > 0 ? (
+        <>
+          <br />
+          <br />
+          Mixsets: {LEGACY_MIXSET_TOOLTIP}
+        </>
+      ) : null}
+    </>
+  )
+
+  const commitQuery = () => {
+    setClassFilterQuery(draftQuery)
+  }
+
+  const revertQuery = () => {
+    setDraftQuery(classFilterQuery)
+  }
+
+  return (
+    <div className="flex min-w-[220px] flex-col gap-2" data-testid="class-filter-group">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-xxs font-medium text-ink">Class Filters</div>
+        {availableOptionCount > 0 ? (
+          <span className="text-xxs text-ink-muted" data-testid="class-filter-options-count">
+            {activeOptionCount > 0 ? `${activeOptionCount} active` : `${availableOptionCount} available`}
+          </span>
+        ) : null}
+      </div>
+
+      <div
+        className="flex h-7 items-center gap-1 rounded-md border border-border bg-surface-0 px-2 text-xs text-ink-muted hover:bg-surface-1 focus-within:border-brand focus-within:text-ink focus-within:ring-1 focus-within:ring-brand"
+        data-testid="class-filter-shell"
+      >
+        <ListFilter className="size-3 shrink-0" />
+        <Input
+          value={draftQuery}
+          onChange={(event) => setDraftQuery(event.target.value)}
+          onBlur={commitQuery}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault()
+              commitQuery()
+              event.currentTarget.blur()
+            }
+            if (event.key === 'Escape') {
+              event.preventDefault()
+              revertQuery()
+              event.currentTarget.blur()
+            }
+          }}
+          placeholder={CLASS_FILTER_DEFAULT_QUERY}
+          className="h-auto w-[170px] border-0 bg-transparent px-0 py-0 text-xs text-ink shadow-none hover:bg-transparent focus:border-0 focus:ring-0"
+          data-testid="class-filter-input"
+          aria-label="Class filter query"
+        />
+        <Tip content={filterHelpContent} side="bottom">
+          <button
+            type="button"
+            className="inline-flex shrink-0 items-center justify-center rounded-sm text-ink-muted transition-colors hover:text-ink focus-visible:outline-2 focus-visible:outline-brand focus-visible:outline-offset-1"
+            data-testid="class-filter-info-button"
+            aria-label="Class filter help"
+          >
+            <CircleHelp className="size-3.5" />
+          </button>
+        </Tip>
+      </div>
+
+      {availableOptions.namedFilters.length > 0 ? (
+        <NamedFilterList
+          title="Named Filters"
+          options={availableOptions.namedFilters}
+          active={activeNamedFilters}
+          onToggle={toggleNamedFilter}
+          testIdPrefix="class-filter-named-filter"
+        />
+      ) : null}
+      {availableOptions.mixsets.length > 0 ? (
+        <NamedFilterList
+          title="Mixsets"
+          options={availableOptions.mixsets}
+          active={activeMixsets}
+          onToggle={toggleMixset}
+          testIdPrefix="class-filter-mixset"
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function NamedFilterList({
+  title,
+  options,
+  active,
+  onToggle,
+  testIdPrefix,
+}: {
+  title: string
+  options: string[]
+  active: string[]
+  onToggle: (name: string) => void
+  testIdPrefix: string
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-xxs font-medium text-ink-muted">{title}</div>
+      {options.map((name) => {
+        const checked = active.includes(name)
+        return (
+          <label
+            key={name}
+            className="flex items-center justify-between gap-3 py-0.5 cursor-pointer min-w-[120px]"
+            data-testid={`${testIdPrefix}-${name}`}
+          >
+            <span className={`text-xxs transition-colors ${checked ? 'text-ink font-medium' : 'text-ink-muted'}`}>
+              {name}
+            </span>
+            <Switch size="sm" checked={checked} onCheckedChange={() => onToggle(name)} />
+          </label>
+        )
+      })}
+    </div>
   )
 }
 

--- a/frontend/src/components/diagram/__tests__/CanvasToolbar.test.tsx
+++ b/frontend/src/components/diagram/__tests__/CanvasToolbar.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { usePreferencesStore } from '@/stores/preferencesStore'
+import { useSessionStore } from '@/stores/sessionStore'
+import { CanvasToolbar } from '../CanvasToolbar'
+
+describe('CanvasToolbar', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    usePreferencesStore.setState({
+      showAttributes: true,
+      showMethods: false,
+      showOrthogonalEdges: false,
+      showTraits: false,
+      showActions: true,
+      showTransitionLabels: false,
+      showGuards: true,
+      showGuardLabels: false,
+      showNaturalLanguage: true,
+      showFeatureDependency: false,
+      layoutAlgorithm: 'dot',
+    })
+    useSessionStore.setState({
+      code: '',
+      viewMode: 'class',
+      classFilterQuery: '*',
+      activeNamedFilters: [],
+      activeMixsets: [],
+      activeTabId: 'main',
+      tabsVersion: 0,
+      tabs: [{ id: 'main', name: 'Model.ump', code: '', dirty: false, savedCode: '', undoStack: [], redoStack: [] }],
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows the restored class filter controls only in class view', () => {
+    const { rerender } = render(
+      <TooltipProvider>
+        <CanvasToolbar
+          hasDiagram
+          onExport={() => {}}
+          canToggleRenderer={false}
+          renderMode="graphviz"
+          onRenderModeChange={() => {}}
+          variant="banner"
+        />
+      </TooltipProvider>,
+    )
+
+    fireEvent.click(screen.getByTestId('canvas-display-options-button'))
+    expect(screen.getByTestId('class-filter-group')).toBeDefined()
+    expect(screen.getByTestId('class-filter-input')).toBeDefined()
+
+    useSessionStore.setState({ viewMode: 'state' })
+    rerender(
+      <TooltipProvider>
+        <CanvasToolbar
+          hasDiagram
+          onExport={() => {}}
+          canToggleRenderer={false}
+          renderMode="graphviz"
+          onRenderModeChange={() => {}}
+          variant="banner"
+        />
+      </TooltipProvider>,
+    )
+
+    fireEvent.click(screen.getByTestId('canvas-display-options-button'))
+    expect(screen.queryByTestId('class-filter-group')).toBeNull()
+  })
+
+  it('commits the class filter query on blur', () => {
+    render(
+      <TooltipProvider>
+        <CanvasToolbar
+          hasDiagram
+          onExport={() => {}}
+          canToggleRenderer={false}
+          renderMode="graphviz"
+          onRenderModeChange={() => {}}
+          variant="banner"
+        />
+      </TooltipProvider>,
+    )
+
+    fireEvent.click(screen.getByTestId('canvas-display-options-button'))
+    const input = screen.getByTestId('class-filter-input')
+    fireEvent.change(input, { target: { value: 'Invoice 2' } })
+    fireEvent.blur(input)
+
+    expect(useSessionStore.getState().classFilterQuery).toBe('Invoice 2')
+  })
+
+  it('shows named filter and mixset controls only when the code declares them', () => {
+    const { unmount } = render(
+      <TooltipProvider>
+        <CanvasToolbar
+          hasDiagram
+          onExport={() => {}}
+          canToggleRenderer={false}
+          renderMode="graphviz"
+          onRenderModeChange={() => {}}
+          variant="banner"
+        />
+      </TooltipProvider>,
+    )
+
+    fireEvent.click(screen.getByTestId('canvas-display-options-button'))
+    expect(screen.queryByText('Named Filters')).toBeNull()
+    expect(screen.queryByText('Mixsets')).toBeNull()
+    expect(screen.queryByTestId('class-filter-options-count')).toBeNull()
+
+    useSessionStore.setState({
+      code: 'filter Focus { include Invoice; }\nmixset Metrics { }\n',
+      tabs: [{
+        id: 'main',
+        name: 'Model.ump',
+        code: 'filter Focus { include Invoice; }\nmixset Metrics { }\n',
+        dirty: false,
+        savedCode: '',
+        undoStack: [],
+        redoStack: [],
+      }],
+    })
+
+    unmount()
+    render(
+      <TooltipProvider>
+        <CanvasToolbar
+          hasDiagram
+          onExport={() => {}}
+          canToggleRenderer={false}
+          renderMode="graphviz"
+          onRenderModeChange={() => {}}
+          variant="banner"
+        />
+      </TooltipProvider>,
+    )
+
+    fireEvent.click(screen.getByTestId('canvas-display-options-button'))
+    expect(screen.getByText('Named Filters')).toBeDefined()
+    expect(screen.getByText('Mixsets')).toBeDefined()
+    expect(screen.getByTestId('class-filter-options-count').textContent).toContain('2 available')
+  })
+})

--- a/frontend/src/hooks/__tests__/useCompiler.test.ts
+++ b/frontend/src/hooks/__tests__/useCompiler.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from '@/api/client'
+import { useEphemeralStore } from '@/stores/ephemeralStore'
+import { usePreferencesStore } from '@/stores/preferencesStore'
+import { useSessionStore } from '@/stores/sessionStore'
+import { generateAndRefresh } from '../useCompiler'
+
+describe('generateAndRefresh', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    usePreferencesStore.setState({
+      showAttributes: true,
+      showMethods: false,
+      showOrthogonalEdges: false,
+      showTraits: false,
+      showActions: true,
+      showTransitionLabels: false,
+      showGuards: true,
+      showGuardLabels: false,
+      showNaturalLanguage: true,
+      showFeatureDependency: false,
+      layoutAlgorithm: 'dot',
+    })
+    useSessionStore.setState({
+      code: 'class Invoice {}',
+      modelId: 'playwright-model',
+      activeTabId: 'main',
+      tabsVersion: 0,
+      tabs: [{ id: 'main', name: 'Model.ump', code: 'class Invoice {}', dirty: false, savedCode: 'class Invoice {}', undoStack: [], redoStack: [] }],
+      generateTargetId: 'classDiagram',
+      viewMode: 'class',
+      classFilterQuery: 'Invoice 2 gvseparator=1.7',
+      activeNamedFilters: ['Focus'],
+      activeMixsets: ['Metrics'],
+      svgCache: {},
+      htmlCache: {},
+      umpleModel: null,
+      classLayout: {
+        bboxWidth: 10,
+        bboxHeight: 10,
+        nodes: [{ name: 'Existing', x: 1, y: 1, width: 1, height: 1 }],
+      },
+      storedLayout: null,
+    })
+    useEphemeralStore.setState({
+      rightPanelView: 'diagram',
+      generatingOutput: false,
+      outputErrorCount: 0,
+      outputWarningCount: 0,
+      executionOutput: '',
+      executionErrors: null,
+      parsedIssues: [],
+      rawErrorText: '',
+      diagramSourceCode: null,
+      diagramSourceTabId: null,
+      diagramSourceSignature: null,
+      diagramTargetId: null,
+      generatedError: null,
+      generatingCode: false,
+      generationRequested: false,
+      generationSuspendedByError: false,
+      generationErrorSourceCode: null,
+      generationErrorSourceTabId: null,
+      generationErrorSourceSignature: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('includes class filter fields in diagram requests and preserves editable layout when active', async () => {
+    const model = { umpleClasses: [{ name: 'Invoice', attributes: [], methods: [] }], umpleAssociations: [] }
+    const nextLayout = {
+      bboxWidth: 20,
+      bboxHeight: 20,
+      nodes: [{ name: 'Invoice', x: 5, y: 5, width: 2, height: 2 }],
+    }
+    const generateSpy = vi.spyOn(api, 'generate').mockResolvedValue({
+      modelId: 'playwright-model',
+      result: JSON.stringify(model),
+      svg: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+      layout: nextLayout,
+    })
+
+    const previousLayout = useSessionStore.getState().classLayout
+
+    await generateAndRefresh(false)
+
+    expect(generateSpy).toHaveBeenCalledTimes(1)
+    expect(generateSpy.mock.calls[0]?.[0]).toMatchObject({
+      diagramType: 'GvClassDiagram',
+      classFilterQuery: 'Invoice 2 gvseparator=1.7',
+      namedFilters: ['Focus'],
+      mixsets: ['Metrics'],
+    })
+    expect(useSessionStore.getState().umpleModel).toEqual(model)
+    expect(useSessionStore.getState().classLayout).toBe(previousLayout)
+    expect(useSessionStore.getState().svgCache.class).toContain('<svg')
+  })
+})

--- a/frontend/src/hooks/useCompiler.ts
+++ b/frontend/src/hooks/useCompiler.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { toast } from 'sonner'
-import { useSessionStore, type DiagramView } from '../stores/sessionStore'
+import { selectClassFilterKey, useSessionStore, type DiagramView } from '../stores/sessionStore'
 import { useEphemeralStore } from '../stores/ephemeralStore'
 import { urlModelResolved } from './useModelFromURL'
 import {
@@ -13,6 +13,11 @@ import { useIsDark } from './useIsDark'
 import { api } from '../api/client'
 import type { UmpleModel, GvLayout, StoredLayoutMetadata } from '../api/types'
 import { getGenerateTarget, resolveGenerateRequestLanguage } from '../generation/targets'
+import {
+  buildClassDiagramFilterRequestFields,
+  discoverNamedClassDiagramOverlays,
+  hasTransientClassDiagramFilters,
+} from '../lib/classDiagramFilters'
 import { getCompileSourceSnapshot } from '../lib/compileSource'
 import { useEffectiveDynamicGeneration } from '../lib/effectiveDynamicGeneration'
 
@@ -29,10 +34,21 @@ const DEBOUNCE_MS = 1500
 /** Build the diagram request params from current store state + isDark flag. */
 function getDiagramRequestParams(view: DiagramView, isDark: boolean) {
   const s = usePreferencesStore.getState()
-  return {
+  const params = {
     diagramType: getEffectiveDiagramType(view, s.showTraits),
     suboptions: buildSuboptions(s, view, isDark),
     needsLayout: view === 'class',
+  }
+  if (view !== 'class') return params
+
+  const session = useSessionStore.getState()
+  return {
+    ...params,
+    ...buildClassDiagramFilterRequestFields(
+      session.classFilterQuery,
+      session.activeNamedFilters,
+      session.activeMixsets,
+    ),
   }
 }
 
@@ -60,7 +76,18 @@ export async function generateAndRefresh(
   signal?: AbortSignal,
   targetId?: string,
 ): Promise<{ success: boolean; model: UmpleModel | null }> {
-  const { modelId, setModelId, setUmpleModel, activeTabId, generateTargetId, viewMode, setViewMode } = useSessionStore.getState()
+  const {
+    modelId,
+    setModelId,
+    setUmpleModel,
+    activeTabId,
+    generateTargetId,
+    viewMode,
+    setViewMode,
+    classFilterQuery,
+    activeNamedFilters,
+    activeMixsets,
+  } = useSessionStore.getState()
   const { clearSvgCache, clearHtmlCache, setSvgForView, setHtmlForView } = useSessionStore.getState()
   const {
     clearGenerationError,
@@ -171,11 +198,15 @@ export async function generateAndRefresh(
 
       // Store the parsed model and layout for UmpleDiagram
       if (model && success) {
-        setUmpleModel(
-          model,
-          activeView === 'class' ? gvLayout ?? null : undefined,
-          activeView === 'class' ? storedLayout : undefined,
-        )
+        if (activeView === 'class' && hasTransientClassDiagramFilters(classFilterQuery, activeNamedFilters, activeMixsets)) {
+          setUmpleModel(model)
+        } else {
+          setUmpleModel(
+            model,
+            activeView === 'class' ? gvLayout ?? null : undefined,
+            activeView === 'class' ? storedLayout : undefined,
+          )
+        }
       }
       if (success) {
         markDiagramFresh(target.id, sourceSnapshot)
@@ -243,6 +274,7 @@ export function useCompiler() {
   const tabsVersion = useSessionStore((s) => s.tabsVersion)
   const viewMode = useSessionStore((s) => s.viewMode)
   const generateTargetId = useSessionStore((s) => s.generateTargetId)
+  const classFilterKey = useSessionStore(selectClassFilterKey)
   const dynamicGeneration = useEffectiveDynamicGeneration()
   const setSvgForView = useSessionStore((s) => s.setSvgForView)
   const setHtmlForView = useSessionStore((s) => s.setHtmlForView)
@@ -318,6 +350,12 @@ export function useCompiler() {
     // compile assigns a modelId → dep changes → second (redundant) compile.
   }, [dynamicGeneration, code, tabsVersion])
 
+  useEffect(() => {
+    const { tabs } = getCompileSourceSnapshot()
+    const discovered = discoverNamedClassDiagramOverlays(tabs)
+    useSessionStore.getState().reconcileClassDiagramFilters(discovered.namedFilters, discovered.mixsets)
+  }, [code, tabsVersion])
+
   // When diagram display preferences or dark theme change, re-fetch diagram only
   useEffect(() => {
     if (!mountedRef.current) return
@@ -329,7 +367,7 @@ export function useCompiler() {
     if (!currentCode?.trim() || !currentModelId) return
 
     fetchDiagramSvg(currentCode, viewModeRef.current, currentModelId)
-  }, [viewMode, suboptionsKey, isDark])
+  }, [viewMode, suboptionsKey, classFilterKey, isDark])
 
   async function fetchDiagramSvg(umpleCode: string, view: DiagramView, mid: string) {
     // Abort previous diagram request
@@ -350,7 +388,12 @@ export function useCompiler() {
         setHtmlForView(view, res.html)
       }
       if (view === 'class' && lastModelRef.current) {
-        useSessionStore.getState().setUmpleModel(lastModelRef.current, res.layout ?? null, res.storedLayout ?? null)
+        const { classFilterQuery, activeNamedFilters, activeMixsets } = useSessionStore.getState()
+        if (hasTransientClassDiagramFilters(classFilterQuery, activeNamedFilters, activeMixsets)) {
+          useSessionStore.getState().setUmpleModel(lastModelRef.current)
+        } else {
+          useSessionStore.getState().setUmpleModel(lastModelRef.current, res.layout ?? null, res.storedLayout ?? null)
+        }
       }
       if (res.errors) {
         const { panelErrors, toastMessages } = splitDiagramToasts(res.errors)

--- a/frontend/src/lib/__tests__/classDiagramFilters.test.ts
+++ b/frontend/src/lib/__tests__/classDiagramFilters.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildClassDiagramFilterRequestFields,
+  discoverNamedClassDiagramOverlays,
+  normalizeClassFilterQuery,
+} from '../classDiagramFilters'
+
+describe('classDiagramFilters', () => {
+  it('discovers named filters and mixsets while ignoring commented declarations', () => {
+    const discovered = discoverNamedClassDiagramOverlays([
+      {
+        code: `
+          // filter HiddenByComment {
+          mixset VisibleMixset {
+          }
+          filter VisibleFilter {
+          }
+          /* mixset BlockCommented {
+          } */
+        `,
+      },
+      {
+        code: `
+          filter 7 {
+          }
+          // mixset IgnoredLineComment {
+          // }
+          mixset AlsoVisible {
+          }
+        `,
+      },
+    ])
+
+    expect(discovered.namedFilters).toEqual(['7', 'VisibleFilter'])
+    expect(discovered.mixsets).toEqual(['AlsoVisible', 'VisibleMixset'])
+  })
+
+  it('builds request fields only when the class filter state is active', () => {
+    expect(buildClassDiagramFilterRequestFields('*', [], [])).toEqual({})
+
+    expect(
+      buildClassDiagramFilterRequestFields('  Invoice   ~Archived 2  ', ['F1'], ['M2']),
+    ).toEqual({
+      classFilterQuery: 'Invoice ~Archived 2',
+      namedFilters: ['F1'],
+      mixsets: ['M2'],
+    })
+  })
+
+  it('normalizes blank class filter queries back to the legacy default', () => {
+    expect(normalizeClassFilterQuery('   ')).toBe('*')
+  })
+})

--- a/frontend/src/lib/classDiagramFilters.ts
+++ b/frontend/src/lib/classDiagramFilters.ts
@@ -1,0 +1,88 @@
+import type { ApiTab } from '@/api/types'
+
+export const CLASS_FILTER_DEFAULT_QUERY = '*'
+
+export interface NamedClassDiagramOverlays {
+  namedFilters: string[]
+  mixsets: string[]
+}
+
+export interface ClassDiagramFilterRequestFields {
+  classFilterQuery?: string
+  namedFilters?: string[]
+  mixsets?: string[]
+}
+
+const DECLARATION_RE = /^\s*(mixset|filter)\s+([A-Za-z0-9_-]+)\b/
+
+function stripComments(code: string): string {
+  return code
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+}
+
+export function normalizeClassFilterQuery(query: string | null | undefined): string {
+  const trimmed = (query ?? '').trim()
+  if (!trimmed) return CLASS_FILTER_DEFAULT_QUERY
+  return trimmed.replace(/\s+/g, ' ')
+}
+
+export function isInactiveClassFilterQuery(query: string | null | undefined): boolean {
+  return normalizeClassFilterQuery(query) === CLASS_FILTER_DEFAULT_QUERY
+}
+
+export function hasTransientClassDiagramFilters(
+  query: string | null | undefined,
+  namedFilters: readonly string[],
+  mixsets: readonly string[],
+): boolean {
+  return !isInactiveClassFilterQuery(query) || namedFilters.length > 0 || mixsets.length > 0
+}
+
+export function buildClassDiagramFilterRequestFields(
+  query: string | null | undefined,
+  namedFilters: readonly string[],
+  mixsets: readonly string[],
+): ClassDiagramFilterRequestFields {
+  const normalized = normalizeClassFilterQuery(query)
+  const fields: ClassDiagramFilterRequestFields = {}
+
+  if (normalized !== CLASS_FILTER_DEFAULT_QUERY) {
+    fields.classFilterQuery = normalized
+  }
+  if (namedFilters.length > 0) {
+    fields.namedFilters = [...namedFilters]
+  }
+  if (mixsets.length > 0) {
+    fields.mixsets = [...mixsets]
+  }
+
+  return fields
+}
+
+export function discoverNamedClassDiagramOverlays(
+  tabs: ReadonlyArray<Pick<ApiTab, 'code'>>,
+): NamedClassDiagramOverlays {
+  const namedFilters = new Set<string>()
+  const mixsets = new Set<string>()
+
+  for (const tab of tabs) {
+    const code = stripComments(tab.code)
+    for (const line of code.split('\n')) {
+      const match = line.match(DECLARATION_RE)
+      if (!match) continue
+
+      const [, kind, name] = match
+      if (kind === 'filter') {
+        namedFilters.add(name)
+      } else {
+        mixsets.add(name)
+      }
+    }
+  }
+
+  return {
+    namedFilters: [...namedFilters].sort((left, right) => left.localeCompare(right)),
+    mixsets: [...mixsets].sort((left, right) => left.localeCompare(right)),
+  }
+}

--- a/frontend/src/stores/__tests__/sessionStore.test.ts
+++ b/frontend/src/stores/__tests__/sessionStore.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useSessionStore } from '../sessionStore'
+
+describe('sessionStore class filters', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    useSessionStore.setState({
+      classFilterQuery: '*',
+      activeNamedFilters: [],
+      activeMixsets: [],
+    })
+  })
+
+  it('normalizes blank class filter queries to the legacy default value', () => {
+    useSessionStore.getState().setClassFilterQuery('   ')
+
+    expect(useSessionStore.getState().classFilterQuery).toBe('*')
+  })
+
+  it('prunes stale named filters and mixsets when declarations disappear', () => {
+    useSessionStore.setState({
+      activeNamedFilters: ['KeepFilter', 'DropFilter'],
+      activeMixsets: ['DropMixset', 'KeepMixset'],
+    })
+
+    useSessionStore.getState().reconcileClassDiagramFilters(['KeepFilter'], ['KeepMixset'])
+
+    expect(useSessionStore.getState().activeNamedFilters).toEqual(['KeepFilter'])
+    expect(useSessionStore.getState().activeMixsets).toEqual(['KeepMixset'])
+  })
+})

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -10,6 +10,7 @@ import type {
 } from "../api/types";
 import { VIEW_OUTPUT_KIND } from "../constants/diagram";
 import type { DiagramView } from "../constants/diagram";
+import { CLASS_FILTER_DEFAULT_QUERY, normalizeClassFilterQuery } from "../lib/classDiagramFilters";
 import { useEphemeralStore } from "./ephemeralStore";
 import { ensureUmpExt } from "../lib/umpFile";
 
@@ -83,6 +84,9 @@ interface SessionState {
   selectedExampleId: string | null;
   selectedExampleSetId: ExampleSetId | null;
   generateTargetId: string;
+  classFilterQuery: string;
+  activeNamedFilters: string[];
+  activeMixsets: string[];
   /** Set by setCodeFromSync so useCompiler can skip the debounce */
   syncPending: boolean;
   /** Bumped on tab rename/reorder to trigger a compile that persists tabs.json */
@@ -128,6 +132,11 @@ interface SessionState {
   restoreTabs: (tabs: ApiTab[], activeTabId: string) => void;
   setSelectedExample: (name: string | null) => void;
   setGenerateTargetId: (id: string) => void;
+  setClassFilterQuery: (query: string) => void;
+  toggleNamedFilter: (name: string) => void;
+  toggleMixset: (name: string) => void;
+  resetClassDiagramFilters: () => void;
+  reconcileClassDiagramFilters: (namedFilters: string[], mixsets: string[]) => void;
 
   // Diagram actions
   setViewMode: (mode: DiagramView) => void;
@@ -161,6 +170,12 @@ interface SessionState {
 export function getActiveTabName(): string {
   const { tabs, activeTabId } = useSessionStore.getState();
   return tabs.find((t) => t.id === activeTabId)?.name ?? "Model.ump";
+}
+
+export function selectClassFilterKey(
+  s: Pick<SessionState, "classFilterQuery" | "activeNamedFilters" | "activeMixsets">,
+): string {
+  return JSON.stringify([s.classFilterQuery, s.activeNamedFilters, s.activeMixsets])
 }
 
 function suggestBlankTabName(tabs: Tab[], activeTabId: string): string {
@@ -201,6 +216,9 @@ export const useSessionStore = create<SessionState>()(
       selectedExampleId: null,
       selectedExampleSetId: null,
       generateTargetId: "classDiagram",
+      classFilterQuery: CLASS_FILTER_DEFAULT_QUERY,
+      activeNamedFilters: [],
+      activeMixsets: [],
       syncPending: false,
       tabsVersion: 0,
 
@@ -509,6 +527,43 @@ export const useSessionStore = create<SessionState>()(
             : { selectedExampleId: null, selectedExampleSetId: null }),
         }),
       setGenerateTargetId: (generateTargetId) => set({ generateTargetId }),
+      setClassFilterQuery: (classFilterQuery) =>
+        set({ classFilterQuery: normalizeClassFilterQuery(classFilterQuery) }),
+      toggleNamedFilter: (name) =>
+        set((s) => ({
+          activeNamedFilters: s.activeNamedFilters.includes(name)
+            ? s.activeNamedFilters.filter((value) => value !== name)
+            : [...s.activeNamedFilters, name].sort((left, right) => left.localeCompare(right)),
+        })),
+      toggleMixset: (name) =>
+        set((s) => ({
+          activeMixsets: s.activeMixsets.includes(name)
+            ? s.activeMixsets.filter((value) => value !== name)
+            : [...s.activeMixsets, name].sort((left, right) => left.localeCompare(right)),
+        })),
+      resetClassDiagramFilters: () =>
+        set({
+          classFilterQuery: CLASS_FILTER_DEFAULT_QUERY,
+          activeNamedFilters: [],
+          activeMixsets: [],
+        }),
+      reconcileClassDiagramFilters: (namedFilters, mixsets) =>
+        set((s) => {
+          const nextNamedFilters = s.activeNamedFilters.filter((name) => namedFilters.includes(name))
+          const nextMixsets = s.activeMixsets.filter((name) => mixsets.includes(name))
+
+          if (
+            nextNamedFilters.join("\u0000") === s.activeNamedFilters.join("\u0000") &&
+            nextMixsets.join("\u0000") === s.activeMixsets.join("\u0000")
+          ) {
+            return s
+          }
+
+          return {
+            activeNamedFilters: nextNamedFilters,
+            activeMixsets: nextMixsets,
+          }
+        }),
 
       loadExample: (id, name, code, modelId, setId) => {
         set((s) => ({
@@ -517,6 +572,9 @@ export const useSessionStore = create<SessionState>()(
           selectedExampleId: id,
           selectedExampleSetId: setId ?? null,
           ...(modelId ? { modelId } : {}),
+          classFilterQuery: CLASS_FILTER_DEFAULT_QUERY,
+          activeNamedFilters: [],
+          activeMixsets: [],
           tabs: s.tabs.map((t) =>
             t.id === s.activeTabId
               ? {
@@ -552,6 +610,9 @@ export const useSessionStore = create<SessionState>()(
           selectedExample: null,
           selectedExampleId: "blank",
           selectedExampleSetId: setId ?? null,
+          classFilterQuery: CLASS_FILTER_DEFAULT_QUERY,
+          activeNamedFilters: [],
+          activeMixsets: [],
           tabs: s.tabs.map((t) =>
             t.id === s.activeTabId
               ? {
@@ -646,6 +707,9 @@ export const useSessionStore = create<SessionState>()(
             selectedExample: null,
             selectedExampleId: null,
             selectedExampleSetId: null,
+            classFilterQuery: CLASS_FILTER_DEFAULT_QUERY,
+            activeNamedFilters: [],
+            activeMixsets: [],
             // Fresh restore — no cached diagram or model state
             svgCache: {},
             htmlCache: {},

--- a/frontend/tests/e2e/generation.spec.ts
+++ b/frontend/tests/e2e/generation.spec.ts
@@ -150,6 +150,19 @@ async function installGenerationRoutes(page: Page, requests: GenerationRequest[]
   })
 }
 
+async function installDiagramRoutes(page: Page, requests: GenerationRequest[]) {
+  await page.route('**/api/diagram', async (route) => {
+    const body = route.request().postDataJSON() as GenerationRequest
+    requests.push(body)
+    await route.fulfill({
+      json: {
+        modelId: 'playwright-model',
+        svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>',
+      },
+    })
+  })
+}
+
 test.describe('Generation UI', () => {
   test('uses class diagram generation as the default output target', async ({ page }) => {
     const requests: GenerationRequest[] = []
@@ -170,6 +183,59 @@ test.describe('Generation UI', () => {
     await expect
       .poll(() => getLastRequest(requests)?.language ?? null)
       .toBe(null)
+  })
+
+  test('refetches class diagrams with legacy filter fields and keeps the renderer toggle working', async ({
+    page,
+  }) => {
+    const generateRequests: GenerationRequest[] = []
+    const diagramRequests: GenerationRequest[] = []
+    await addPreferencesInitScript(page)
+    await installGenerationRoutes(page, generateRequests)
+    await installDiagramRoutes(page, diagramRequests)
+
+    await page.goto('/')
+    await expect(page.getByTestId('app-shell')).toBeVisible()
+
+    await setEditorCode(page, [
+      'filter Focus {',
+      '  include Invoice;',
+      '}',
+      'mixset Metrics {',
+      '}',
+      'class Invoice { number; }',
+      'class ArchivedInvoice { number; }',
+    ].join('\n'))
+
+    await expect(page.getByTestId('class-node-Invoice')).toBeVisible({
+      timeout: 10_000,
+    })
+
+    await page.getByTestId('canvas-display-options-button').click()
+    const filterInput = page.getByTestId('class-filter-input')
+    await filterInput.fill('Invoice ~ArchivedInvoice 2 gvseparator=1.7')
+    await filterInput.press('Enter')
+
+    await expect
+      .poll(() => diagramRequests[diagramRequests.length - 1]?.classFilterQuery)
+      .toBe('Invoice ~ArchivedInvoice 2 gvseparator=1.7')
+
+    await page.getByTestId('class-filter-named-filter-Focus').click()
+    await page.getByTestId('class-filter-mixset-Metrics').click()
+
+    await expect
+      .poll(() => diagramRequests[diagramRequests.length - 1])
+      .toMatchObject({
+        classFilterQuery: 'Invoice ~ArchivedInvoice 2 gvseparator=1.7',
+        namedFilters: ['Focus'],
+        mixsets: ['Metrics'],
+      })
+
+    const rendererToggle = page.getByRole('switch', { name: 'Edit GV' })
+    await rendererToggle.click()
+    await rendererToggle.click()
+
+    await expect(page.getByTestId('class-node-Invoice')).toBeVisible()
   })
 
   test('keeps the last diagram visible after a compile error in dynamic mode', async ({


### PR DESCRIPTION
## Summary
- restore legacy class diagram filter controls in the canvas display options
- send class filter, named filter, and mixset selections through the compile and diagram APIs via a transient backend overlay
- add backend, Vitest, and Playwright coverage for the restored class filter flow
- related to #93

## Test plan
- `cd frontend && bun run test src/lib/__tests__/classDiagramFilters.test.ts src/hooks/__tests__/useCompiler.test.ts src/stores/__tests__/sessionStore.test.ts src/components/diagram/__tests__/CanvasToolbar.test.tsx`
- `cd frontend && bun run test:e2e -- tests/e2e/generation.spec.ts`
- `go test ./backend/internal/api/handlers/...` *(not run here: `go` is not installed in this environment)*