### PR TITLE
fix(output): expose generated files and verification details

### DIFF
--- a/backend/internal/api/handlers/compile.go
+++ b/backend/internal/api/handlers/compile.go
@@ -56,6 +56,7 @@ type GenerateResponse struct {
 	GeneratedHTML      string                       `json:"generatedHtml,omitempty"`
 	GeneratedIframeURL string                       `json:"generatedIframeUrl,omitempty"`
 	GeneratedDownloads []generate.GeneratedArtifact `json:"generatedDownloads,omitempty"`
+	GeneratedFiles     []generate.GeneratedFile     `json:"generatedFiles,omitempty"`
 }
 
 func (h *GenerateHandler) Generate(w http.ResponseWriter, r *http.Request) {
@@ -218,6 +219,7 @@ func (h *GenerateHandler) Generate(w http.ResponseWriter, r *http.Request) {
 		resp.GeneratedHTML = genResp.HTML
 		resp.GeneratedIframeURL = genResp.IframeURL
 		resp.GeneratedDownloads = genResp.Downloads
+		resp.GeneratedFiles = genResp.Files
 
 		if genResp.Errors != "" {
 			if resp.Errors != "" {

--- a/backend/internal/api/handlers/generate/files.go
+++ b/backend/internal/api/handlers/generate/files.go
@@ -74,10 +74,10 @@ func cleanGeneratedFiles(dir, language, entryFile string) {
 	})
 }
 
-func readGeneratedFiles(dir, language, entryFile string) (string, []string, error) {
+func readGeneratedFiles(dir, language, entryFile string) (string, []GeneratedFile, []string, error) {
 	exts := languageExtensions(language)
 	if len(exts) == 0 {
-		return "", nil, fmt.Errorf("unknown language: %s", language)
+		return "", nil, nil, fmt.Errorf("unknown language: %s", language)
 	}
 
 	extSet := make(map[string]bool, len(exts))
@@ -98,19 +98,32 @@ func readGeneratedFiles(dir, language, entryFile string) (string, []string, erro
 	sort.Strings(paths)
 
 	if len(paths) == 0 {
-		return "", nil, fmt.Errorf("no generated files found")
+		return "", nil, nil, fmt.Errorf("no generated files found")
 	}
 
 	var parts []string
+	files := make([]GeneratedFile, 0, len(paths))
 	for _, p := range paths {
 		data, err := os.ReadFile(p)
 		if err != nil {
 			continue
 		}
-		parts = append(parts, string(data))
+		content := string(data)
+		parts = append(parts, content)
+
+		relPath, err := filepath.Rel(dir, p)
+		if err != nil {
+			relPath = filepath.Base(p)
+		}
+		relPath = filepath.ToSlash(relPath)
+		files = append(files, GeneratedFile{
+			Name:    filepath.Base(p),
+			Path:    relPath,
+			Content: content,
+		})
 	}
 
-	return strings.Join(parts, "\n"), paths, nil
+	return strings.Join(parts, "\n"), files, paths, nil
 }
 
 func prepareGeneratedWorkspace(dir, name string) (string, error) {

--- a/backend/internal/api/handlers/generate/files_test.go
+++ b/backend/internal/api/handlers/generate/files_test.go
@@ -1,0 +1,51 @@
+package generate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadGeneratedFilesReturnsCombinedAndStructuredFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "model.ump"), []byte("class Invoice {}"), 0o644); err != nil {
+		t.Fatalf("write entry file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "billing"), 0o755); err != nil {
+		t.Fatalf("create package dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "billing", "Invoice.java"), []byte("class Invoice {}"), 0o644); err != nil {
+		t.Fatalf("write invoice file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "billing", "Customer.java"), []byte("class Customer {}"), 0o644); err != nil {
+		t.Fatalf("write customer file: %v", err)
+	}
+
+	combined, files, paths, err := readGeneratedFiles(dir, "Java", "model.ump")
+	if err != nil {
+		t.Fatalf("readGeneratedFiles returned error: %v", err)
+	}
+
+	if len(files) != 2 {
+		t.Fatalf("len(files) = %d, want 2", len(files))
+	}
+	if len(paths) != 2 {
+		t.Fatalf("len(paths) = %d, want 2", len(paths))
+	}
+
+	if files[0].Path != "billing/Customer.java" || files[0].Name != "Customer.java" {
+		t.Fatalf("first file = %#v, want billing/Customer.java", files[0])
+	}
+	if files[1].Path != "billing/Invoice.java" || files[1].Name != "Invoice.java" {
+		t.Fatalf("second file = %#v, want billing/Invoice.java", files[1])
+	}
+
+	if !strings.Contains(combined, "class Customer {}") || !strings.Contains(combined, "class Invoice {}") {
+		t.Fatalf("combined output missing generated content:\n%s", combined)
+	}
+	if strings.Contains(combined, "class Invoice {}class Customer {}") {
+		t.Fatalf("combined output should separate files with a newline:\n%s", combined)
+	}
+}

--- a/backend/internal/api/handlers/generate/service.go
+++ b/backend/internal/api/handlers/generate/service.go
@@ -52,9 +52,9 @@ func (s *Service) generateGeneric(language, dir, modelID, entryFile string, subo
 	}
 	output := strings.TrimSpace(stdout)
 
-	files, paths, err := readGeneratedFiles(outputDir, language, entryFile)
-	if err == nil && files != "" {
-		output = files
+	outputFiles, generatedFiles, paths, err := readGeneratedFiles(outputDir, language, entryFile)
+	if err == nil && outputFiles != "" {
+		output = outputFiles
 	}
 
 	if runErr != nil && strings.TrimSpace(stderr) == "" {
@@ -67,6 +67,7 @@ func (s *Service) generateGeneric(language, dir, modelID, entryFile string, subo
 		Errors:   strings.TrimSpace(stderr),
 		ModelID:  modelID,
 		Kind:     "text",
+		Files:    generatedFiles,
 	}
 
 	if IsHTMLLanguage(language) {
@@ -108,9 +109,9 @@ func (s *Service) generateJavadoc(dir, modelID, entryFile string) (GenerateRespo
 		return GenerateResponse{}, err
 	}
 
-	files, javaFiles, err := readGeneratedFiles(javadocSrcDir, "Java", entryFile)
-	if err == nil && files != "" {
-		output = files
+	outputFiles, _, javaFiles, err := readGeneratedFiles(javadocSrcDir, "Java", entryFile)
+	if err == nil && outputFiles != "" {
+		output = outputFiles
 	}
 
 	if len(javaFiles) == 0 {
@@ -174,8 +175,8 @@ func (s *Service) generateYuml(dir, modelID, entryFile string) (GenerateResponse
 	stdout, stderr, runErr := s.runGenerateCommand("Yuml", filepath.Join(dir, entryFile), dir, nil)
 	output := strings.TrimSpace(stdout)
 	if output == "" {
-		if files, _, err := readGeneratedFiles(dir, "Yuml", entryFile); err == nil && files != "" {
-			output = strings.TrimSpace(files)
+		if outputFiles, _, _, err := readGeneratedFiles(dir, "Yuml", entryFile); err == nil && outputFiles != "" {
+			output = strings.TrimSpace(outputFiles)
 		}
 	}
 

--- a/backend/internal/api/handlers/generate/types.go
+++ b/backend/internal/api/handlers/generate/types.go
@@ -3,9 +3,9 @@ package generate
 import "strings"
 
 type GenerateRequest struct {
-	Code      string `json:"code"`
-	Language  string `json:"language"`
-	ModelID   string `json:"modelId,omitempty"`
+	Code        string `json:"code"`
+	Language    string `json:"language"`
+	ModelID     string `json:"modelId,omitempty"`
 	ActiveTabID string `json:"activeTabId,omitempty"`
 }
 
@@ -13,6 +13,12 @@ type GeneratedArtifact struct {
 	Label    string `json:"label"`
 	URL      string `json:"url"`
 	Filename string `json:"filename,omitempty"`
+}
+
+type GeneratedFile struct {
+	Name    string `json:"name"`
+	Path    string `json:"path"`
+	Content string `json:"content"`
 }
 
 type GenerateResponse struct {
@@ -24,6 +30,7 @@ type GenerateResponse struct {
 	HTML      string              `json:"html,omitempty"`
 	IframeURL string              `json:"iframeUrl,omitempty"`
 	Downloads []GeneratedArtifact `json:"downloads,omitempty"`
+	Files     []GeneratedFile     `json:"files,omitempty"`
 }
 
 var validLanguages = map[string]bool{

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -41,6 +41,7 @@ export interface GenerationResponse {
   generatedHtml?: string;
   generatedIframeUrl?: string;
   generatedDownloads?: GeneratedArtifact[];
+  generatedFiles?: GeneratedCodeFile[];
 }
 
 export interface UmpleModel {
@@ -212,6 +213,12 @@ export interface GeneratedArtifact {
   filename?: string;
 }
 
+export interface GeneratedCodeFile {
+  name: string;
+  path: string;
+  content: string;
+}
+
 export interface GenerateResponse {
   output: string;
   language: string;
@@ -221,6 +228,7 @@ export interface GenerateResponse {
   html?: string;
   iframeUrl?: string;
   downloads?: GeneratedArtifact[];
+  files?: GeneratedCodeFile[];
 }
 
 // CRUD schema types (from POST /api/crud/schema)

--- a/frontend/src/components/agent/ActionRow.tsx
+++ b/frontend/src/components/agent/ActionRow.tsx
@@ -9,6 +9,7 @@ interface ActionRowProps {
   label: string
   status?: ActionStatus
   children?: ReactNode
+  autoOpen?: boolean
 }
 
 /**
@@ -25,10 +26,11 @@ export function ActionRow({
   label,
   status,
   children,
+  autoOpen = false,
 }: ActionRowProps) {
   const hasContent = !!children
   const [open, setOpen] = useState(
-    status === 'approval' || status === 'error',
+    status === 'approval' || status === 'error' || autoOpen,
   )
   const prevStatus = useRef(status)
   const [flash, setFlash] = useState(false)
@@ -37,6 +39,11 @@ export function ActionRow({
   useEffect(() => {
     if (status === 'approval' || status === 'error') setOpen(true)
   }, [status])
+
+  /* Auto-expand when content becomes available and the caller wants it visible */
+  useEffect(() => {
+    if (autoOpen && hasContent) setOpen(true)
+  }, [autoOpen, hasContent])
 
   /* Flash green when transitioning to done */
   useEffect(() => {

--- a/frontend/src/components/agent/MessageBubble.tsx
+++ b/frontend/src/components/agent/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { getToolName, isToolUIPart, type UIMessage } from 'ai'
 import {
   Eye,
@@ -9,11 +9,15 @@ import {
   Wrench,
   Check,
   XIcon,
+  AlertTriangle,
 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { cn } from '@/lib/utils'
 import type { ToolPreviewInfo } from '@/ai/editPreview'
+import { useEphemeralStore } from '@/stores/ephemeralStore'
+import { useSessionStore } from '@/stores/sessionStore'
+import { resolveIssueTab } from '@/components/editor/issueNavigation'
 import { ActionRow } from './ActionRow'
 
 /* ── Memoized Markdown ── */
@@ -50,6 +54,10 @@ const TOOL_CONFIG: Record<
   compile: {
     icon: <Play className="size-3" />,
     labels: { running: 'Generating', approval: 'Generating', done: 'Generated' },
+  },
+  verifyCode: {
+    icon: <Check className="size-3" />,
+    labels: { running: 'Verifying code', approval: 'Verifying code', done: 'Verified code' },
   },
 }
 
@@ -107,6 +115,233 @@ function DiffBlock({
     >
       {text || '\u00A0'}
     </pre>
+  )
+}
+
+function formatToolOutput(output: unknown): string {
+  if (typeof output === 'string') return output
+  if (output == null) return ''
+  if (typeof output === 'number' || typeof output === 'boolean') return String(output)
+
+  try {
+    return JSON.stringify(output, null, 2)
+  } catch {
+    return String(output)
+  }
+}
+
+function ToolOutputBlock({ output }: { output: unknown }) {
+  const formatted = formatToolOutput(output)
+
+  return (
+    <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-surface-0 p-2 font-mono text-xxs leading-relaxed text-ink">
+      {formatted || 'No output returned.'}
+    </pre>
+  )
+}
+
+interface VerifyCodeOutput {
+  success?: boolean
+  errors?: string | null
+  modelId?: string | null
+}
+
+interface ParsedVerifyIssue {
+  severity: number
+  errorCode: string
+  message: string
+  line: number
+  filename: string
+  url: string
+}
+
+function parseVerifyIssues(raw: string | null | undefined): {
+  issues: ParsedVerifyIssue[]
+  rawText: string
+  errorCount: number
+  warningCount: number
+} {
+  if (!raw) return { issues: [], rawText: '', errorCount: 0, warningCount: 0 }
+
+  const allResults: ParsedVerifyIssue[] = []
+  const rawLines: string[] = []
+
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+
+    try {
+      const parsed = JSON.parse(trimmed)
+      const results = parsed?.results
+
+      if (Array.isArray(results)) {
+        for (const result of results) {
+          allResults.push({
+            severity: Number(result.severity ?? 1),
+            errorCode: String(result.errorCode ?? ''),
+            message: String(result.message ?? ''),
+            line: Number(result.line ?? 0),
+            filename: String(result.filename ?? ''),
+            url: String(result.url ?? ''),
+          })
+        }
+      } else {
+        rawLines.push(trimmed)
+      }
+    } catch {
+      rawLines.push(trimmed)
+    }
+  }
+
+  const seen = new Set<string>()
+  const issues: ParsedVerifyIssue[] = []
+
+  for (const issue of allResults) {
+    const key = `${issue.errorCode}:${issue.line}:${issue.message}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      issues.push(issue)
+    }
+  }
+
+  issues.sort((a, b) => {
+    const aBucket = a.severity <= 2 ? 0 : 1
+    const bBucket = b.severity <= 2 ? 0 : 1
+    if (aBucket !== bBucket) return aBucket - bBucket
+    return a.line - b.line
+  })
+
+  const rawText = rawLines.join('\n')
+  const errorCount = issues.filter((issue) => issue.severity <= 2).length + (rawText && !issues.length ? 1 : 0)
+  const warningCount = issues.filter((issue) => issue.severity > 2).length
+
+  return { issues, rawText, errorCount, warningCount }
+}
+
+function VerifyIssueRow({ issue }: { issue: ParsedVerifyIssue }) {
+  const isError = issue.severity <= 2
+  const toneClass = isError ? 'text-status-error' : 'text-status-warning'
+  const bgClass = isError ? 'bg-status-error/6' : 'bg-status-warning/8'
+  const tabs = useSessionStore((state) => state.tabs)
+  const activeTabId = useSessionStore((state) => state.activeTabId)
+  const targetTab = useMemo(
+    () => resolveIssueTab(tabs, activeTabId, issue.filename),
+    [tabs, activeTabId, issue.filename],
+  )
+  const showTabLabel = !!issue.filename && !!targetTab
+
+  const handleJump = useCallback(() => {
+    if (!issue.line || !targetTab) return
+
+    const { setActiveTab } = useSessionStore.getState()
+    if (targetTab.id !== useSessionStore.getState().activeTabId) {
+      setActiveTab(targetTab.id)
+    }
+
+    useEphemeralStore.getState().requestEditorJump({
+      tabId: targetTab.id,
+      line: issue.line,
+    })
+  }, [issue.line, targetTab])
+
+  return (
+    <div className={`rounded-md px-2.5 py-2 ${bgClass}`}>
+      <p className={`break-words font-mono text-xxs leading-relaxed ${toneClass}`}>
+        <span className="font-semibold">{isError ? 'Error' : 'Warning'}</span>
+        {issue.line > 0 && targetTab ? (
+          <>
+            <span>{' on '}</span>
+            <button
+              type="button"
+              onClick={handleJump}
+              className={cn(
+                'inline cursor-pointer rounded px-0.5 font-semibold underline decoration-current/70 underline-offset-2 transition-colors',
+                'focus-visible:outline-2 focus-visible:outline-brand focus-visible:outline-offset-1',
+                isError ? 'hover:text-status-error' : 'hover:text-status-warning',
+              )}
+            >
+              {`line ${issue.line}`}
+            </button>
+          </>
+        ) : issue.line > 0 ? (
+          <span>{` on line ${issue.line}`}</span>
+        ) : null}
+        {issue.filename ? ` in ${issue.filename}` : ''}
+        {`: ${issue.message}`}
+      </p>
+      {(showTabLabel || issue.errorCode || issue.url) && (
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          {issue.errorCode ? (
+            <span className="rounded-full bg-surface-0 px-1.5 py-0.5 font-mono text-[10px] text-ink-muted">
+              {issue.errorCode}
+            </span>
+          ) : null}
+          {issue.url ? (
+            <a
+              href={issue.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[10px] text-brand underline underline-offset-2"
+            >
+              More information
+            </a>
+          ) : null}
+          {showTabLabel ? (
+            <span className="rounded-full bg-surface-0 px-1.5 py-0.5 font-mono text-[10px] text-ink-muted">
+              {targetTab.name}
+            </span>
+          ) : null}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function VerifyCodeResultCard({ output }: { output: VerifyCodeOutput }) {
+  const { issues, rawText, errorCount, warningCount } = parseVerifyIssues(output.errors)
+  const isSuccess = Boolean(output.success) && errorCount === 0
+
+  return (
+    <div className="space-y-2 rounded-lg border border-border bg-surface-0 p-3">
+      <div className="flex flex-wrap items-start gap-2">
+        <div
+          className={cn(
+            'flex size-5 items-center justify-center rounded-full',
+            isSuccess ? 'bg-status-success/12 text-status-success' : 'bg-status-error/10 text-status-error',
+          )}
+        >
+          {isSuccess ? <Check className="size-3" /> : <AlertTriangle className="size-3" />}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-medium text-ink">
+            {isSuccess ? 'Verification passed' : 'Verification found issues'}
+          </p>
+          <p className="mt-0.5 text-xs text-ink-muted">
+            {isSuccess
+              ? 'No validation issues were reported.'
+              : `${errorCount} ${errorCount === 1 ? 'error' : 'errors'} and ${warningCount} ${warningCount === 1 ? 'warning' : 'warnings'}.`}
+          </p>
+        </div>
+        {output.modelId ? (
+          <span className="rounded-full bg-surface-1 px-2 py-0.5 font-mono text-[10px] text-ink-muted">
+            {output.modelId}
+          </span>
+        ) : null}
+      </div>
+
+      {issues.length > 0 ? (
+        <div className="space-y-1.5">
+          {issues.map((issue, index) => (
+            <VerifyIssueRow
+              key={`${issue.errorCode}-${issue.line}-${issue.message}-${index}`}
+              issue={issue}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {rawText ? <ToolOutputBlock output={rawText} /> : null}
+    </div>
   )
 }
 
@@ -188,18 +423,10 @@ function ToolActionRow({
     )
   } else if (state === 'output-available' && output != null) {
     children =
-      typeof output === 'string' ? (
-        output.includes('\n') || output.length > 80 ? (
-          <pre className="max-h-32 overflow-auto rounded border border-border bg-surface-0 p-2 font-mono text-xxs text-ink-muted">
-            {output}
-          </pre>
-        ) : (
-          <p className="text-xs text-ink-muted">{output}</p>
-        )
+      toolName === 'verifyCode' ? (
+        <VerifyCodeResultCard output={output as VerifyCodeOutput} />
       ) : (
-        <pre className="max-h-32 overflow-auto rounded border border-border bg-surface-0 p-2 font-mono text-xxs text-ink-muted">
-          {JSON.stringify(output, null, 2)}
-        </pre>
+        <ToolOutputBlock output={output} />
       )
   } else if (state === 'output-error') {
     children = <p className="text-xs text-status-error">{errorText}</p>
@@ -216,6 +443,7 @@ function ToolActionRow({
       icon={icon}
       label={actionLabel(toolName, state)}
       status={actionStatus(state)}
+      autoOpen={state === 'output-available'}
     >
       {children}
     </ActionRow>

--- a/frontend/src/components/agent/__tests__/AgentPanel.test.tsx
+++ b/frontend/src/components/agent/__tests__/AgentPanel.test.tsx
@@ -119,6 +119,176 @@ describe('AgentPanel', () => {
     expect(mockRejectToolCall).toHaveBeenCalledWith('approval-1', 'call-1', 'editCode')
   })
 
+  it('renders tool output in an expanded wrapped block', () => {
+    useSessionStore.setState({ showAgentPanel: true })
+
+    mockAgentState = {
+      ...mockAgentState,
+      messages: [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-readEditorCode',
+              toolCallId: 'call-1',
+              state: 'output-available',
+              input: {},
+              output: 'class Student {\n  name;\n}',
+            },
+          ],
+        },
+      ],
+    }
+
+    renderAgentPanel()
+
+    const output = screen.getByText((content, element) => {
+      return element?.tagName === 'PRE' && content.includes('class Student {') && content.includes('name;')
+    })
+    const pre = output.closest('pre')
+
+    expect(screen.getByText('Read code')).toBeDefined()
+    expect(pre).not.toBeNull()
+    expect(pre?.className).toContain('whitespace-pre-wrap')
+    expect(pre?.className).toContain('break-words')
+  })
+
+  it('renders verifyCode output with a structured verification card', () => {
+    useSessionStore.setState({
+      showAgentPanel: true,
+      activeTabId: 'main',
+      tabs: [
+        { id: 'main', name: 'Model.ump', code: 'class Person {}', dirty: false, savedCode: 'class Person {}', undoStack: [], redoStack: [] },
+        { id: 'support', name: 'Main.ump', code: 'class Order {}', dirty: false, savedCode: 'class Order {}', undoStack: [], redoStack: [] },
+      ],
+    })
+    useEphemeralStore.setState({ pendingEditorJump: null })
+
+    mockAgentState = {
+      ...mockAgentState,
+      messages: [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-verifyCode',
+              toolCallId: 'call-verify',
+              state: 'output-available',
+              input: {},
+              output: {
+                success: false,
+                modelId: 'model-123',
+                errors: [
+                  JSON.stringify({
+                    results: [
+                      {
+                        severity: 1,
+                        errorCode: 'E001',
+                        message: 'Missing semicolon',
+                        line: 3,
+                        filename: 'Main.ump',
+                        url: 'https://example.com/error/E001',
+                      },
+                      {
+                        severity: 3,
+                        errorCode: 'W010',
+                        message: 'Unused attribute',
+                        line: 7,
+                        filename: 'Main.ump',
+                        url: 'https://example.com/error/W010',
+                      },
+                    ],
+                  }),
+                ].join('\n'),
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    renderAgentPanel()
+
+    expect(screen.getByText('Verified code')).toBeDefined()
+    expect(screen.getByText('Verification found issues')).toBeDefined()
+    expect(screen.getByText('1 error and 1 warning.')).toBeDefined()
+    expect(
+      screen.getByText((_, element) =>
+        (element?.tagName === 'P' &&
+          (element.textContent?.includes('Error on line 3 in Main.ump: Missing semicolon') ?? false)) ||
+        false,
+      ),
+    ).toBeDefined()
+    expect(
+      screen.getByText((_, element) =>
+        (element?.tagName === 'P' &&
+          (element.textContent?.includes('Warning on line 7 in Main.ump: Unused attribute') ?? false)) ||
+        false,
+      ),
+    ).toBeDefined()
+    expect(screen.getByText('model-123')).toBeDefined()
+    expect(screen.getAllByText('Main.ump')).toHaveLength(2)
+  })
+
+  it('clicks verifyCode line numbers to jump the editor to the matching tab', async () => {
+    const user = userEvent.setup()
+    useSessionStore.setState({
+      showAgentPanel: true,
+      activeTabId: 'main',
+      tabs: [
+        { id: 'main', name: 'Model.ump', code: 'class Person {}', dirty: false, savedCode: 'class Person {}', undoStack: [], redoStack: [] },
+        { id: 'support', name: 'Main.ump', code: 'class Order {}', dirty: false, savedCode: 'class Order {}', undoStack: [], redoStack: [] },
+      ],
+    })
+    useEphemeralStore.setState({ pendingEditorJump: null })
+
+    mockAgentState = {
+      ...mockAgentState,
+      messages: [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-verifyCode',
+              toolCallId: 'call-verify',
+              state: 'output-available',
+              input: {},
+              output: {
+                success: false,
+                modelId: 'model-123',
+                errors: JSON.stringify({
+                  results: [
+                    {
+                      severity: 1,
+                      errorCode: 'E001',
+                      message: 'Missing semicolon',
+                      line: 3,
+                      filename: 'Main.ump',
+                      url: 'https://example.com/error/E001',
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    renderAgentPanel()
+
+    await user.click(screen.getByRole('button', { name: /line 3/i }))
+
+    expect(useSessionStore.getState().activeTabId).toBe('support')
+    expect(useEphemeralStore.getState().pendingEditorJump).toEqual({
+      tabId: 'support',
+      line: 3,
+    })
+  })
+
   it('starts minimized with the launcher visible', () => {
     renderAgentPanel()
 

--- a/frontend/src/components/diagram/DiagramPanel.tsx
+++ b/frontend/src/components/diagram/DiagramPanel.tsx
@@ -46,6 +46,7 @@ export function DiagramPanel() {
   const generatedKind = useEphemeralStore((s) => s.generatedKind)
   const generatedIframeUrl = useEphemeralStore((s) => s.generatedIframeUrl)
   const generatedDownloads = useEphemeralStore((s) => s.generatedDownloads)
+  const generatedFiles = useEphemeralStore((s) => s.generatedFiles)
   const generatedTargetId = useEphemeralStore((s) => s.generatedTargetId)
   const generatedLanguage = useEphemeralStore((s) => s.generatedLanguage)
   const generatedSourceSignature = useEphemeralStore((s) => s.generatedSourceSignature)
@@ -278,6 +279,7 @@ export function DiagramPanel() {
                     iframeUrl={generatedIframeUrl}
                     language={generatedLanguage}
                     downloads={generatedDownloads}
+                    files={generatedFiles}
                   />
                 </div>
                 {generatedOutputStale && (

--- a/frontend/src/components/diagram/__tests__/DiagramPanel.test.tsx
+++ b/frontend/src/components/diagram/__tests__/DiagramPanel.test.tsx
@@ -96,6 +96,7 @@ afterEach(() => {
     generatedKind: 'text',
     generatedIframeUrl: null,
     generatedDownloads: [],
+    generatedFiles: [],
     generatedLanguage: 'Java',
     generatedSourceCode: null,
     generatedSourceTabId: null,

--- a/frontend/src/components/editor/ExecutionPanel.tsx
+++ b/frontend/src/components/editor/ExecutionPanel.tsx
@@ -415,7 +415,7 @@ export function OutputPanel() {
           <div className="flex flex-col items-center justify-center h-full gap-2 text-center px-4 animate-fade-in">
             <Terminal className="size-5 text-ink-faint/50" strokeWidth={1.5} />
             <p className="text-xs text-ink-faint max-w-48 leading-relaxed">
-              Output from compilation and code generation will appear here.
+              Message output will appear here.
             </p>
           </div>
         )}

--- a/frontend/src/components/generation/CodeOutput.tsx
+++ b/frontend/src/components/generation/CodeOutput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { EditorView } from '@codemirror/view'
 import { EditorState } from '@codemirror/state'
 import { basicSetup } from 'codemirror'
@@ -11,6 +11,7 @@ import { useIsDark } from '../../hooks/useIsDark'
 interface CodeOutputProps {
   code: string
   language: string
+  testId?: string
 }
 
 export function getLanguageExtension(language: string) {
@@ -34,18 +35,10 @@ export function getLanguageExtension(language: string) {
   }
 }
 
-export function CodeOutput({ code, language }: CodeOutputProps) {
+export function CodeOutput({ code, language, testId = 'code-output' }: CodeOutputProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const viewRef = useRef<EditorView | null>(null)
-  const [copied, setCopied] = useState(false)
   const isDark = useIsDark()
-
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(code).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    })
-  }, [code])
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -81,17 +74,7 @@ export function CodeOutput({ code, language }: CodeOutputProps) {
   }, [code, language, isDark])
 
   return (
-    <div className="h-full relative">
-      <button
-        onClick={handleCopy}
-        className={`absolute top-2 right-3 z-10 px-2.5 py-1 text-xs border rounded cursor-pointer transition-colors ${
-          copied
-            ? 'bg-surface-1 text-status-success border-status-success'
-            : 'bg-surface-0 text-ink-muted border-border hover:bg-surface-1 hover:border-border-strong'
-        }`}
-      >
-        {copied ? 'Copied!' : 'Copy'}
-      </button>
+    <div className="h-full relative" data-testid={testId}>
       <div
         ref={containerRef}
         className="h-full w-full overflow-hidden"

--- a/frontend/src/components/generation/GeneratedOutputView.tsx
+++ b/frontend/src/components/generation/GeneratedOutputView.tsx
@@ -1,5 +1,8 @@
-import type { GeneratedArtifact } from '../../api/types'
+import { useCallback, useState } from 'react'
+import type { GeneratedArtifact, GeneratedCodeFile } from '../../api/types'
 import { CodeOutput } from './CodeOutput'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { cn } from '@/lib/utils'
 
 interface GeneratedOutputViewProps {
   kind: 'text' | 'html' | 'iframe'
@@ -8,13 +11,14 @@ interface GeneratedOutputViewProps {
   iframeUrl: string | null
   language: string
   downloads: GeneratedArtifact[]
+  files: GeneratedCodeFile[]
 }
 
-function DownloadLinks({ downloads }: { downloads: GeneratedArtifact[] }) {
+function DownloadButtons({ downloads }: { downloads: GeneratedArtifact[] }) {
   if (downloads.length === 0) return null
 
   return (
-    <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-surface-1/60 shrink-0">
+    <>
       {downloads.map((download) => (
         <a
           key={`${download.url}-${download.label}`}
@@ -25,6 +29,77 @@ function DownloadLinks({ downloads }: { downloads: GeneratedArtifact[] }) {
           {download.label}
         </a>
       ))}
+    </>
+  )
+}
+
+const generatedTabTriggerClassName = cn(
+  '!flex-none h-7 shrink-0 rounded-none border-b border-b-transparent px-2.5 py-0 text-xs text-ink-muted',
+  'data-[state=active]:bg-surface-0 data-[state=active]:text-ink data-[state=active]:shadow-[inset_0_-2px_0_0_var(--color-brand)]',
+  'hover:text-ink',
+)
+
+function CopyButton({ text, className }: { text: string; className?: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }, [text])
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={cn(
+        'rounded-md border px-2.5 py-1 text-xs transition-colors',
+        copied
+          ? 'bg-surface-1 text-status-success border-status-success'
+          : 'bg-surface-0 text-ink-muted border-border hover:bg-surface-1 hover:border-border-strong',
+        className,
+      )}
+    >
+      {copied ? 'Copied!' : 'Copy'}
+    </button>
+  )
+}
+
+function SearchableCodeBlock({
+  code,
+  label,
+  language,
+  downloads,
+  testId,
+}: {
+  code: string
+  label?: string
+  language: string
+  downloads: GeneratedArtifact[]
+  testId?: string
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-surface-0">
+      <div className="shrink-0 flex items-center justify-between gap-3 border-b border-border bg-surface-0/95 px-3 py-2 backdrop-blur-sm">
+        <div className="min-w-0 text-xs text-ink-muted">
+          {label ? <span className="truncate">{label}</span> : <span>All generated code</span>}
+        </div>
+        <div className="flex items-center gap-2">
+          <DownloadButtons downloads={downloads} />
+          <CopyButton text={code} />
+        </div>
+      </div>
+      <div className="relative min-h-0 flex-1">
+        <CodeOutput code={code} language={language} testId="generated-output-highlighted-all-code" />
+        <pre
+          className="pointer-events-none absolute inset-0 overflow-hidden opacity-0"
+          data-testid={testId}
+          aria-hidden="true"
+        >
+          {code}
+        </pre>
+      </div>
     </div>
   )
 }
@@ -36,11 +111,14 @@ export function GeneratedOutputView({
   iframeUrl,
   language,
   downloads,
+  files,
 }: GeneratedOutputViewProps) {
   if (kind === 'iframe' && iframeUrl) {
     return (
       <div className="h-full flex flex-col">
-        <DownloadLinks downloads={downloads} />
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-surface-1/60 shrink-0">
+          <DownloadButtons downloads={downloads} />
+        </div>
         <iframe
           src={iframeUrl}
           title="Generated output"
@@ -54,7 +132,9 @@ export function GeneratedOutputView({
   if (kind === 'html') {
     return (
       <div className="h-full flex flex-col">
-        <DownloadLinks downloads={downloads} />
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-surface-1/60 shrink-0">
+          <DownloadButtons downloads={downloads} />
+        </div>
         <iframe
           srcDoc={html}
           title="Generated HTML output"
@@ -65,12 +145,69 @@ export function GeneratedOutputView({
     )
   }
 
+  const hasSplitFiles = files.length > 1
+
   return (
     <div className="h-full flex flex-col">
-      <DownloadLinks downloads={downloads} />
-      <div className="flex-1 min-h-0">
-        <CodeOutput code={code} language={language} />
-      </div>
+      {hasSplitFiles ? (
+        <Tabs defaultValue="all-code" className="flex-1 min-h-0 gap-0">
+          <div className="shrink-0 overflow-x-auto border-b border-border bg-surface-1/60 px-3 py-1">
+            <TabsList variant="line" className="h-7 min-w-full justify-start gap-1 rounded-none bg-transparent p-0">
+              <TabsTrigger
+                value="all-code"
+                className={generatedTabTriggerClassName}
+                data-testid="generated-output-tab-all-code"
+              >
+                All code
+              </TabsTrigger>
+              {files.map((file) => (
+                <TabsTrigger
+                  key={file.path}
+                  value={file.path}
+                  className={cn(generatedTabTriggerClassName, 'max-w-[16rem] truncate')}
+                  title={file.path}
+                  data-testid={`generated-output-tab-${file.name}`}
+                >
+                  {file.name}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </div>
+
+          <TabsContent value="all-code" className="flex-1 min-h-0 mt-0 outline-none">
+            <SearchableCodeBlock
+              code={code}
+              language={language}
+              downloads={downloads}
+              testId="generated-output-all-code"
+            />
+          </TabsContent>
+
+          {files.map((file) => (
+            <TabsContent key={file.path} value={file.path} className="flex-1 min-h-0 mt-0 outline-none">
+              <div className="flex h-full min-h-0 flex-col">
+                <div className="flex items-center justify-between gap-3 border-b border-border bg-surface-0 px-3 py-2">
+                  <div className="min-w-0 truncate text-xs text-ink-muted">{file.path}</div>
+                  <div className="flex items-center gap-2">
+                    <DownloadButtons downloads={downloads} />
+                    <CopyButton text={file.content} />
+                  </div>
+                </div>
+                <div className="flex-1 min-h-0">
+                  <CodeOutput code={file.content} language={language} />
+                </div>
+              </div>
+            </TabsContent>
+          ))}
+        </Tabs>
+      ) : (
+        <SearchableCodeBlock
+          code={code}
+          language={language}
+          downloads={downloads}
+          testId="generated-output-all-code"
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/generation/__tests__/GeneratedOutputView.test.tsx
+++ b/frontend/src/components/generation/__tests__/GeneratedOutputView.test.tsx
@@ -1,11 +1,16 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { GeneratedOutputView } from '../GeneratedOutputView'
 
 vi.mock('../CodeOutput', () => ({
-  CodeOutput: () => <div data-testid="code-output" />,
+  CodeOutput: ({ code, testId = 'code-output' }: { code: string; testId?: string }) => <div data-testid={testId}>{code}</div>,
 }))
+
+afterEach(() => {
+  cleanup()
+})
 
 describe('GeneratedOutputView', () => {
   it('allows scripts for iframe output', () => {
@@ -17,6 +22,7 @@ describe('GeneratedOutputView', () => {
         iframeUrl="/api/generated/tmp123/javadoc/index.html"
         language="Java"
         downloads={[]}
+        files={[]}
       />
     )
 
@@ -32,9 +38,65 @@ describe('GeneratedOutputView', () => {
         iframeUrl={null}
         language="Yuml"
         downloads={[]}
+        files={[]}
       />
     )
 
     expect(screen.getByTitle('Generated HTML output').getAttribute('sandbox')).toBe('')
+  })
+
+  it('renders text output in a searchable pre block by default', () => {
+    render(
+      <GeneratedOutputView
+        kind="text"
+        code={'public class Invoice {}\npublic class Customer {}'}
+        html=""
+        iframeUrl={null}
+        language="Java"
+        downloads={[]}
+        files={[]}
+      />
+    )
+
+    const allCode = screen.getByTestId('generated-output-all-code')
+    expect(allCode.tagName).toBe('PRE')
+    expect(allCode.textContent).toContain('public class Invoice {}')
+    expect(screen.getByTestId('generated-output-highlighted-all-code').textContent).toContain('public class Customer {}')
+    expect(screen.queryByTestId('code-output')).toBeNull()
+  })
+
+  it('shows an all-code tab first and lets users switch to generated files', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <GeneratedOutputView
+        kind="text"
+        code={'public class Invoice {}\npublic class Customer {}'}
+        html=""
+        iframeUrl={null}
+        language="Java"
+        downloads={[]}
+        files={[
+          {
+            name: 'Invoice.java',
+            path: 'billing/Invoice.java',
+            content: 'public class Invoice {}',
+          },
+          {
+            name: 'Customer.java',
+            path: 'billing/Customer.java',
+            content: 'public class Customer {}',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('tab', { name: 'All code' }).getAttribute('data-state')).toBe('active')
+    expect(screen.getAllByTestId('generated-output-all-code').length).toBeGreaterThan(0)
+
+    await user.click(screen.getByRole('tab', { name: 'Customer.java' }))
+
+    expect(screen.getByRole('tab', { name: 'Customer.java' }).getAttribute('data-state')).toBe('active')
+    expect(screen.getByTestId('code-output').textContent).toContain('public class Customer {}')
   })
 })

--- a/frontend/src/hooks/useCompiler.ts
+++ b/frontend/src/hooks/useCompiler.ts
@@ -229,6 +229,7 @@ export async function generateAndRefresh(
           html: res.generatedHtml,
           iframeUrl: res.generatedIframeUrl,
           downloads: res.generatedDownloads,
+          files: res.generatedFiles,
           modelId: res.modelId,
         }, target.id, sourceSnapshot)
         setRightPanelView('generated')

--- a/frontend/src/stores/ephemeralStore.ts
+++ b/frontend/src/stores/ephemeralStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import type { DiffPreviewState } from '@/ai/editPreview'
-import type { GenerateResponse, GeneratedArtifact } from '../api/types'
+import type { GenerateResponse, GeneratedArtifact, GeneratedCodeFile } from '../api/types'
 import { useSessionStore } from './sessionStore'
 import { usePreferencesStore } from './preferencesStore'
 
@@ -104,6 +104,7 @@ interface EphemeralState {
   generatedKind: 'text' | 'html' | 'iframe'
   generatedIframeUrl: string | null
   generatedDownloads: GeneratedArtifact[]
+  generatedFiles: GeneratedCodeFile[]
   generatedTargetId: string
   generatedLanguage: string
   generatedSourceCode: string | null
@@ -221,6 +222,7 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
   generatedKind: 'text',
   generatedIframeUrl: null,
   generatedDownloads: [],
+  generatedFiles: [],
   generatedTargetId: 'Java',
   generatedLanguage: 'Java',
   generatedSourceCode: null,
@@ -307,6 +309,7 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
       generatedKind: result.kind ?? (result.iframeUrl ? 'iframe' : result.html ? 'html' : 'text'),
       generatedIframeUrl: result.iframeUrl ?? null,
       generatedDownloads: result.downloads ?? [],
+      generatedFiles: result.files ?? [],
       generatedTargetId,
       generatedLanguage: result.language,
       generatedSourceCode: source.code,
@@ -338,6 +341,7 @@ export const useEphemeralStore = create<EphemeralState>((set, get) => ({
     generatedKind: 'text',
     generatedIframeUrl: null,
     generatedDownloads: [],
+    generatedFiles: [],
     generatedSourceCode: null,
     generatedSourceTabId: null,
     generatedSourceSignature: null,

--- a/frontend/tests/e2e/generation.spec.ts
+++ b/frontend/tests/e2e/generation.spec.ts
@@ -88,9 +88,45 @@ async function installGenerationRoutes(page: Page, requests: GenerationRequest[]
         json: {
           modelId: 'playwright-model',
           result: JSON.stringify(classModel),
-          generatedOutput: `public class ${className} {\n  public String getNumber() { return number; }\n}`,
+          generatedOutput: [
+            `package billing;`,
+            '',
+            `public class ${className} {`,
+            '  public String getNumber() { return number; }',
+            '}',
+            '',
+            'package billing;',
+            '',
+            'public class CustomerGenerated {',
+            '  public String getName() { return name; }',
+            '}',
+          ].join('\n'),
           generatedLanguage: 'Java',
           generatedKind: 'text',
+          generatedFiles: [
+            {
+              name: `${className}.java`,
+              path: `billing/${className}.java`,
+              content: [
+                'package billing;',
+                '',
+                `public class ${className} {`,
+                '  public String getNumber() { return number; }',
+                '}',
+              ].join('\n'),
+            },
+            {
+              name: 'CustomerGenerated.java',
+              path: 'billing/CustomerGenerated.java',
+              content: [
+                'package billing;',
+                '',
+                'public class CustomerGenerated {',
+                '  public String getName() { return name; }',
+                '}',
+              ].join('\n'),
+            },
+          ],
         },
       })
       return
@@ -183,6 +219,26 @@ test.describe('Generation UI', () => {
     await expect
       .poll(() => getLastRequest(requests)?.language ?? null)
       .toBe(null)
+  })
+
+  test('keeps all generated code visible by default and offers per-file tabs', async ({ page }) => {
+    const requests: GenerationRequest[] = []
+    await addPreferencesInitScript(page, { dynamicGeneration: false })
+    await installGenerationRoutes(page, requests)
+
+    await page.goto('/')
+    await expect(page.getByTestId('app-shell')).toBeVisible()
+
+    await setEditorCode(page, 'class Invoice { number; }\nclass Customer { name; }')
+    await chooseGenerateTarget(page, 'Java')
+
+    await expect(page.getByTestId('generated-output-all-code')).toContainText('public class InvoiceGenerated')
+    await expect(page.getByTestId('generated-output-all-code')).toContainText('public class CustomerGenerated')
+    await expect(page.getByRole('tab', { name: 'All code' })).toHaveAttribute('data-state', 'active')
+
+    await page.getByRole('tab', { name: 'CustomerGenerated.java' }).click()
+
+    await expect(page.getByTestId('code-output')).toContainText('public class CustomerGenerated')
   })
 
   test('refetches class diagrams with legacy filter fields and keeps the renderer toggle working', async ({
@@ -333,7 +389,10 @@ test.describe('Generation UI', () => {
     await setEditorCode(page, 'class Invoice { number; }')
     await chooseGenerateTarget(page, 'Java')
 
-    await expect(page.getByText('InvoiceGenerated')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('generated-output-highlighted-all-code')).toContainText(
+      'InvoiceGenerated',
+      { timeout: 10_000 },
+    )
     await expect(page.getByTestId('regenerate-button')).toBeVisible()
     await expect(page.getByTestId('generated-output-stale-overlay')).toHaveCount(0)
     expect(getLastRequest(requests)?.language).toBe('Java')
@@ -342,7 +401,9 @@ test.describe('Generation UI', () => {
 
     await expect(page.getByTestId('generated-output-stale-overlay')).toBeVisible()
     expect(requests).toHaveLength(1)
-    await expect(page.getByText('InvoiceGenerated')).toBeVisible()
+    await expect(page.getByTestId('generated-output-highlighted-all-code')).toContainText(
+      'InvoiceGenerated',
+    )
 
     const regenerateResponse = page.waitForResponse(
       (response) =>
@@ -353,9 +414,10 @@ test.describe('Generation UI', () => {
 
     expect(requests).toHaveLength(2)
     expect(getLastRequest(requests)?.language).toBe('Java')
-    await expect(page.getByText('UpdatedInvoiceGenerated')).toBeVisible({
-      timeout: 10_000,
-    })
+    await expect(page.getByTestId('generated-output-highlighted-all-code')).toContainText(
+      'UpdatedInvoiceGenerated',
+      { timeout: 10_000 },
+    )
     await expect(page.getByTestId('generated-output-stale-overlay')).toHaveCount(0)
   })
 
@@ -372,14 +434,19 @@ test.describe('Generation UI', () => {
     await setEditorCode(page, 'class Invoice { number; }')
     await chooseGenerateTarget(page, 'Java')
 
-    await expect(page.getByText('InvoiceGenerated')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('generated-output-highlighted-all-code')).toContainText(
+      'InvoiceGenerated',
+      { timeout: 10_000 },
+    )
     expect(getLastRequest(requests)?.language).toBe('Java')
 
     await chooseToolbarGenerateTarget(page, 'State Diagram', 'State Diagram (GraphViz SVG)')
     await page.waitForTimeout(300)
 
     expect(requests).toHaveLength(1)
-    await expect(page.getByText('InvoiceGenerated')).toBeVisible()
+    await expect(page.getByTestId('generated-output-highlighted-all-code')).toContainText(
+      'InvoiceGenerated',
+    )
     await expect(page.getByTestId('generated-output-stale-overlay')).toBeVisible()
 
     const regenerateResponse = page.waitForResponse(
@@ -422,7 +489,10 @@ test.describe('Generation UI', () => {
 
     expect(requests).toHaveLength(1)
     expect(getLastRequest(requests)?.language).toBe('Java')
-    await expect(page.getByText('InvoiceGenerated')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('generated-output-highlighted-all-code')).toContainText(
+      'InvoiceGenerated',
+      { timeout: 10_000 },
+    )
   })
 
   test('greys stale diagrams until manual regenerate when dynamic generation is off', async ({


### PR DESCRIPTION
## Summary
- return structured generated files from the backend and store them with generated output state
- keep generated code visible by default with an all-code tab plus per-file tabs and copy actions
- render verifyCode tool results in a structured card with issue links and editor jumps
- Refs #93

## Test plan
- `cd frontend && bun run test src/components/generation/__tests__/GeneratedOutputView.test.tsx src/components/agent/__tests__/AgentPanel.test.tsx src/components/diagram/__tests__/DiagramPanel.test.tsx`
- `cd frontend && bun run test:e2e tests/e2e/generation.spec.ts`
- backend Go package test could not run in this shell because `go` is not installed locally