### PR TITLE
fix: refine compiler issue actions

### DIFF
--- a/frontend/src/components/editor/EditorPanel.tsx
+++ b/frontend/src/components/editor/EditorPanel.tsx
@@ -14,6 +14,7 @@ import { useCollabTabs } from '../../hooks/useCollabTabs'
 import { useLsp } from '../../hooks/useLsp'
 import { attachLspToView } from '../../codemirror/lsp'
 import { findDiagramRange, type DiagramSelectDetail } from './diagramSelection'
+import { jumpEditorViewToLine } from './issueNavigation'
 
 const AgentPanel = lazy(() => import('../agent/AgentPanel'))
 
@@ -24,6 +25,8 @@ export function EditorPanel() {
   const collabConfig = useCollabEditor()
   useCollabTabs()
   const diffPreview = useEphemeralStore((s) => s.diffPreview)
+  const pendingEditorJump = useEphemeralStore((s) => s.pendingEditorJump)
+  const clearPendingEditorJump = useEphemeralStore((s) => s.clearPendingEditorJump)
   const readOnly = useEphemeralStore((s) => s.readOnly)
   const isAiConfigured = usePreferencesStore(
     (s) => {
@@ -70,6 +73,20 @@ export function EditorPanel() {
     window.addEventListener('umple:diagram-select', handler)
     return () => window.removeEventListener('umple:diagram-select', handler)
   }, [])
+
+  useEffect(() => {
+    if (!pendingEditorJump || pendingEditorJump.tabId !== activeTabId) return
+
+    const frame = window.requestAnimationFrame(() => {
+      const view = editorViewRef.current ?? editorRef.current?.view
+      if (!view) return
+
+      jumpEditorViewToLine(view, pendingEditorJump.line)
+      clearPendingEditorJump()
+    })
+
+    return () => window.cancelAnimationFrame(frame)
+  }, [activeTabId, clearPendingEditorJump, diffPreview, pendingEditorJump])
 
   const handleChange = useCallback((newCode: string) => {
     setCode(newCode)

--- a/frontend/src/components/editor/ExecutionPanel.tsx
+++ b/frontend/src/components/editor/ExecutionPanel.tsx
@@ -3,9 +3,10 @@ import { useEphemeralStore } from '../../stores/ephemeralStore'
 import type { ParsedIssue } from '../../stores/ephemeralStore'
 import { useSessionStore } from '../../stores/sessionStore'
 import { usePreferencesStore } from '@/stores/preferencesStore'
-import { ChevronDown, Check, AlertTriangle, X, XCircle, Sparkles, Loader2, Copy, ExternalLink, Terminal } from 'lucide-react'
+import { ChevronDown, Check, AlertTriangle, X, XCircle, Sparkles, Loader2, Copy, Terminal } from 'lucide-react'
 import { Tip } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { resolveIssueTab } from './issueNavigation'
 
 /** Animated checkmark that draws itself on mount */
 function AnimatedCheck({ className }: { className?: string }) {
@@ -117,30 +118,78 @@ function Badges() {
 
 function IssueRow({ issue }: { issue: ParsedIssue }) {
   const isError = issue.severity <= 2
+  const severityLabel = isError ? 'error' : 'warning'
   const colorClass = isError ? 'text-status-error' : 'text-status-warning'
-  const bgClass = isError ? 'bg-status-error/5 hover:bg-status-error/10' : 'bg-status-warning/5 hover:bg-status-warning/10'
+  const bgClass = isError ? 'bg-status-error/5' : 'bg-status-warning/5'
   const Icon = isError ? XCircle : AlertTriangle
+  const tabs = useSessionStore((s) => s.tabs)
+  const activeTabId = useSessionStore((s) => s.activeTabId)
+  const targetTab = useMemo(
+    () => resolveIssueTab(tabs, activeTabId, issue.filename),
+    [tabs, activeTabId, issue.filename],
+  )
+  const showTabLabel = !!issue.filename && !!targetTab
+
+  const handleJump = useCallback(() => {
+    if (!issue.line || !targetTab) return
+
+    const { setActiveTab } = useSessionStore.getState()
+    if (targetTab.id !== useSessionStore.getState().activeTabId) {
+      setActiveTab(targetTab.id)
+    }
+
+    useEphemeralStore.getState().requestEditorJump({
+      tabId: targetTab.id,
+      line: issue.line,
+    })
+  }, [issue.line, targetTab])
 
   return (
-    <div className={`flex items-start gap-2 rounded px-2 py-1.5 ${bgClass} transition-colors`}>
-      <Icon className={`size-3.5 shrink-0 mt-0.5 ${colorClass}`} />
-      <span className={`flex-1 min-w-0 font-mono text-xs leading-relaxed ${colorClass}`}>
-        {issue.message}
-      </span>
-      <div className="flex items-center gap-2 shrink-0">
-        {issue.line > 0 && (
-          <span className="text-xxs text-ink-faint">line {issue.line}</span>
-        )}
-        {issue.url && (
-          <a
-            href={issue.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-ink-faint hover:text-brand transition-colors"
-            title="View documentation"
-          >
-            <ExternalLink className="size-3" />
-          </a>
+    <div className={`flex cursor-default items-start gap-2 rounded-lg px-2.5 py-2 ${bgClass}`}>
+      <Icon className={`mt-0.5 size-3.5 shrink-0 ${colorClass}`} />
+      <div className="min-w-0 flex-1">
+        <div className={`min-w-0 break-words font-mono text-xs leading-relaxed ${colorClass}`}>
+          <span className="font-semibold">{severityLabel}</span>
+          {issue.line > 0 && targetTab ? (
+            <>
+              <span>{' on '}</span>
+              <button
+                type="button"
+                onClick={handleJump}
+                className={cn(
+                  'inline cursor-pointer rounded px-0.5 font-semibold underline decoration-current/70 underline-offset-2 transition-colors',
+                  'focus-visible:outline-2 focus-visible:outline-brand focus-visible:outline-offset-1',
+                  isError
+                    ? 'hover:text-status-error'
+                    : 'hover:text-status-warning',
+                )}
+              >
+                {`line ${issue.line}`}
+              </button>
+            </>
+          ) : issue.line > 0 ? (
+            <span>{` on line ${issue.line}`}</span>
+          ) : null}
+          <span>{`: ${issue.message}`}</span>
+        </div>
+        {(showTabLabel || issue.url) && (
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1">
+            {issue.url && (
+              <a
+                href={issue.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-xxs leading-relaxed text-ink-muted underline decoration-border-strong/70 underline-offset-2 transition-colors hover:text-brand"
+              >
+                {issue.errorCode ? `More information (${issue.errorCode})` : 'More information'}
+              </a>
+            )}
+            {showTabLabel && (
+              <span className="rounded-full bg-surface-0/80 px-1.5 py-0.5 font-mono text-xxs text-ink-muted">
+                {targetTab.name}
+              </span>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/components/editor/__tests__/ExecutionPanel.test.tsx
+++ b/frontend/src/components/editor/__tests__/ExecutionPanel.test.tsx
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { OutputPanel } from '../ExecutionPanel'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { useEphemeralStore } from '@/stores/ephemeralStore'
+import { useSessionStore } from '@/stores/sessionStore'
 
 function resetExecutionState() {
   useEphemeralStore.setState({
@@ -15,10 +17,22 @@ function resetExecutionState() {
     rawErrorText: '',
     outputErrorCount: 0,
     outputWarningCount: 0,
+    pendingEditorJump: null,
   })
 }
 
 describe('ExecutionPanel', () => {
+  beforeEach(() => {
+    useSessionStore.setState({
+      code: 'class Person {}\nclass Order {}',
+      activeTabId: 'main',
+      tabs: [
+        { id: 'main', name: 'Model.ump', code: 'class Person {}', dirty: false, savedCode: 'class Person {}', undoStack: [], redoStack: [] },
+        { id: 'support', name: 'Support.ump', code: 'class Order {}', dirty: false, savedCode: 'class Order {}', undoStack: [], redoStack: [] },
+      ],
+    })
+  })
+
   afterEach(() => {
     cleanup()
     resetExecutionState()
@@ -38,5 +52,43 @@ describe('ExecutionPanel', () => {
     expect(screen.getByText('For main method in class Shape2D:')).toBeTruthy()
     expect(screen.getByText(/Java result:/)).toBeTruthy()
     expect(screen.queryByText(/<strong>For main method in class Shape2D:/)).toBeNull()
+  })
+
+  it('renders more information link and clicking line requests an editor jump on the correct tab', async () => {
+    const user = userEvent.setup()
+    useEphemeralStore.setState({
+      parsedIssues: [
+        {
+          severity: 1,
+          errorCode: 'E1',
+          message: 'Parsing error: namespce, did you mean namespace',
+          line: 9,
+          filename: 'Support.ump',
+          url: 'https://cruise.umple.org/umple/UmpleReference/Namespace.html',
+        },
+      ],
+      outputErrorCount: 1,
+    })
+
+    render(
+      <TooltipProvider>
+        <OutputPanel />
+      </TooltipProvider>,
+    )
+
+    expect(screen.getByText('error')).toBeTruthy()
+    expect(screen.getByText(/: Parsing error: namespce, did you mean namespace/)).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'More information (E1)' }).getAttribute('href')).toBe(
+      'https://cruise.umple.org/umple/UmpleReference/Namespace.html',
+    )
+    expect(screen.getByText('Support.ump')).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: /line 9/i }))
+
+    expect(useSessionStore.getState().activeTabId).toBe('support')
+    expect(useEphemeralStore.getState().pendingEditorJump).toEqual({
+      tabId: 'support',
+      line: 9,
+    })
   })
 })

--- a/frontend/src/components/editor/__tests__/issueNavigation.test.ts
+++ b/frontend/src/components/editor/__tests__/issueNavigation.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { EditorState } from '@codemirror/state'
+import { describe, expect, it, vi } from 'vitest'
+import type { EditorView } from '@codemirror/view'
+
+import { jumpEditorViewToLine, resolveIssueTab } from '../issueNavigation'
+import type { Tab } from '@/stores/sessionStore'
+
+const tabs: Tab[] = [
+  { id: 'main', name: 'Model.ump', code: '', dirty: false, savedCode: '', undoStack: [], redoStack: [] },
+  { id: 'support', name: 'Support.ump', code: '', dirty: false, savedCode: '', undoStack: [], redoStack: [] },
+]
+
+describe('issueNavigation', () => {
+  it('resolves issue filenames to the matching tab', () => {
+    expect(resolveIssueTab(tabs, 'main', 'Support.ump')?.id).toBe('support')
+  })
+
+  it('resolves issue paths by basename and falls back to the active tab', () => {
+    expect(resolveIssueTab(tabs, 'main', 'nested/Support.ump')?.id).toBe('support')
+    expect(resolveIssueTab(tabs, 'main', 'missing.ump')?.id).toBe('main')
+  })
+
+  it('jumps the editor view to the requested line', () => {
+    const state = EditorState.create({
+      doc: 'first\nsecond\nthird',
+    })
+    const focus = vi.fn()
+    const dispatch = vi.fn()
+    const view = {
+      state,
+      focus,
+      dispatch,
+    } as unknown as EditorView
+
+    jumpEditorViewToLine(view, 2)
+
+    expect(focus).toHaveBeenCalledOnce()
+    const transaction = dispatch.mock.calls[0]?.[0]
+    expect(transaction.selection.anchor).toBe(state.doc.line(2).from)
+    expect(transaction.selection.head).toBe(state.doc.line(2).from)
+  })
+})

--- a/frontend/src/components/editor/issueNavigation.ts
+++ b/frontend/src/components/editor/issueNavigation.ts
@@ -1,0 +1,48 @@
+import { EditorSelection } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+
+import { ensureUmpExt } from '@/lib/umpFile'
+import type { Tab } from '@/stores/sessionStore'
+
+export interface EditorIssueJump {
+  tabId: string
+  line: number
+}
+
+function issueFilenameCandidates(filename: string): string[] {
+  const trimmed = filename.trim()
+  if (!trimmed) return []
+
+  const normalized = trimmed.replace(/\\/g, '/')
+  const basename = normalized.split('/').filter(Boolean).pop() ?? normalized
+  const candidates = new Set<string>([trimmed, normalized, basename])
+
+  if (basename && !basename.includes('.')) {
+    candidates.add(ensureUmpExt(basename))
+  }
+
+  if (normalized && !normalized.includes('.')) {
+    candidates.add(ensureUmpExt(normalized))
+  }
+
+  return [...candidates]
+}
+
+export function resolveIssueTab(tabs: Tab[], activeTabId: string, filename?: string | null): Tab | null {
+  const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0] ?? null
+  if (!filename) return activeTab
+
+  const candidates = new Set(issueFilenameCandidates(filename))
+  return tabs.find((tab) => candidates.has(tab.name)) ?? activeTab
+}
+
+export function jumpEditorViewToLine(view: EditorView, lineNumber: number) {
+  const targetLine = Math.min(Math.max(Math.trunc(lineNumber) || 1, 1), view.state.doc.lines)
+  const line = view.state.doc.line(targetLine)
+
+  view.focus()
+  view.dispatch({
+    selection: EditorSelection.cursor(line.from),
+    effects: EditorView.scrollIntoView(line.from, { y: 'center' }),
+  })
+}

--- a/frontend/src/stores/__tests__/uiStore.test.ts
+++ b/frontend/src/stores/__tests__/uiStore.test.ts
@@ -9,6 +9,7 @@ afterEach(() => {
     executionErrors: null,
     outputErrorCount: 0,
     outputWarningCount: 0,
+    pendingEditorJump: null,
   })
   useSessionStore.setState({ showAgentPanel: false, showAgentBar: false })
 })

--- a/frontend/src/stores/ephemeralStore.ts
+++ b/frontend/src/stores/ephemeralStore.ts
@@ -131,6 +131,7 @@ interface EphemeralState {
 
   // Editor ephemeral
   diffPreview: DiffPreviewState | null
+  pendingEditorJump: { tabId: string; line: number } | null
   selection: { fromLine: number; toLine: number; text: string; coords?: { x: number; yTop: number; yBottom: number } } | null
 
   // LSP
@@ -187,6 +188,8 @@ interface EphemeralState {
   // Editor ephemeral actions
   showDiffPreview: (preview: DiffPreviewState) => void
   clearDiffPreview: (toolCallId?: string) => void
+  requestEditorJump: (jump: { tabId: string; line: number }) => void
+  clearPendingEditorJump: () => void
   setSelection: (sel: EphemeralState['selection']) => void
 
   // Agent message queue actions
@@ -245,6 +248,7 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
 
   // Editor ephemeral
   diffPreview: null,
+  pendingEditorJump: null,
   selection: null,
 
   // LSP
@@ -369,6 +373,8 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
     if (toolCallId && s.diffPreview?.toolCallId !== toolCallId) return s
     return { diffPreview: null }
   }),
+  requestEditorJump: (pendingEditorJump) => set({ pendingEditorJump }),
+  clearPendingEditorJump: () => set({ pendingEditorJump: null }),
   setSelection: (selection) => set({ selection }),
 
   // Agent message queue actions


### PR DESCRIPTION
## Summary
- restore the legacy-style compiler issue sentence format in the output panel
- keep line jumps inline, show the legacy More information link label with the error code, and move the tab tag to the end
- add issue-navigation helpers and focused frontend tests for the updated behavior

Related to #93

## Test plan
- bun run test src/components/editor/__tests__/ExecutionPanel.test.tsx
- bun run build