### PR TITLE
feat(status): add operational status dashboard

### DIFF
--- a/backend/internal/api/handlers/status.go
+++ b/backend/internal/api/handlers/status.go
@@ -1,0 +1,557 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/umple/umpleonline/backend/internal/compiler"
+	"github.com/umple/umpleonline/backend/internal/config"
+)
+
+type StatusHandler struct {
+	cfg     *config.Config
+	pool    *compiler.Pool
+	client  *http.Client
+	started time.Time
+	mu      sync.Mutex
+
+	sessionsSinceStart int
+}
+
+type statusCounters struct {
+	SessionsStarted int    `json:"sessionsStarted"`
+	UpdatedAt       string `json:"updatedAt,omitempty"`
+}
+
+func NewStatusHandler(cfg *config.Config, pool *compiler.Pool) *StatusHandler {
+	return &StatusHandler{
+		cfg:  cfg,
+		pool: pool,
+		client: &http.Client{
+			Timeout: 2 * time.Second,
+		},
+		started: time.Now(),
+	}
+}
+
+func (h *StatusHandler) Status(w http.ResponseWriter, r *http.Request) {
+	checks := map[string]map[string]string{}
+	overall := "ok"
+
+	recordStatusCheck(checks, "umplesyncJar", h.requirePath(h.cfg.UmpleSyncJar))
+	recordStatusCheck(checks, "txlBinary", h.requirePath(txlBinaryPath))
+	recordStatusCheck(checks, "txlRuntime", h.requirePath(txlLibPath))
+	recordStatusCheck(checks, "modelStore", h.requireWritableDir(h.cfg.ModelStorePath))
+	recordStatusCheck(checks, "executionService", h.requireExecutionService())
+
+	for _, check := range checks {
+		if check["status"] != "ok" {
+			overall = "degraded"
+			break
+		}
+	}
+
+	umplesync := h.umplesyncStatus()
+	if status, _ := umplesync["status"].(string); status != "ok" {
+		overall = "degraded"
+	}
+
+	services := map[string]any{
+		"codeExecution": h.serviceStatus("codeExecution", h.cfg.ExecutionURL),
+		"collaboration": h.serviceStatus("collaboration", h.cfg.CollabURL),
+		"lsp":           h.serviceStatus("lsp", h.cfg.LSPURL),
+	}
+	for _, service := range services {
+		if serviceMap, ok := service.(map[string]any); ok {
+			if serviceMap["status"] == "unreachable" {
+				overall = "degraded"
+			}
+		}
+	}
+
+	counters := h.counters()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status":        overall,
+		"generatedAt":   time.Now().UTC().Format(time.RFC3339),
+		"uptimeSeconds": int(time.Since(h.started).Seconds()),
+		"build":         buildStatus(),
+		"process": map[string]any{
+			"pid":       os.Getpid(),
+			"hostname":  hostname(),
+			"goVersion": runtime.Version(),
+			"os":        runtime.GOOS,
+			"arch":      runtime.GOARCH,
+		},
+		"config": map[string]any{
+			"backendPort":    h.cfg.Port,
+			"umplePort":      h.cfg.UmplePort,
+			"modelStorePath": h.cfg.ModelStorePath,
+			"examplePath":    h.cfg.ExamplePath,
+			"executionURL":   h.cfg.ExecutionURL,
+			"collabURL":      h.cfg.CollabURL,
+			"lspURL":         h.cfg.LSPURL,
+		},
+		"dependencies": dependencyStatus(),
+		"checks":       checks,
+		"umplesync":    umplesync,
+		"services":     services,
+		"counters":     counters,
+		"legacy":       h.legacyStatus(),
+	})
+}
+
+func (h *StatusHandler) RecordSession(w http.ResponseWriter, r *http.Request) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	counters, err := h.readCounters()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	counters.SessionsStarted++
+	counters.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := h.writeCounters(counters); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	h.sessionsSinceStart++
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func recordStatusCheck(checks map[string]map[string]string, name string, err error) {
+	if err != nil {
+		checks[name] = map[string]string{
+			"status": "degraded",
+			"detail": err.Error(),
+		}
+		return
+	}
+
+	checks[name] = map[string]string{"status": "ok"}
+}
+
+func (h *StatusHandler) requirePath(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("%s unavailable: %w", path, err)
+	}
+
+	return nil
+}
+
+func (h *StatusHandler) requireWritableDir(path string) error {
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+
+	file, err := os.CreateTemp(path, ".statuscheck-*")
+	if err != nil {
+		return fmt.Errorf("write temp file: %w", err)
+	}
+
+	name := file.Name()
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	if err := os.Remove(name); err != nil {
+		return fmt.Errorf("remove temp file: %w", err)
+	}
+
+	return nil
+}
+
+func (h *StatusHandler) requireExecutionService() error {
+	url := strings.TrimRight(h.cfg.ExecutionURL, "/") + "/health"
+	resp, err := h.client.Get(url)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("request %s returned status %d", url, resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (h *StatusHandler) counters() map[string]any {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	counters, err := h.readCounters()
+	if err != nil {
+		return map[string]any{
+			"status": "degraded",
+			"error":  err.Error(),
+		}
+	}
+
+	return map[string]any{
+		"status":                    "ok",
+		"sessionsStartedHistorical": counters.SessionsStarted,
+		"sessionsStartedSinceStart": h.sessionsSinceStart,
+		"updatedAt":                 counters.UpdatedAt,
+	}
+}
+
+func (h *StatusHandler) readCounters() (statusCounters, error) {
+	var counters statusCounters
+	data, err := os.ReadFile(h.countersPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return counters, nil
+		}
+		return counters, fmt.Errorf("read counters: %w", err)
+	}
+
+	if err := json.Unmarshal(data, &counters); err != nil {
+		return counters, fmt.Errorf("parse counters: %w", err)
+	}
+
+	return counters, nil
+}
+
+func (h *StatusHandler) writeCounters(counters statusCounters) error {
+	if err := os.MkdirAll(h.cfg.ModelStorePath, 0o755); err != nil {
+		return fmt.Errorf("create counter dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(counters, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode counters: %w", err)
+	}
+
+	return os.WriteFile(h.countersPath(), append(data, '\n'), 0o644)
+}
+
+func (h *StatusHandler) countersPath() string {
+	return filepath.Join(h.cfg.ModelStorePath, "status-counters.json")
+}
+
+func (h *StatusHandler) serviceStatus(name string, baseURL string) map[string]any {
+	url := strings.TrimRight(baseURL, "/") + "/status"
+	var body map[string]any
+	if err := h.fetchJSON(url, &body); err != nil {
+		return map[string]any{
+			"name":   name,
+			"status": "unreachable",
+			"url":    url,
+			"error":  err.Error(),
+		}
+	}
+
+	body["name"] = name
+	body["url"] = url
+	if _, ok := body["status"]; !ok {
+		body["status"] = "ok"
+	}
+	return body
+}
+
+func (h *StatusHandler) fetchJSON(url string, target any) error {
+	resp, err := h.client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func (h *StatusHandler) umplesyncStatus() map[string]any {
+	snapshot := h.pool.Status()
+	status := map[string]any{
+		"status":  "ok",
+		"jarPath": snapshot.JarPath,
+		"port":    snapshot.Port,
+		"workDir": snapshot.WorkDir,
+		"alive":   snapshot.Alive,
+	}
+	if snapshot.PID != 0 {
+		status["pid"] = snapshot.PID
+	}
+
+	result, err := h.pool.Log()
+	if err != nil {
+		status["status"] = "degraded"
+		status["error"] = err.Error()
+		return status
+	}
+
+	status["log"] = strings.TrimSpace(result.Output)
+	if strings.TrimSpace(result.Errors) != "" {
+		status["errors"] = strings.TrimSpace(result.Errors)
+	}
+	return status
+}
+
+func buildStatus() map[string]any {
+	return map[string]any{
+		"commit":    firstNonEmpty(os.Getenv("GIT_COMMIT"), os.Getenv("GITHUB_SHA"), commandOutput("git", "rev-parse", "--short", "HEAD")),
+		"branch":    firstNonEmpty(os.Getenv("GIT_BRANCH"), os.Getenv("GITHUB_REF_NAME"), commandOutput("git", "rev-parse", "--abbrev-ref", "HEAD")),
+		"updated":   firstNonEmpty(os.Getenv("BUILD_TIME"), commandOutput("git", "log", "-1", "--format=%cd", "--date=relative")),
+		"builtAt":   os.Getenv("BUILD_TIME"),
+		"imageTag":  os.Getenv("IMAGE_TAG"),
+		"sourceRef": os.Getenv("GITHUB_REF"),
+	}
+}
+
+func dependencyStatus() []map[string]string {
+	return []map[string]string{
+		commandDependency("java", "java", "-version"),
+		commandDependency("dot", "dot", "-V"),
+		commandDependency("gcc", "gcc", "--version"),
+		commandDependency("php", "php", "-v"),
+		commandDependency("docker", "docker", "--version"),
+		pathDependency("txlBinary", txlBinaryPath),
+		pathDependency("txlRuntime", txlLibPath),
+	}
+}
+
+func (h *StatusHandler) legacyStatus() map[string]any {
+	return map[string]any{
+		"software": legacySoftwareStatus(),
+		"listener": listenerStatus(h.cfg.UmplePort),
+		"docker":   legacyDockerStatus(),
+		"execution": map[string]any{
+			"mainContainerName": firstNonEmpty(os.Getenv("CODE_EXEC_CONTAINER_NAME"), "code-exec"),
+			"tempContainerName": firstNonEmpty(os.Getenv("CODE_RUNNER_IMAGE"), os.Getenv("EXECUTION_RUNNER_IMAGE"), "umple-code-runner:dev"),
+			"port":              h.cfg.ExecutionURL,
+			"timeoutSeconds":    firstNonEmpty(os.Getenv("EXECUTION_TIMEOUT_SECONDS"), "20"),
+		},
+		"visits": legacyVisitCounter(),
+	}
+}
+
+func legacySoftwareStatus() []map[string]string {
+	return []map[string]string{
+		legacyCommand("php", "php", "-v"),
+		legacyCommand("java", "java", "-version"),
+		legacyCommand("dot", "dot", "-V"),
+		legacyCommand("gcc", "gcc", "--version"),
+		legacyCommand("docker", "docker", "--version"),
+	}
+}
+
+func legacyCommand(name string, command string, args ...string) map[string]string {
+	result := commandDependency(name, command, args...)
+	if path, err := exec.LookPath(command); err == nil {
+		result["path"] = path
+	}
+	return result
+}
+
+func listenerStatus(port int) map[string]string {
+	result := map[string]string{
+		"port": fmt.Sprint(port),
+	}
+	if _, err := exec.LookPath("lsof"); err != nil {
+		result["status"] = "unavailable"
+		result["detail"] = err.Error()
+		return result
+	}
+
+	output := commandOutput("lsof", "-nP", "-i", fmt.Sprintf(":%d", port), "-sTCP:LISTEN")
+	if output == "" {
+		result["status"] = "unavailable"
+		result["detail"] = "no listening process reported"
+		return result
+	}
+
+	result["status"] = "ok"
+	result["detail"] = output
+	return result
+}
+
+func legacyDockerStatus() map[string]any {
+	type dockerTarget struct {
+		Name       string   `json:"name"`
+		Candidates []string `json:"candidates"`
+	}
+
+	targets := []dockerTarget{
+		{Name: "backend", Candidates: compactStrings(os.Getenv("BACKEND_CONTAINER_NAME"), "umpleonline-prod-backend-1", "umpleonline-dev-backend-1")},
+		{Name: "collaboration", Candidates: compactStrings(os.Getenv("COLLAB_CONTAINER_NAME"), "umpleonline-prod-collab-1", "umpleonline-dev-collab-1")},
+		{Name: "lsp", Candidates: compactStrings(os.Getenv("LSP_CONTAINER_NAME"), "umpleonline-prod-lsp-proxy-1", "umpleonline-dev-lsp-proxy-1")},
+		{Name: "codeExecution", Candidates: compactStrings(os.Getenv("CODE_EXEC_CONTAINER_NAME"), "umpleonline-prod-code-exec-1", "umpleonline-dev-code-exec-1")},
+		{Name: "codeRunner", Candidates: compactStrings(os.Getenv("CODE_RUNNER_CONTAINER_NAME"), "umple-code-runner", os.Getenv("CODE_RUNNER_IMAGE"), os.Getenv("EXECUTION_RUNNER_IMAGE"))},
+	}
+
+	status := map[string]any{
+		"containers": targets,
+		"stats":      []map[string]any{},
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		status["status"] = "unavailable"
+		status["detail"] = err.Error()
+		return status
+	}
+
+	records := []map[string]any{}
+	for _, target := range targets {
+		record := map[string]any{
+			"name":       target.Name,
+			"status":     "unavailable",
+			"candidates": target.Candidates,
+		}
+
+		for _, candidate := range target.Candidates {
+			output, ok := commandOutputOK("docker", "container", "stats", "--no-stream", "--format", "json", candidate)
+			if !ok || output == "" {
+				continue
+			}
+
+			stat := map[string]any{}
+			if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &stat); err != nil {
+				record["status"] = "unparsed"
+				record["container"] = candidate
+				record["detail"] = strings.TrimSpace(output)
+				break
+			}
+			record["status"] = "ok"
+			record["container"] = candidate
+			for key, value := range stat {
+				record[key] = value
+			}
+			break
+		}
+		records = append(records, record)
+	}
+
+	status["status"] = "ok"
+	status["stats"] = records
+	return status
+}
+
+func legacyVisitCounter() map[string]string {
+	paths := []string{
+		filepath.Join(".", "countlog.txt"),
+		filepath.Join("..", "countlog.txt"),
+		filepath.Join(os.Getenv("MODEL_STORE_PATH"), "countlog.txt"),
+	}
+	for _, path := range paths {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		return map[string]string{
+			"status": "ok",
+			"label":  "visits since October 2018",
+			"value":  strings.TrimSpace(string(data)),
+			"path":   path,
+		}
+	}
+
+	return map[string]string{
+		"status": "unavailable",
+		"label":  "visits since October 2018",
+		"detail": "legacy countlog.txt not found in this deployment",
+	}
+}
+
+func compactStrings(values ...string) []string {
+	seen := map[string]bool{}
+	compacted := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		compacted = append(compacted, value)
+	}
+	return compacted
+}
+
+func commandDependency(name string, command string, args ...string) map[string]string {
+	output := commandOutput(command, args...)
+	if output == "" {
+		return map[string]string{
+			"name":   name,
+			"status": "unavailable",
+		}
+	}
+
+	return map[string]string{
+		"name":   name,
+		"status": "ok",
+		"detail": output,
+	}
+}
+
+func pathDependency(name string, path string) map[string]string {
+	if _, err := os.Stat(path); err != nil {
+		return map[string]string{
+			"name":   name,
+			"status": "unavailable",
+			"detail": err.Error(),
+		}
+	}
+
+	return map[string]string{
+		"name":   name,
+		"status": "ok",
+		"detail": path,
+	}
+}
+
+func commandOutput(command string, args ...string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, command, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil && len(output) == 0 {
+		return ""
+	}
+
+	return strings.TrimSpace(string(output))
+}
+
+func commandOutputOK(command string, args ...string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, command, args...)
+	output, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(output)), err == nil
+}
+
+func hostname() string {
+	name, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	return name
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return "unknown"
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -32,6 +32,7 @@ func NewRouter(cfg *config.Config, pool *compiler.Pool, store *model.Store, task
 	generateH := handlers.NewGenerateHandler(pool, store, cfg)
 	exampleH := handlers.NewExampleHandler(cfg, store)
 	healthH := handlers.NewHealthHandler(cfg)
+	statusH := handlers.NewStatusHandler(cfg, pool)
 
 	// New handlers
 	syncH := handlers.NewSyncHandler(pool, store)
@@ -48,6 +49,8 @@ func NewRouter(cfg *config.Config, pool *compiler.Pool, store *model.Store, task
 
 	r.Route("/api", func(r chi.Router) {
 		r.Get("/health", healthH.Health)
+		r.Get("/status", statusH.Status)
+		r.Post("/status/session", statusH.RecordSession)
 
 		// Generate (includes compilation)
 		r.Post("/generate", generateH.Generate)

--- a/backend/internal/compiler/pool.go
+++ b/backend/internal/compiler/pool.go
@@ -37,6 +37,14 @@ type Pool struct {
 	modelMu sync.Map // map[string]*sync.Mutex
 }
 
+type StatusSnapshot struct {
+	JarPath string `json:"jarPath"`
+	Port    int    `json:"port"`
+	WorkDir string `json:"workDir"`
+	Alive   bool   `json:"alive"`
+	PID     int    `json:"pid,omitempty"`
+}
+
 func NewPool(jarPath string, port int) (*Pool, error) {
 	return NewPoolWithWorkDir(jarPath, port, "")
 }
@@ -105,6 +113,38 @@ func (p *Pool) execute(req CompileRequest) (*CompileResult, error) {
 	defer conn.Close()
 
 	return sendCommand(conn, req.Command)
+}
+
+func (p *Pool) Log() (*CompileResult, error) {
+	if err := p.ensureRunning(); err != nil {
+		return nil, fmt.Errorf("compiler not available: %w", err)
+	}
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", p.port), dialTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("connect failed: %w", err)
+	}
+	defer conn.Close()
+
+	return sendCommand(conn, "-log")
+}
+
+func (p *Pool) Status() StatusSnapshot {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	pid := 0
+	if p.process != nil && p.process.Process != nil {
+		pid = p.process.Process.Pid
+	}
+
+	return StatusSnapshot{
+		JarPath: p.jarPath,
+		Port:    p.port,
+		WorkDir: p.workDir,
+		Alive:   p.alive,
+		PID:     pid,
+	}
 }
 
 func (p *Pool) startServer() error {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	ModelStorePath string
 	ExamplePath    string
 	ExecutionURL   string
+	CollabURL      string
+	LSPURL         string
 	TaskStorePath  string
 	AllowedOrigins []string
 }
@@ -26,6 +28,8 @@ func Load() *Config {
 		ModelStorePath: getEnv("MODEL_STORE_PATH", "/data/models"),
 		ExamplePath:    getEnv("EXAMPLE_PATH", "/examples"),
 		ExecutionURL:   getExecutionURL(),
+		CollabURL:      getCollabURL(),
+		LSPURL:         getLSPURL(),
 		TaskStorePath:  getEnv("TASK_STORE_PATH", "/data/models/tasks"),
 		AllowedOrigins: getOrigins("ALLOWED_ORIGINS", []string{"http://localhost:3100"}),
 	}
@@ -37,6 +41,22 @@ func getExecutionURL() string {
 	}
 
 	return fmt.Sprintf("http://code-exec:%d", getEnvInt("CODE_EXEC_PORT", 4401))
+}
+
+func getCollabURL() string {
+	if v := os.Getenv("COLLAB_URL"); v != "" {
+		return v
+	}
+
+	return fmt.Sprintf("http://collab:%d", getEnvInt("COLLAB_PORT", 3002))
+}
+
+func getLSPURL() string {
+	if v := os.Getenv("LSP_URL"); v != "" {
+		return v
+	}
+
+	return fmt.Sprintf("http://lsp-proxy:%d", getEnvInt("LSP_PORT", 9999))
 }
 
 func getOrigins(key string, fallback []string) []string {

--- a/code-exec/app.js
+++ b/code-exec/app.js
@@ -54,11 +54,14 @@ function resolvePort() {
 }
 
 const port = resolvePort();
+const startedAt = Date.now();
 
 // Declare max requests
 const MAX_REQUESTS = 20;
 let mainFileName;
 let numberOfRequests = 0;
+let totalRunRequests = 0;
+let rejectedRequests = 0;
 
 function sendAndRelease(res, payload) {
     numberOfRequests--;
@@ -69,6 +72,22 @@ app.get('/health', (req, res) => {
     res.json({ status: 'ok', requestsInFlight: numberOfRequests });
 });
 
+app.get('/status', (req, res) => {
+    res.json({
+        status: 'ok',
+        port,
+        pid: process.pid,
+        uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
+        nodeVersion: process.version,
+        requestsInFlight: numberOfRequests,
+        maxConcurrentRequests: MAX_REQUESTS,
+        totalRunRequests,
+        rejectedRequests,
+        runnerImage: process.env.EXECUTION_RUNNER_IMAGE || 'umple-code-runner:dev',
+        runnerAutoBuild: process.env.EXECUTION_RUNNER_AUTO_BUILD === '1',
+    });
+});
+
 app.post('/run' , (req, res)  => 
 {
     canProceed((err) => {
@@ -76,6 +95,7 @@ app.post('/run' , (req, res)  =>
             return res.send(err); 
         } else {
             numberOfRequests++;
+            totalRunRequests++;
 
             // Extract out path and validate
             const path = req.body.path;
@@ -212,6 +232,7 @@ const validatePath = (path) => {
 const canProceed = (callback) => {
     // Check max number of requests allowed
     if(numberOfRequests >= MAX_REQUESTS) {
+        rejectedRequests++;
         callback({errors:"Umple code execution Docker server is too heavily loaded to execute your code at the same time as many others, please try again in a few seconds to execute your code. If the problem persists for many minutes, then please report to Umple developers.", output:""})
     } else {
         callback(null);
@@ -224,4 +245,3 @@ const canProceed = (callback) => {
 server.listen(port, () => {
     console.log("Listening at "+port)
 });
-

--- a/collab/src/server.ts
+++ b/collab/src/server.ts
@@ -1,13 +1,30 @@
 import http from 'node:http'
 import { WebSocketServer } from 'ws'
-import { setupWSConnection } from './sync.js'
+import { getCollabStats, setupWSConnection } from './sync.js'
 
 const PORT = parseInt(process.env.PORT ?? '3002', 10)
+const startedAt = Date.now()
+let totalConnectionsStarted = 0
+let maxConcurrentConnections = 0
 
 const server = http.createServer((req, res) => {
   if (req.url === '/health') {
     res.writeHead(200, { 'Content-Type': 'text/plain' })
     res.end('ok')
+    return
+  }
+  if (req.url === '/status') {
+    const stats = getCollabStats()
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({
+      status: 'ok',
+      port: PORT,
+      pid: process.pid,
+      uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
+      totalConnectionsStarted,
+      maxConcurrentConnections,
+      ...stats,
+    }))
     return
   }
   res.writeHead(404)
@@ -27,8 +44,10 @@ wss.on('connection', (ws, req) => {
   }
 
   console.log(`[collab] client connected to room "${roomId}" (url: ${req.url})`)
+  totalConnectionsStarted += 1
 
   setupWSConnection(ws, req, { docName: roomId })
+  maxConcurrentConnections = Math.max(maxConcurrentConnections, getCollabStats().activeConnections)
 
   ws.on('close', () => {
     console.log(`[collab] client disconnected from room "${roomId}"`)

--- a/collab/src/sync.ts
+++ b/collab/src/sync.ts
@@ -176,3 +176,19 @@ export function setupWSConnection(
     send(doc, conn, encoding.toUint8Array(encoder))
   }
 }
+
+export function getCollabStats() {
+  let activeConnections = 0
+  let awarenessStates = 0
+
+  docs.forEach((doc) => {
+    activeConnections += doc.conns.size
+    awarenessStates += doc.awareness.getStates().size
+  })
+
+  return {
+    activeRooms: docs.size,
+    activeConnections,
+    awarenessStates,
+  }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,8 @@ services:
       - MODEL_STORE_PATH=/data/models
       - EXAMPLE_PATH=/examples
       - CODE_EXEC_PORT=${CODE_EXEC_PORT:-4401}
+      - COLLAB_PORT=${COLLAB_PORT:-3002}
+      - LSP_PORT=${LSP_PORT:-9999}
       - PORT=${BACKEND_PORT:-3001}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
     depends_on:
@@ -90,13 +92,7 @@ services:
       - UMPLESYNC_JAR_PATH=/jars/umplesync.jar
       - LSP_PORT=${LSP_PORT:-9999}
     healthcheck:
-      test:
-        [
-          "CMD",
-          "node",
-          "-e",
-          "const W=require('ws'),c=new W('ws://127.0.0.1:${LSP_PORT:-9999}');c.on('open',()=>{c.close();process.exit(0)});c.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),4000)",
-        ]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:${LSP_PORT:-9999}/health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - MODEL_STORE_PATH=/data/models
       - EXAMPLE_PATH=/examples
       - CODE_EXEC_PORT=${CODE_EXEC_PORT:-4401}
+      - COLLAB_PORT=${COLLAB_PORT:-3002}
+      - LSP_PORT=${LSP_PORT:-9999}
       - PORT=${BACKEND_PORT:-3001}
     depends_on:
       code-exec:
@@ -58,13 +60,7 @@ services:
       - UMPLESYNC_JAR_PATH=/jars/umplesync.jar
       - LSP_PORT=${LSP_PORT:-9999}
     healthcheck:
-      test:
-        [
-          "CMD",
-          "node",
-          "-e",
-          "const W=require('ws'),c=new W('ws://127.0.0.1:${LSP_PORT:-9999}');c.on('open',()=>{c.close();process.exit(0)});c.on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),4000)",
-        ]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:${LSP_PORT:-9999}/health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,6 +7,7 @@ import type {
   GetModelResponse,
   CrudSchemaResponse,
   PromoteResponse,
+  StatusResponse,
 } from "./types";
 
 const API_BASE = "/api";
@@ -151,5 +152,20 @@ export const api = {
     return request(`/models/${encodeURIComponent(id)}/promote`, {
       method: "POST",
     });
+  },
+
+  status(signal?: AbortSignal): Promise<StatusResponse> {
+    return request("/status", { signal });
+  },
+
+  async recordSessionStarted(): Promise<void> {
+    const res = await fetch(`${API_BASE}/status/session`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ error: res.statusText }));
+      throw new Error(err.error || res.statusText);
+    }
   },
 };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -286,6 +286,21 @@ export interface PromoteResponse {
   newId: string;
 }
 
+export interface StatusResponse {
+  status: "ok" | "degraded" | string;
+  generatedAt: string;
+  uptimeSeconds: number;
+  build: Record<string, unknown>;
+  process: Record<string, unknown>;
+  config: Record<string, unknown>;
+  dependencies: Array<Record<string, unknown>>;
+  checks: Record<string, Record<string, unknown>>;
+  umplesync: Record<string, unknown>;
+  services: Record<string, Record<string, unknown>>;
+  counters: Record<string, unknown>;
+  legacy: Record<string, unknown>;
+}
+
 // ── Task types ──
 
 export interface TaskTab {

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -16,8 +16,10 @@ import { WelcomeDialog } from '@/components/onboarding/WelcomeDialog'
 import { OnboardingTour } from '@/components/onboarding/OnboardingTour'
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary'
 import { TaskSheet } from '@/components/task/TaskSheet'
+import { api } from '@/api/client'
 
 const SIDEBAR_TOGGLE_GUARD_MS = 350
+const SESSION_COUNTER_KEY = 'umpleonline-session-counted-v1'
 
 export function AppShell() {
   const showEditor = useEphemeralStore((s) => s.showEditor)
@@ -27,6 +29,14 @@ export function AppShell() {
   useModelFromURL()
   useCollab()
   useTaskRoute()
+
+  useEffect(() => {
+    if (sessionStorage.getItem(SESSION_COUNTER_KEY)) return
+    sessionStorage.setItem(SESSION_COUNTER_KEY, '1')
+    void api.recordSessionStarted().catch(() => {
+      sessionStorage.removeItem(SESSION_COUNTER_KEY)
+    })
+  }, [])
 
   useEffect(() => {
     let lastSidebarToggleAt = 0

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-accent", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,12 +4,14 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import App from './App'
 import { AppShell } from './components/layout/AppShell'
+import { StatusPage } from './pages/status/StatusPage'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
         <Route element={<App />}>
+          <Route path="/status" element={<StatusPage />} />
           <Route path="*" element={<AppShell />} />
         </Route>
       </Routes>

--- a/frontend/src/pages/status/StatusPage.tsx
+++ b/frontend/src/pages/status/StatusPage.tsx
@@ -1,0 +1,410 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { api } from "@/api/client";
+import type { StatusResponse } from "@/api/types";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+const REFRESH_INTERVAL_MS = 30_000;
+
+export function StatusPage() {
+  const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadStatus = useCallback(async (signal?: AbortSignal) => {
+    setError(null);
+    setRefreshing(true);
+    try {
+      const next = await api.status(signal);
+      setStatus(next);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      setError(err instanceof Error ? err.message : "Failed to load status");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadStatus(controller.signal);
+    const interval = window.setInterval(() => {
+      void loadStatus();
+    }, REFRESH_INTERVAL_MS);
+
+    return () => {
+      controller.abort();
+      window.clearInterval(interval);
+    };
+  }, [loadStatus]);
+
+  return (
+    <main className="h-screen overflow-y-auto bg-surface-1 text-ink">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 px-4 py-4 sm:px-6 lg:px-8">
+        <header className="flex flex-col gap-3 rounded-lg border border-border bg-surface-0 px-4 py-4 shadow-sm md:flex-row md:items-center md:justify-between">
+          <div className="flex min-w-0 flex-col gap-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-xl font-semibold tracking-tight">UmpleOnline Status</h1>
+              {status ? <StatusBadge value={status.status} /> : null}
+            </div>
+            <p className="text-sm text-ink-muted">
+              Developer monitoring for the backend, compiler, collaboration, LSP, and execution services.
+            </p>
+            {status ? (
+              <p className="text-xs text-ink-faint">
+                Last refresh {formatDate(status.generatedAt)}. Auto-refreshes every 30 seconds.
+              </p>
+            ) : null}
+          </div>
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
+            <Button asChild variant="outline" size="sm">
+              <Link to="/">Back to editor</Link>
+            </Button>
+            <Button onClick={() => void loadStatus()} disabled={refreshing} size="sm">
+              <RefreshCw data-icon="inline-start" />
+              {refreshing ? "Refreshing" : "Refresh"}
+            </Button>
+          </div>
+        </header>
+
+        {error ? (
+          <Alert variant="destructive">
+            <AlertCircle />
+            <AlertTitle>Status unavailable</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {loading && !status ? <StatusSkeleton /> : null}
+        {status ? <StatusContent status={status} /> : null}
+      </div>
+    </main>
+  );
+}
+
+function StatusContent({ status }: { status: StatusResponse }) {
+  const services = Object.entries(status.services ?? {});
+  const legacy = status.legacy ?? {};
+  const legacyDocker = asRecord(legacy.docker);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid gap-4 lg:grid-cols-3">
+        <SummaryCard title="Backend uptime" value={formatDuration(status.uptimeSeconds)} description="Since this backend process started" />
+        <SummaryCard title="Commit" value={formatValue(status.build?.commit)} description={formatValue(status.build?.branch)} />
+        <SummaryCard title="Compiler" value={formatValue(status.umplesync?.alive) === "true" ? "Running" : "Not running"} description={`Port ${formatValue(status.umplesync?.port)}`} />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <DataCard title="Build" description="Source revision and image metadata">
+          <KeyValueTable data={status.build} />
+        </DataCard>
+
+        <DataCard title="Runtime" description="Backend process and configured service targets">
+          <KeyValueTable data={{ ...status.process, ...status.config }} />
+        </DataCard>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <DataCard title="Dependency Checks" description="Configured software and filesystem dependencies">
+          <RecordsTable records={status.dependencies ?? []} primary="name" />
+        </DataCard>
+
+        <DataCard title="Health Checks" description="Backend healthcheck inputs used by Docker and operators">
+          <KeyValueTable data={status.checks} />
+        </DataCard>
+      </div>
+
+      <section className="grid gap-4 xl:grid-cols-3">
+        {services.map(([name, service]) => (
+          <DataCard key={name} title={serviceTitle(name)} description={formatValue(service.url)}>
+            <KeyValueTable data={service} />
+          </DataCard>
+        ))}
+      </section>
+
+      <DataCard
+        title="Umplesync"
+        description="Compiler process details and raw output from the umplesync -log command"
+        action={<StatusBadge value={formatValue(status.umplesync?.status)} />}
+      >
+        <KeyValueTable data={withoutKeys(status.umplesync, ["log"])} />
+        <Separator className="my-4" />
+        <pre className="max-h-[28rem] overflow-auto rounded-md bg-muted p-3 font-mono text-xs leading-relaxed text-foreground">
+          {formatValue(status.umplesync?.log) || "No log output returned."}
+        </pre>
+      </DataCard>
+
+      <DataCard title="Counters" description="Historical and since-start counters exposed by the status API">
+        <KeyValueTable data={status.counters} />
+      </DataCard>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <DataCard title="Legacy Software" description="Legacy log.php software probes, including executable paths">
+          <RecordsTable records={asRecordArray(legacy.software)} primary="name" />
+        </DataCard>
+
+        <DataCard title="Legacy Listener" description="Legacy lsof-style listener check for the umplesync port">
+          <KeyValueTable data={asRecord(legacy.listener)} />
+        </DataCard>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <DataCard title="Legacy Docker" description="Legacy container names and docker stats probes">
+          <KeyValueTable data={withoutKeys(legacyDocker, ["stats"])} />
+          <Separator className="my-4" />
+          <RecordsTable records={asRecordArray(legacyDocker.stats)} primary="name" />
+        </DataCard>
+
+        <DataCard title="Legacy Execution" description="Execution-server fields exposed by the old status page">
+          <KeyValueTable data={asRecord(legacy.execution)} />
+        </DataCard>
+      </div>
+
+      <DataCard title="Legacy Visits" description="Old countlog.txt visit counter when present in the deployment">
+        <KeyValueTable data={asRecord(legacy.visits)} />
+      </DataCard>
+    </div>
+  );
+}
+
+function SummaryCard({
+  title,
+  value,
+  description,
+}: {
+  title: string;
+  value: string;
+  description: string;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm text-muted-foreground">{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="truncate text-2xl font-semibold tracking-tight">{value}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DataCard({
+  title,
+  description,
+  action,
+  children,
+}: {
+  title: string;
+  description: string;
+  action?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+        {action ? <CardAction>{action}</CardAction> : null}
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+function KeyValueTable({ data }: { data: Record<string, unknown> | undefined }) {
+  const entries = Object.entries(data ?? {});
+  if (entries.length === 0) {
+    return <p className="text-sm text-muted-foreground">No data reported.</p>;
+  }
+
+  return (
+    <Table>
+      <TableBody>
+        {entries.map(([key, value]) => (
+          <TableRow key={key}>
+            <TableCell className="w-48 align-top font-medium text-muted-foreground">{labelize(key)}</TableCell>
+            <TableCell className="max-w-[44rem] whitespace-normal break-words font-mono text-xs">
+              <FormattedValue value={value} />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function RecordsTable({
+  records,
+  primary,
+}: {
+  records: Array<Record<string, unknown>>;
+  primary: string;
+}) {
+  if (records.length === 0) {
+    return <p className="text-sm text-muted-foreground">No records reported.</p>;
+  }
+
+  const keys = Array.from(new Set(records.flatMap((record) => Object.keys(record))));
+  const sortedKeys = [primary, ...keys.filter((key) => key !== primary)];
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          {sortedKeys.map((key) => (
+            <TableHead key={key}>{labelize(key)}</TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {records.map((record, index) => (
+          <TableRow key={`${formatValue(record[primary])}-${index}`}>
+            {sortedKeys.map((key) => (
+              <TableCell key={key} className="max-w-[28rem] whitespace-normal break-words font-mono text-xs">
+                <FormattedValue value={record[key]} />
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function FormattedValue({ value }: { value: unknown }) {
+  if (isStatusValue(value)) {
+    return <StatusBadge value={value} />;
+  }
+  if (typeof value === "boolean") {
+    return <Badge variant="outline">{value ? "true" : "false"}</Badge>;
+  }
+  if (value && typeof value === "object") {
+    return <pre className="m-0 whitespace-pre-wrap break-words">{JSON.stringify(value, null, 2)}</pre>;
+  }
+  return <>{formatValue(value)}</>;
+}
+
+function StatusBadge({ value }: { value: string }) {
+  const normalized = value.toLowerCase();
+  const className = cn(
+    "border font-semibold",
+    (normalized === "ok" || normalized === "running") &&
+      "border-status-success/30 bg-status-success/10 text-status-success",
+    normalized === "degraded" &&
+      "border-status-warning/30 bg-status-warning/10 text-status-warning",
+    (normalized === "unreachable" || normalized === "unavailable") &&
+      "border-status-error/30 bg-status-error/10 text-status-error",
+  );
+
+  return (
+    <Badge variant="outline" className={className}>
+      {value}
+    </Badge>
+  );
+}
+
+function StatusSkeleton() {
+  return (
+    <div className="grid gap-4 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <Card key={index}>
+          <CardHeader>
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-48" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-full" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function isStatusValue(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  return ["ok", "degraded", "unreachable", "unavailable", "not_tracked", "running"].includes(value.toLowerCase());
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined || value === "") return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return JSON.stringify(value);
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function formatDuration(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds)) return "";
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = Math.floor(totalSeconds % 60);
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
+function labelize(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .replace(/^./, (match) => match.toUpperCase());
+}
+
+function serviceTitle(value: string): string {
+  if (value === "codeExecution") return "Code Execution";
+  if (value === "lsp") return "LSP";
+  return labelize(value);
+}
+
+function withoutKeys(data: Record<string, unknown>, keys: string[]) {
+  return Object.fromEntries(Object.entries(data ?? {}).filter(([key]) => !keys.includes(key)));
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function asRecordArray(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is Record<string, unknown> => (
+    item !== null && typeof item === "object" && !Array.isArray(item)
+  ));
+}

--- a/lsp-proxy/server.js
+++ b/lsp-proxy/server.js
@@ -2,6 +2,7 @@
 
 const { WebSocketServer } = require("ws");
 const { spawn } = require("child_process");
+const http = require("http");
 const path = require("path");
 const fs = require("fs");
 const url = require("url");
@@ -23,6 +24,10 @@ const SESSION_ID_RE = /^[a-zA-Z0-9_-]+$/;
 // ---------------------------------------------------------------------------
 const activeSessions = new Map();
 let connectionCounter = 0;
+let totalSessionsStarted = 0;
+let rejectedConnections = 0;
+let maxConcurrentSessions = 0;
+const startedAt = Date.now();
 
 function log(msg) {
   console.log(`[lsp-proxy] ${new Date().toISOString()} ${msg}`);
@@ -118,9 +123,39 @@ function killSession(modelId, reason) {
 // ---------------------------------------------------------------------------
 // WebSocket server
 // ---------------------------------------------------------------------------
-const wss = new WebSocketServer({ port: LSP_PORT, host: "0.0.0.0" });
+const server = http.createServer((req, res) => {
+  const pathname = new url.URL(req.url, "http://localhost").pathname;
+  if (pathname === "/health") {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("ok");
+    return;
+  }
+  if (pathname === "/status") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      status: "ok",
+      port: LSP_PORT,
+      pid: process.pid,
+      uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
+      command: LSP_COMMAND,
+      baseDir: UMP_BASE_DIR,
+      umplesyncJarPath: UMPLESYNC_JAR_PATH,
+      activeSessions: activeSessions.size,
+      totalSessionsStarted,
+      rejectedConnections,
+      maxConcurrentSessions,
+      processLimit: MAX_PROCESSES_GLOBAL,
+      debug: LSP_DEBUG,
+    }));
+    return;
+  }
+  res.writeHead(404);
+  res.end();
+});
 
-wss.on("listening", () => {
+const wss = new WebSocketServer({ server });
+
+server.on("listening", () => {
   log(`WebSocket server listening on 0.0.0.0:${LSP_PORT}`);
 });
 
@@ -130,6 +165,7 @@ wss.on("connection", (ws, req) => {
 
   if (!SESSION_ID_RE.test(modelId)) {
     warn(`Invalid session ID: ${modelId}`);
+    rejectedConnections++;
     ws.close(4001, "Invalid session ID");
     return;
   }
@@ -142,12 +178,14 @@ wss.on("connection", (ws, req) => {
   }
   if (!modelDir) {
     warn(`Model directory not found or path traversal: ${modelId}`);
+    rejectedConnections++;
     ws.close(4002, "Model directory not found");
     return;
   }
 
   if (activeSessions.size >= MAX_PROCESSES_GLOBAL) {
     warn(`Global process limit reached (${MAX_PROCESSES_GLOBAL})`);
+    rejectedConnections++;
     ws.close(4005, "Server capacity reached");
     return;
   }
@@ -174,6 +212,8 @@ wss.on("connection", (ws, req) => {
   const entry = { process: lspProcess, framer, ws, cleanedUp: false };
 
   activeSessions.set(connId, entry);
+  totalSessionsStarted++;
+  maxConcurrentSessions = Math.max(maxConcurrentSessions, activeSessions.size);
   log(`Session started for model=${modelId} conn=${connId} (pid=${lspProcess.pid})`);
 
   // LSP stdout → WebSocket
@@ -245,6 +285,8 @@ wss.on("connection", (ws, req) => {
 wss.on("error", (err) => {
   warn(`WebSocket server error: ${err.message}`);
 });
+
+server.listen(LSP_PORT, "0.0.0.0");
 
 // ---------------------------------------------------------------------------
 // Graceful shutdown


### PR DESCRIPTION
## Summary
- Add a backend status endpoint with compiler, dependency, service, and legacy runtime checks
- Add status endpoints for code execution, collaboration, and LSP services
- Add a dedicated frontend /status page outside the editor shell

## Test plan
- bun run tsc -b --noEmit
- go vet ./...
- CGO_ENABLED=0 go build -o /dev/null ./cmd/server
- node --check lsp-proxy/server.js
- node --check code-exec/app.js