### PR TITLE
Fix state transition editor selection

### DIFF
--- a/frontend/src/components/diagram/SmartSvgView.tsx
+++ b/frontend/src/components/diagram/SmartSvgView.tsx
@@ -509,6 +509,7 @@ const SmartSvgViewInner = ({ svg, viewMode }: SmartSvgViewProps) => {
           detail: {
             name: interactionTarget.rawId,
             kind: interactionTarget.kind,
+            anchorTitle: interactionTarget.anchorTitle,
           },
         }))
       } else {

--- a/frontend/src/components/diagram/__tests__/SmartSvgView.state.test.tsx
+++ b/frontend/src/components/diagram/__tests__/SmartSvgView.state.test.tsx
@@ -50,10 +50,16 @@ const STATE_SVG = `
     </g>
     <g class="edge">
       <title>Phone_screenLight_On->Phone_screenLight_Off</title>
-      <a xlink:title="From On to Off on hangUp">
-        <path d="M120,34 C120,60 60,60 40,34"></path>
-      </a>
-      <text x="86" y="58">hangUp</text>
+      <g id="a_edge1">
+        <a xlink:title="From On to Off on hangUp">
+          <path d="M120,34 C120,60 60,60 40,34"></path>
+        </a>
+      </g>
+      <g id="a_edge1-label">
+        <a xlink:title="From On to Off on hangUp">
+          <text x="86" y="58">hangUp</text>
+        </a>
+      </g>
     </g>
   </svg>
 `
@@ -117,6 +123,31 @@ afterEach(() => {
 })
 
 describe('SmartSvgView state interactions', () => {
+  it('dispatches edge metadata when clicking a transition label', () => {
+    const events: Array<CustomEvent<{ name: string; kind: string; anchorTitle?: string | null }>> = []
+    const handler = (event: Event) => {
+      events.push(event as CustomEvent<{ name: string; kind: string; anchorTitle?: string | null }>)
+    }
+    window.addEventListener('umple:diagram-select', handler)
+
+    render(
+      <TooltipProvider>
+        <SmartSvgView svg={STATE_SVG} viewMode="state" />
+      </TooltipProvider>,
+    )
+
+    fireEvent.click(screen.getByText('hangUp'))
+
+    expect(events).toHaveLength(1)
+    expect(events[0].detail).toEqual({
+      name: 'Phone_screenLight_On->Phone_screenLight_Off',
+      kind: 'edge',
+      anchorTitle: 'From On to Off on hangUp',
+    })
+
+    window.removeEventListener('umple:diagram-select', handler)
+  })
+
   it('opens a state node menu and renames the selected state', async () => {
     useSessionStore.setState({
       code: STATE_CODE,

--- a/frontend/src/components/editor/EditorPanel.tsx
+++ b/frontend/src/components/editor/EditorPanel.tsx
@@ -54,12 +54,12 @@ export function EditorPanel() {
   // Uses a native DOM CustomEvent so delivery is synchronous and framework-independent.
   useEffect(() => {
     const handler = (e: Event) => {
-      const { name, kind } = (e as CustomEvent<DiagramSelectDetail>).detail
+      const { name, kind, anchorTitle } = (e as CustomEvent<DiagramSelectDetail>).detail
       const view = editorViewRef.current ?? editorRef.current?.view
       if (!view) return
 
       const doc = view.state.doc.toString()
-      const range = findDiagramRange(doc, { name, kind })
+      const range = findDiagramRange(doc, { name, kind, anchorTitle })
       if (!range) return
 
       view.dispatch({

--- a/frontend/src/components/editor/diagramSelection.test.ts
+++ b/frontend/src/components/editor/diagramSelection.test.ts
@@ -69,6 +69,88 @@ describe('findDiagramRange', () => {
     }`)
   })
 
+  it('matches a multi-line state transition instead of falling back to the source state', () => {
+    const code = `class ItemAtAuction {
+  status {
+    created {
+
+      listitem(double reserve) / {
+        reservePrice = reserve;
+        active = true;
+      }
+      -> listed;
+    }
+
+    listed {
+    }
+  }
+}
+`
+
+    const range = findDiagramRange(code, {
+      name: 'ItemAtAuction_status_created->ItemAtAuction_status_listed',
+      kind: 'edge',
+      anchorTitle: `From created to listed on listitem(double reserve)
+Transition Action:
+    reservePrice = reserve;
+    active = true;`,
+    })
+
+    expect(range).not.toBeNull()
+    expect(code.slice(range!.from, range!.to)).toBe(`      listitem(double reserve) / {
+        reservePrice = reserve;
+        active = true;
+      }
+      -> listed;`)
+  })
+
+  it('matches an automatic transition without falling back to the source state', () => {
+    const code = `class X {
+  sm {
+    s1 {
+      -> s2;
+    }
+
+    s2 {
+    }
+  }
+}
+`
+
+    const range = findDiagramRange(code, {
+      name: 'X_sm_s1->X_sm_s2',
+      kind: 'edge',
+      anchorTitle: 'From s1 to s2 automatically',
+    })
+
+    expect(range).not.toBeNull()
+    expect(code.slice(range!.from, range!.to)).toBe('      -> s2;')
+  })
+
+  it('matches a guarded automatic transition without falling back to the source state', () => {
+    const code = `class X {
+  sm {
+    s1 {
+      [guard] -> s2;
+    }
+
+    s2 {
+    }
+  }
+}
+`
+
+    const range = findDiagramRange(code, {
+      name: 'X_sm_s1->X_sm_s2',
+      kind: 'edge',
+      anchorTitle: `From s1 to s2 automatically
+Guard: [guard]`,
+    })
+
+    expect(range).not.toBeNull()
+    expect(code.slice(range!.from, range!.to)).toBe('      [guard] -> s2;')
+  })
+
   it('still resolves simple instance ids back to their class definitions', () => {
     const code = `class Segment {
   bend;

--- a/frontend/src/components/editor/diagramSelection.ts
+++ b/frontend/src/components/editor/diagramSelection.ts
@@ -1,6 +1,7 @@
 export interface DiagramSelectDetail {
   name: string
   kind: 'node' | 'edge'
+  anchorTitle?: string | null
 }
 
 interface TextRange {
@@ -8,8 +9,20 @@ interface TextRange {
   to: number
 }
 
+interface ParsedStateEdgeSelection {
+  sourceRawId: string
+  targetRawId: string
+  targetLabel: string
+  trigger: string
+  guard: string | null
+}
+
 function escapeForRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim()
 }
 
 function stripNumericInstanceSuffix(value: string): string {
@@ -195,12 +208,177 @@ function findRangeForPath(code: string, path: string[]): TextRange | null {
   return match
 }
 
+function parseStateEdgeSelection(detail: DiagramSelectDetail): ParsedStateEdgeSelection | null {
+  if (detail.kind !== 'edge' || !detail.anchorTitle) return null
+
+  const [sourceRawId = '', targetRawId = ''] = detail.name.split('->')
+  if (!sourceRawId || !targetRawId) return null
+
+  const lines = detail.anchorTitle
+    .split(/[\r\n]+/)
+    .map(normalizeWhitespace)
+    .filter(Boolean)
+
+  const firstLine = lines[0] ?? ''
+  const match = firstLine.match(/^From\s+(.+?)\s+to\s+(.+?)\s+(.+)$/)
+  if (!match) return null
+
+  let trigger = normalizeWhitespace(match[3])
+  if (trigger.startsWith('on ')) trigger = trigger.slice(3).trim()
+  if (trigger === 'automatically') trigger = ''
+
+  const guardLine = lines.find((line) => line.startsWith('Guard:'))
+
+  return {
+    sourceRawId,
+    targetRawId,
+    targetLabel: match[2].trim(),
+    trigger,
+    guard: guardLine ? normalizeWhitespace(guardLine.slice('Guard:'.length)) : null,
+  }
+}
+
+function findTransitionEnd(code: string, from: number): number | null {
+  let braceDepth = 0
+  let quote: '"' | '\'' | '`' | null = null
+  let lineComment = false
+  let blockComment = false
+
+  for (let i = from; i < code.length; i++) {
+    const char = code[i]
+    const next = code[i + 1]
+
+    if (lineComment) {
+      if (char === '\n') lineComment = false
+      continue
+    }
+
+    if (blockComment) {
+      if (char === '*' && next === '/') {
+        blockComment = false
+        i++
+      }
+      continue
+    }
+
+    if (quote) {
+      if (char === '\\') {
+        i++
+        continue
+      }
+      if (char === quote) quote = null
+      continue
+    }
+
+    if (char === '/' && next === '/') {
+      lineComment = true
+      i++
+      continue
+    }
+
+    if (char === '/' && next === '*') {
+      blockComment = true
+      i++
+      continue
+    }
+
+    if (char === '"' || char === '\'' || char === '`') {
+      quote = char
+      continue
+    }
+
+    if (char === '{') {
+      braceDepth++
+      continue
+    }
+
+    if (char === '}') {
+      if (braceDepth > 0) braceDepth--
+      continue
+    }
+
+    if (char === ';' && braceDepth === 0) return i + 1
+  }
+
+  return null
+}
+
+function transitionMatchesCandidate(
+  candidate: string,
+  transition: ParsedStateEdgeSelection,
+  requireGuard: boolean,
+): boolean {
+  const normalized = normalizeWhitespace(candidate)
+  if (!normalized.startsWith(transition.trigger)) return false
+
+  const destinationPattern = new RegExp(`->\\s*${escapeForRegex(transition.targetLabel)}\\s*;`)
+  if (!destinationPattern.test(candidate)) return false
+
+  if (requireGuard && transition.guard && !normalized.includes(transition.guard)) return false
+
+  return true
+}
+
+function findStateTransitionRangeWithin(
+  stateBlock: string,
+  transition: ParsedStateEdgeSelection,
+): TextRange | null {
+  const triggerPattern = transition.trigger.length > 0
+    ? new RegExp(`^[ \\t]*${escapeForRegex(transition.trigger)}(?=[ \\t]|\\[|\\/|\\-|$)`, 'gm')
+    : /^[ \t]*(?=(?:\[[^\n]*\]\s*)?(?:\/|->))/gm
+
+  const matches: TextRange[] = []
+  let match: RegExpExecArray | null
+  while ((match = triggerPattern.exec(stateBlock)) !== null) {
+    const from = match.index
+    const to = findTransitionEnd(stateBlock, from)
+    if (!to) continue
+    matches.push({ from, to })
+  }
+
+  for (const range of matches) {
+    if (transitionMatchesCandidate(stateBlock.slice(range.from, range.to), transition, true)) {
+      return range
+    }
+  }
+
+  for (const range of matches) {
+    if (transitionMatchesCandidate(stateBlock.slice(range.from, range.to), transition, false)) {
+      return range
+    }
+  }
+
+  return null
+}
+
+function findStateEdgeRange(code: string, detail: DiagramSelectDetail): TextRange | null {
+  const parsed = parseStateEdgeSelection(detail)
+  if (!parsed) return null
+
+  const sourceRange = findDiagramRange(code, { name: parsed.sourceRawId, kind: 'node' })
+  if (!sourceRange) return null
+
+  const stateBlock = code.slice(sourceRange.from, sourceRange.to)
+  const localRange = findStateTransitionRangeWithin(stateBlock, parsed)
+  if (!localRange) return null
+
+  return {
+    from: sourceRange.from + localRange.from,
+    to: sourceRange.from + localRange.to,
+  }
+}
+
 export function findDiagramRange(code: string, detail: DiagramSelectDetail): TextRange | null {
   if (detail.kind === 'node') {
     for (const path of getNodeLookupPaths(detail.name)) {
       const range = findRangeForPath(code, path)
       if (range) return range
     }
+  }
+
+  if (detail.kind === 'edge') {
+    const stateEdgeRange = findStateEdgeRange(code, detail)
+    if (stateEdgeRange) return stateEdgeRange
   }
 
   for (const candidate of getLookupCandidates(detail.name, detail.kind)) {


### PR DESCRIPTION
## Summary
- pass SVG anchor metadata through diagram selection events
- map clicked state edges to the matching source transition, including multiline and automatic transitions
- add regression coverage for transition label clicks and edge selection matching

## Test plan
- cd frontend && bun x vitest run src/components/editor/diagramSelection.test.ts
- cd frontend && bun x vitest run src/components/diagram/__tests__/SmartSvgView.state.test.tsx src/components/diagram/svg-adapters/__tests__/stateTransforms.test.ts