### PR TITLE
fix(config): parameterize service ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,19 @@
-# Backend
-PORT=3001
+# Normal production bootstrap:
+# - Create this file on the server
+# - Set ALLOWED_ORIGINS to your public site URL
+# - Leave the rest at their defaults unless you need custom ports or image refs
+
+# Optional service port overrides
+# Service ports
+BACKEND_PORT=3001
+COLLAB_PORT=3002
+LSP_PORT=9999
 UMPLE_SYNC_JAR=/jars/umplesync.jar
 UMPLE_PORT=5555
 MODEL_STORE_PATH=/data/models
 EXAMPLE_PATH=/examples
-EXECUTION_URL=http://code-exec:4400
+# Default code-exec port for this rewrite. Legacy UmpleCodeExecution uses 4400.
+CODE_EXEC_PORT=4401
 
 # CORS (comma-separated origins for production)
 ALLOWED_ORIGINS=https://your-domain.example.com

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.bat text eol=crlf

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ This project reproduces the legacy PHP/jQuery stack with a contemporary architec
 
 **Live instance:** [umpleonline.org](https://umpleonline.org/)
 
+## How This Differs From The Original
+
+- The original UmpleOnline in the legacy `umple` repo is a PHP/jQuery application; this repo splits the app into a React/Vite frontend, a Go API, and a Node-based code execution service.
+- Local development is container-first: `make dev` brings up the backend services and the frontend hot-reload server, instead of the older mixed script-based setup.
+- The `code-exec` service defaults to port `4401`, while the legacy `UmpleCodeExecution` service defaults to `4400`, so both stacks can run on the same machine without a port collision.
+- Backend, collab, LSP, and code-exec ports can all be remapped from the repo root `.env` when you need to run multiple local stacks side by side.
+- This repo is forward-only. We keep the same compiler capabilities, but we are not preserving the old stack's implementation details or setup flow.
+
 ## Architecture
 
 ```
@@ -26,7 +34,7 @@ This project reproduces the legacy PHP/jQuery stack with a contemporary architec
 └────────────┬────────────────┘
              │
 ┌────────────▼────────────────┐
-│   Code Exec (Node.js)       │  Port 4400
+│   Code Exec (Node.js)       │  Port 4401
 │   Sandboxed code runner     │
 └─────────────────────────────┘
 ```

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -24,10 +25,18 @@ func Load() *Config {
 		UmplePort:      getEnvInt("UMPLE_PORT", 5555),
 		ModelStorePath: getEnv("MODEL_STORE_PATH", "/data/models"),
 		ExamplePath:    getEnv("EXAMPLE_PATH", "/examples"),
-		ExecutionURL:   getEnv("EXECUTION_URL", "http://code-exec:4400"),
+		ExecutionURL:   getExecutionURL(),
 		TaskStorePath:  getEnv("TASK_STORE_PATH", "/data/models/tasks"),
 		AllowedOrigins: getOrigins("ALLOWED_ORIGINS", []string{"http://localhost:3100"}),
 	}
+}
+
+func getExecutionURL() string {
+	if v := os.Getenv("EXECUTION_URL"); v != "" {
+		return v
+	}
+
+	return fmt.Sprintf("http://code-exec:%d", getEnvInt("CODE_EXEC_PORT", 4401))
 }
 
 func getOrigins(key string, fallback []string) []string {

--- a/code-exec/Dockerfile
+++ b/code-exec/Dockerfile
@@ -1,5 +1,5 @@
 # This dockerfile sets up an image to run node.js, which will
-# act as a server on port 4400 to prepare to execute code
+# act as a server on port 4401 by default to prepare to execute code
 # The actual execution of the code is done in a docker-in-docker within this
 # For that, see the Dockerfile in the javarunner directory
 FROM alpine:3.22
@@ -18,7 +18,9 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-EXPOSE 4400
+ENV PORT=4401
+
+EXPOSE 4401
 
 RUN chown -R nodeuser:nodeuser /usr/src/app
 RUN chown -R nodeuser:nodeuser /home

--- a/code-exec/README.md
+++ b/code-exec/README.md
@@ -1,52 +1,52 @@
 # Umple Code Execution
 
-This code base provides the functionality to securely execute generated Java and Python code using Docker containers.
+This service runs generated Java and Python code inside short-lived Docker runner containers. In this repo it is the `code-exec` service that the Go backend calls when a user clicks Run.
 
-# IMPORTANT
+## How This Differs From The Legacy Service
 
-If you development the project on Windows, MUST set eof to LF
+- The legacy repo's `UmpleCodeExecution` defaulted to port `4400`.
+- This rewrite defaults to port `4401` so you can run both side by side on the same machine while testing.
+- The modern repo uses Docker Compose and environment variables for wiring instead of the old `setup.sh` / `setup.bat` flow.
+- Production should set `EXECUTION_RUNNER_IMAGE` to an immutable published runner image and keep `EXECUTION_RUNNER_AUTO_BUILD=0`.
 
-# Setup
+## Local Configuration
 
-1. Create config.cfg file from config.cfg.template with correct parameters (Explained below).
-2. Run ./setup.sh (run setup.bat on cmd prompt on windows)
-3. (Optional) Run the following command to compile and use latest Javascript changes if haven't done yet.  
-   **ant -DshouldPackageUmpleOnline=true -Dmyenv=wlocal -f build.umple.xml packageUmpleonline**
-
-# Config.cfg
+The committed [`config.cfg`](./config.cfg) file is used when you run the service outside Docker Compose.
 
 **umplePath**  
-Path to the Umple's ump folder where temporary user folders are created. The full path to umpleonline/ump
+Path to the model storage directory. In this repo's containerized setup that is `/data/models`.
 
 **tempPath**  
-A directory where temporary files can be written. Suggested: /tmp
+Directory where temporary execution artifacts can be written. Suggested: `/tmp`
 
 **mainContainerName**  
-Name of the always running container and image. Use the default unless you are running more than one instance.
+Legacy field kept for compatibility with the config format. The current service no longer launches a long-running execution container with this name.
 
 **tempContainerName**  
 Default local runner image used for code execution in development. Production should prefer the `EXECUTION_RUNNER_IMAGE` environment variable so deploys can pin an immutable published runner image.
 
 **portToUse**  
-Port that the Umple Php code uses to communicate with the Docker image. Suggested: 4400. If you are running more than one instance, then each would need a new port.
+Port used when the service is started directly from `config.cfg`. Default: `4401`
 
 **timeoutValue**  
-How many seconds execution will run before the execution is ended. Default 20, but reduce if the server resources are limited.
+How many seconds execution will run before it is ended. Default: `20`
 
-# Setup.sh or setup.bat
+## Docker Compose Defaults
 
-This shell script contains commands to build docker images and to run the main docker container. The server will start at the following url by default.  
-**http:localhost:4400**
+For normal development, use the repo root commands:
 
-# Other Issues
+```bash
+make dev
+```
 
-1. If timeout is coming even though the docker is running, make sure that umplePath in config.cfg does not start with '~'.
+That starts `code-exec` through Docker Compose, passes `PORT=${CODE_EXEC_PORT:-4401}`, and points the backend at `http://code-exec:${CODE_EXEC_PORT:-4401}`.
 
-## Production note
+If you need a different port, set `CODE_EXEC_PORT` in the repo root `.env` before starting Compose.
 
-In this repo's containerized deployment, the `code-exec` service is the coordinator and launches a separate runner image for each execution. Production should set:
+## Windows Line Endings
 
-- `EXECUTION_RUNNER_IMAGE` to a published immutable image ref
-- `EXECUTION_RUNNER_AUTO_BUILD=0`
+This repo expects LF line endings for checked-in text files and shell scripts. The repo root [`.gitattributes`](../.gitattributes) enforces that.
 
-Development may keep auto-build enabled to create the local runner image on first use.
+## Other Issues
+
+If timeouts happen even though Docker is running, make sure `umplePath` in `config.cfg` does not start with `~`.

--- a/code-exec/app.js
+++ b/code-exec/app.js
@@ -10,7 +10,50 @@ app.use(bodyParser.urlencoded({ extended: false }))
 app.use(bodyParser.json())
 
 const server = http.createServer(app);
-const port=4400;
+const DEFAULT_PORT = 4401;
+
+function readConfig() {
+    try {
+        const file = fs.readFileSync(path.join(__dirname, 'config.cfg'), 'utf8');
+        const config = file.toString().replace(/\r\n/g, '\n').split('\n');
+        const obj = {};
+
+        for(const line of config) {
+            if(!line || line.startsWith('#')) {
+                continue;
+            }
+
+            const separatorIndex = line.indexOf('=');
+            if(separatorIndex === -1) {
+                continue;
+            }
+
+            const key = line.slice(0, separatorIndex).trim();
+            const value = line.slice(separatorIndex + 1).trim();
+            if(key) {
+                obj[key] = value;
+            }
+        }
+
+        return obj;
+    } catch (err) {
+        console.warn(`Unable to read config.cfg: ${err.message}`);
+        return {};
+    }
+}
+
+function resolvePort() {
+    const config = readConfig();
+    const configuredPort = Number(process.env.PORT || process.env.CODE_EXEC_PORT || config['portToUse']);
+
+    if(Number.isInteger(configuredPort) && configuredPort > 0) {
+        return configuredPort;
+    }
+
+    return DEFAULT_PORT;
+}
+
+const port = resolvePort();
 
 // Declare max requests
 const MAX_REQUESTS = 20;
@@ -181,5 +224,4 @@ const canProceed = (callback) => {
 server.listen(port, () => {
     console.log("Listening at "+port)
 });
-
 

--- a/code-exec/config.cfg
+++ b/code-exec/config.cfg
@@ -2,5 +2,5 @@ umplePath=/data/models
 tempPath=/tmp
 mainContainerName=code_execution
 tempContainerName=umple-code-runner:dev
-portToUse=4400
+portToUse=4401
 timeoutValue=20

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,15 +17,15 @@ services:
       - UMPLE_SYNC_JAR=/jars/umplesync.jar
       - MODEL_STORE_PATH=/data/models
       - EXAMPLE_PATH=/examples
-      - EXECUTION_URL=http://code-exec:4400
-      - PORT=3001
+      - CODE_EXEC_PORT=${CODE_EXEC_PORT:-4401}
+      - PORT=${BACKEND_PORT:-3001}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
     depends_on:
       code-exec:
         condition: service_healthy
     healthcheck:
       test:
-        ["CMD", "wget", "--spider", "-q", "http://localhost:3001/api/health"]
+        ["CMD", "wget", "--spider", "-q", "http://localhost:${BACKEND_PORT:-3001}/api/health"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -40,9 +40,9 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      - PORT=3002
+      - PORT=${COLLAB_PORT:-3002}
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3002/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:${COLLAB_PORT:-3002}/health"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -56,6 +56,10 @@ services:
     pids_limit: 128
     security_opt:
       - no-new-privileges:true
+    environment:
+      - BACKEND_PORT=${BACKEND_PORT:-3001}
+      - COLLAB_PORT=${COLLAB_PORT:-3002}
+      - LSP_PORT=${LSP_PORT:-9999}
     ports:
       - "${FRONTEND_BIND_HOST:-127.0.0.1}:${FRONTEND_HOST_PORT:-3100}:80"
     depends_on:
@@ -84,14 +88,14 @@ services:
     environment:
       - UMP_BASE_DIR=/data/models
       - UMPLESYNC_JAR_PATH=/jars/umplesync.jar
-      - LSP_PORT=9999
+      - LSP_PORT=${LSP_PORT:-9999}
     healthcheck:
       test:
         [
           "CMD",
           "node",
           "-e",
-          "const W=require('ws'),c=new W('ws://127.0.0.1:9999');c.on('open',()=>{c.close();process.exit(0)});c.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),4000)",
+          "const W=require('ws'),c=new W('ws://127.0.0.1:${LSP_PORT:-9999}');c.on('open',()=>{c.close();process.exit(0)});c.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),4000)",
         ]
       interval: 30s
       timeout: 5s
@@ -112,10 +116,11 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./data/models:/data/models
     environment:
+      - PORT=${CODE_EXEC_PORT:-4401}
       - EXECUTION_RUNNER_IMAGE=${CODE_RUNNER_IMAGE:-ghcr.io/umple/umpleonline/code-runner:latest}
       - EXECUTION_RUNNER_AUTO_BUILD=0
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:4400/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:${CODE_EXEC_PORT:-4401}/health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile.dev
     ports:
-      - "3001:3001"
+      - "${BACKEND_PORT:-3001}:${BACKEND_PORT:-3001}"
     volumes:
       - ./backend:/app
       - ./data/models:/data/models
@@ -18,8 +18,8 @@ services:
       - UMPLE_SYNC_JAR=/jars/umplesync.jar
       - MODEL_STORE_PATH=/data/models
       - EXAMPLE_PATH=/examples
-      - EXECUTION_URL=http://code-exec:4400
-      - PORT=3001
+      - CODE_EXEC_PORT=${CODE_EXEC_PORT:-4401}
+      - PORT=${BACKEND_PORT:-3001}
     depends_on:
       code-exec:
         condition: service_healthy
@@ -29,14 +29,14 @@ services:
       context: ./collab
       dockerfile: Dockerfile.dev
     ports:
-      - "3002:3002"
+      - "${COLLAB_PORT:-3002}:${COLLAB_PORT:-3002}"
     volumes:
       - ./collab:/app
       - /app/node_modules
     environment:
-      - PORT=3002
+      - PORT=${COLLAB_PORT:-3002}
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3002/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:${COLLAB_PORT:-3002}/health"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -49,21 +49,21 @@ services:
       args:
         UMPLE_LSP_VERSION: ${UMPLE_LSP_VERSION:-latest}
     ports:
-      - "9999:9999"
+      - "${LSP_PORT:-9999}:${LSP_PORT:-9999}"
     volumes:
       - ./data/models:/data/models
       - ./jars:/jars:ro
     environment:
       - UMP_BASE_DIR=/data/models
       - UMPLESYNC_JAR_PATH=/jars/umplesync.jar
-      - LSP_PORT=9999
+      - LSP_PORT=${LSP_PORT:-9999}
     healthcheck:
       test:
         [
           "CMD",
           "node",
           "-e",
-          "const W=require('ws'),c=new W('ws://127.0.0.1:9999');c.on('open',()=>{c.close();process.exit(0)});c.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),4000)",
+          "const W=require('ws'),c=new W('ws://127.0.0.1:${LSP_PORT:-9999}');c.on('open',()=>{c.close();process.exit(0)});c.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),4000)",
         ]
       interval: 30s
       timeout: 5s
@@ -74,8 +74,9 @@ services:
     build:
       context: ./code-exec
     ports:
-      - "4400:4400"
+      - "${CODE_EXEC_PORT:-4401}:${CODE_EXEC_PORT:-4401}"
     environment:
+      - PORT=${CODE_EXEC_PORT:-4401}
       - EXECUTION_RUNNER_IMAGE=${CODE_RUNNER_IMAGE:-umple-code-runner:dev}
       - EXECUTION_RUNNER_AUTO_BUILD=1
     group_add:
@@ -84,7 +85,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./data/models:/data/models
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:4400/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:${CODE_EXEC_PORT:-4401}/health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,3 +2,9 @@
 # Only needed when accessing the dev server via a reverse proxy.
 # Example: VITE_ALLOWED_HOSTS=.example.umple.org
 # VITE_ALLOWED_HOSTS=
+
+# Optional local proxy port overrides.
+# By default Vite reads BACKEND_PORT, COLLAB_PORT, and LSP_PORT from the repo root .env.
+# BACKEND_PORT=3001
+# COLLAB_PORT=3002
+# LSP_PORT=9999

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,6 @@ RUN bun run build
 FROM nginx:1.29.6-alpine
 RUN apk upgrade --no-cache
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -12,7 +12,7 @@ server {
 
     # Proxy WebSocket connections to the collab service
     location /ws/collab/ {
-        proxy_pass http://collab:3002;
+        proxy_pass http://collab:${COLLAB_PORT};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -26,7 +26,7 @@ server {
     # Proxy WebSocket connections to the LSP proxy
     location /ws/lsp {
         rewrite ^/ws/lsp(.*) /$1 break;
-        proxy_pass http://lsp-proxy:9999;
+        proxy_pass http://lsp-proxy:${LSP_PORT};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -39,7 +39,7 @@ server {
 
     # Proxy API requests to the Go backend
     location /api/ {
-        proxy_pass http://backend:3001;
+        proxy_pass http://backend:${BACKEND_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,11 +5,23 @@ import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig(({ mode }) => {
 // VITE_ALLOWED_HOSTS: comma-separated hostnames or patterns (e.g. ".umple.org")
-// Defaults to localhost only. Set in frontend/.env for dev behind a reverse proxy.
-const env = loadEnv(mode, __dirname, 'VITE_')
+// Defaults to localhost only. Root .env controls service ports; frontend/.env can override them.
+const env = {
+  ...loadEnv(mode, path.resolve(__dirname, '..'), ''),
+  ...loadEnv(mode, __dirname, ''),
+}
 const allowedHosts = env.VITE_ALLOWED_HOSTS
   ? ['localhost', ...env.VITE_ALLOWED_HOSTS.split(',').map(h => h.trim()).filter(Boolean)]
   : ['localhost']
+
+function readPort(value: string | undefined, fallback: number) {
+  const port = Number(value)
+  return Number.isInteger(port) && port > 0 ? port : fallback
+}
+
+const backendPort = readPort(env.BACKEND_PORT, 3001)
+const collabPort = readPort(env.COLLAB_PORT, 3002)
+const lspPort = readPort(env.LSP_PORT, 9999)
 
 return {
   plugins: [tailwindcss(), react()],
@@ -33,15 +45,15 @@ return {
     allowedHosts,
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: `http://localhost:${backendPort}`,
         changeOrigin: true,
       },
       '/ws/collab': {
-        target: 'ws://localhost:3002',
+        target: `ws://localhost:${collabPort}`,
         ws: true,
       },
       '/ws/lsp': {
-        target: 'ws://localhost:9999',
+        target: `ws://localhost:${lspPort}`,
         ws: true,
         rewrite: (path) => path.replace(/^\/ws\/lsp/, ''),
       },

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -99,7 +99,7 @@ wait_for_backend() {
 
   echo "==> Waiting for backend readiness..."
   for i in $(seq 1 "$attempts"); do
-    if compose -f docker-compose.prod.yml exec -T backend wget -q --spider http://localhost:3001/api/health 2>/dev/null; then
+    if compose -f docker-compose.prod.yml exec -T backend wget -q --spider "http://localhost:${BACKEND_PORT}/api/health" 2>/dev/null; then
       echo "Backend ready."
       return 0
     fi
@@ -180,6 +180,8 @@ FRONTEND_BIND_HOST="$(read_env_value "FRONTEND_BIND_HOST" .env || true)"
 FRONTEND_BIND_HOST="${FRONTEND_BIND_HOST:-127.0.0.1}"
 FRONTEND_HOST_PORT="$(read_env_value "FRONTEND_HOST_PORT" .env || true)"
 FRONTEND_HOST_PORT="${FRONTEND_HOST_PORT:-3100}"
+BACKEND_PORT="$(read_env_value "BACKEND_PORT" .env || true)"
+BACKEND_PORT="${BACKEND_PORT:-3001}"
 
 FRONTEND_CHECK_HOST="$FRONTEND_BIND_HOST"
 if [ "$FRONTEND_CHECK_HOST" = "0.0.0.0" ]; then
@@ -212,6 +214,7 @@ echo "    CODE_RUNNER_IMAGE=$CODE_RUNNER_IMAGE"
 echo "    COLLAB_IMAGE=$COLLAB_IMAGE"
 echo "    LSP_PROXY_IMAGE=$LSP_PROXY_IMAGE"
 echo "    DOCKER_GID=$DOCKER_GID"
+echo "    BACKEND_PORT=$BACKEND_PORT"
 echo "    FRONTEND_BIND_HOST=$FRONTEND_BIND_HOST"
 echo "    FRONTEND_HOST_PORT=$FRONTEND_HOST_PORT"
 


### PR DESCRIPTION
## Summary
- parameterize backend, collab, lsp, and code-exec ports through the root env/compose setup
- make code-exec honor its configured port and avoid the legacy 4400 conflict by defaulting this rewrite to 4401
- simplify the contributor and env docs around defaults, docker usage, and line ending expectations

## Test plan
- cd frontend && bun run build
- docker-compose -f docker-compose.yml config
- ALLOWED_ORIGINS=http://localhost docker-compose -f docker-compose.prod.yml config