### PR TITLE
feat(status): show release metadata

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -93,8 +93,16 @@ jobs:
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ steps.resolve.outputs.sha }}
             org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
             org.opencontainers.image.vendor=University of Ottawa
             org.opencontainers.image.description=UmpleOnline backend API
+          build-args: |
+            SOURCE_COMMIT=${{ steps.resolve.outputs.sha }}
+            SOURCE_REF=${{ github.ref }}
+            SOURCE_REF_NAME=${{ github.ref_name }}
+            SOURCE_REF_TYPE=${{ github.ref_type }}
+            BUILD_TIME=${{ steps.meta.outputs.created }}
+            BACKEND_IMAGE_REF=${{ steps.meta.outputs.prefix }}/backend:${{ steps.meta.outputs.sha_tag }}
           cache-from: type=gha,scope=backend
           cache-to: type=gha,mode=max,scope=backend
           sbom: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,8 @@ jobs:
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
             bash "${{ secrets.DEPLOY_PATH }}/scripts/release.sh" \
               "${{ secrets.DEPLOY_PATH }}" \
+              "${{ steps.meta.outputs.release_tag }}" \
+              "${{ steps.meta.outputs.sha }}" \
               "${{ steps.meta.outputs.backend_image }}" \
               "${{ steps.meta.outputs.frontend_image }}" \
               "${{ steps.meta.outputs.code_exec_image }}" \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,19 @@ RUN go mod tidy && CGO_ENABLED=0 go build -o /server ./cmd/server
 FROM eclipse-temurin:17-jdk-alpine-3.23
 
 ARG GLIBC_VERSION=2.35-r1
+ARG SOURCE_COMMIT=unknown
+ARG SOURCE_REF=
+ARG SOURCE_REF_NAME=
+ARG SOURCE_REF_TYPE=
+ARG BUILD_TIME=
+ARG BACKEND_IMAGE_REF=
+
+ENV SOURCE_COMMIT=${SOURCE_COMMIT} \
+    SOURCE_REF=${SOURCE_REF} \
+    SOURCE_REF_NAME=${SOURCE_REF_NAME} \
+    SOURCE_REF_TYPE=${SOURCE_REF_TYPE} \
+    BUILD_TIME=${BUILD_TIME} \
+    BACKEND_IMAGE_REF=${BACKEND_IMAGE_REF}
 
 RUN apk upgrade --no-cache && apk add --no-cache graphviz python3
 

--- a/backend/internal/api/handlers/status.go
+++ b/backend/internal/api/handlers/status.go
@@ -86,6 +86,7 @@ func (h *StatusHandler) Status(w http.ResponseWriter, r *http.Request) {
 		"generatedAt":   time.Now().UTC().Format(time.RFC3339),
 		"uptimeSeconds": int(time.Since(h.started).Seconds()),
 		"build":         buildStatus(),
+		"release":       releaseStatus(),
 		"process": map[string]any{
 			"pid":       os.Getpid(),
 			"hostname":  hostname(),
@@ -305,14 +306,63 @@ func (h *StatusHandler) umplesyncStatus() map[string]any {
 }
 
 func buildStatus() map[string]any {
+	sourceRef := firstPresent(os.Getenv("SOURCE_REF"), os.Getenv("GITHUB_REF"))
+	imageRef := firstPresent(os.Getenv("BACKEND_IMAGE_REF"), os.Getenv("IMAGE_TAG"))
+
 	return map[string]any{
-		"commit":    firstNonEmpty(os.Getenv("GIT_COMMIT"), os.Getenv("GITHUB_SHA"), commandOutput("git", "rev-parse", "--short", "HEAD")),
-		"branch":    firstNonEmpty(os.Getenv("GIT_BRANCH"), os.Getenv("GITHUB_REF_NAME"), commandOutput("git", "rev-parse", "--abbrev-ref", "HEAD")),
-		"updated":   firstNonEmpty(os.Getenv("BUILD_TIME"), commandOutput("git", "log", "-1", "--format=%cd", "--date=relative")),
-		"builtAt":   os.Getenv("BUILD_TIME"),
-		"imageTag":  os.Getenv("IMAGE_TAG"),
-		"sourceRef": os.Getenv("GITHUB_REF"),
+		"sourceCommit":  firstNonEmpty(os.Getenv("SOURCE_COMMIT"), os.Getenv("GIT_COMMIT"), os.Getenv("GITHUB_SHA"), commitFromImageRef(imageRef), commandOutput("git", "rev-parse", "--short", "HEAD")),
+		"sourceRef":     sourceRef,
+		"sourceRefName": firstPresent(os.Getenv("SOURCE_REF_NAME"), os.Getenv("GITHUB_REF_NAME"), refNameFromRef(sourceRef), commandOutput("git", "rev-parse", "--abbrev-ref", "HEAD")),
+		"sourceRefType": firstPresent(os.Getenv("SOURCE_REF_TYPE"), refTypeFromRef(sourceRef)),
+		"builtAt":       os.Getenv("BUILD_TIME"),
+		"backendImage":  imageRef,
 	}
+}
+
+func releaseStatus() map[string]any {
+	release := map[string]any{
+		"releaseTag":   os.Getenv("RELEASE_TAG"),
+		"deployedAt":   os.Getenv("DEPLOYED_AT"),
+		"sourceCommit": os.Getenv("DEPLOYED_SOURCE_COMMIT"),
+		"sourceRef":    os.Getenv("DEPLOYED_SOURCE_REF"),
+		"backendImage": firstPresent(os.Getenv("BACKEND_IMAGE_REF"), os.Getenv("IMAGE_TAG")),
+	}
+	for _, value := range release {
+		if text, ok := value.(string); ok && strings.TrimSpace(text) != "" {
+			return release
+		}
+	}
+	return map[string]any{}
+}
+
+func commitFromImageRef(imageRef string) string {
+	_, tag, ok := strings.Cut(strings.TrimSpace(imageRef), ":sha-")
+	if !ok {
+		return ""
+	}
+	return tag
+}
+
+func refNameFromRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if name, ok := strings.CutPrefix(ref, "refs/heads/"); ok {
+		return name
+	}
+	if name, ok := strings.CutPrefix(ref, "refs/tags/"); ok {
+		return name
+	}
+	return ""
+}
+
+func refTypeFromRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if strings.HasPrefix(ref, "refs/heads/") {
+		return "branch"
+	}
+	if strings.HasPrefix(ref, "refs/tags/") {
+		return "tag"
+	}
+	return ""
 }
 
 func dependencyStatus() []map[string]string {
@@ -554,4 +604,13 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return "unknown"
+}
+
+func firstPresent(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }

--- a/backend/internal/api/handlers/status_test.go
+++ b/backend/internal/api/handlers/status_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+import "testing"
+
+func TestBuildStatusUsesImageBuildEnvironment(t *testing.T) {
+	clearBuildStatusEnv(t)
+
+	t.Setenv("SOURCE_COMMIT", "e3cdcad2cf7de3b9e510efc58856086406004718")
+	t.Setenv("SOURCE_REF", "refs/heads/master")
+	t.Setenv("SOURCE_REF_NAME", "master")
+	t.Setenv("SOURCE_REF_TYPE", "branch")
+	t.Setenv("BUILD_TIME", "2026-04-23T20:13:17Z")
+	t.Setenv("BACKEND_IMAGE_REF", "ghcr.io/umple/umpleonline/backend:sha-e3cdcad2cf7de3b9e510efc58856086406004718")
+
+	status := buildStatus()
+
+	if status["sourceCommit"] != "e3cdcad2cf7de3b9e510efc58856086406004718" {
+		t.Fatalf("sourceCommit = %q, want image source commit", status["sourceCommit"])
+	}
+	if status["sourceRef"] != "refs/heads/master" {
+		t.Fatalf("sourceRef = %q, want source ref", status["sourceRef"])
+	}
+	if status["sourceRefName"] != "master" {
+		t.Fatalf("sourceRefName = %q, want source ref name", status["sourceRefName"])
+	}
+	if status["sourceRefType"] != "branch" {
+		t.Fatalf("sourceRefType = %q, want source ref type", status["sourceRefType"])
+	}
+	if status["builtAt"] != "2026-04-23T20:13:17Z" {
+		t.Fatalf("builtAt = %q, want build timestamp", status["builtAt"])
+	}
+	if status["backendImage"] != "ghcr.io/umple/umpleonline/backend:sha-e3cdcad2cf7de3b9e510efc58856086406004718" {
+		t.Fatalf("backendImage = %q, want backend image", status["backendImage"])
+	}
+}
+
+func TestBuildStatusFallsBackToImageAndRefMetadata(t *testing.T) {
+	clearBuildStatusEnv(t)
+
+	t.Setenv("BACKEND_IMAGE_REF", "ghcr.io/umple/umpleonline/backend:sha-abcdef123456")
+	t.Setenv("GITHUB_REF", "refs/tags/v0.0.9")
+	t.Setenv("BUILD_TIME", "2026-04-23T20:13:17Z")
+
+	status := buildStatus()
+
+	if status["sourceCommit"] != "abcdef123456" {
+		t.Fatalf("sourceCommit = %q, want commit parsed from image tag", status["sourceCommit"])
+	}
+	if status["sourceRefName"] != "v0.0.9" {
+		t.Fatalf("sourceRefName = %q, want ref name parsed from source ref", status["sourceRefName"])
+	}
+	if status["sourceRefType"] != "tag" {
+		t.Fatalf("sourceRefType = %q, want ref type parsed from source ref", status["sourceRefType"])
+	}
+}
+
+func TestReleaseStatusUsesDeploymentEnvironment(t *testing.T) {
+	clearBuildStatusEnv(t)
+
+	t.Setenv("RELEASE_TAG", "v0.0.8")
+	t.Setenv("DEPLOYED_AT", "2026-04-23T22:30:00Z")
+	t.Setenv("DEPLOYED_SOURCE_COMMIT", "e3cdcad2cf7de3b9e510efc58856086406004718")
+	t.Setenv("DEPLOYED_SOURCE_REF", "refs/tags/v0.0.8")
+	t.Setenv("BACKEND_IMAGE_REF", "ghcr.io/umple/umpleonline/backend:sha-e3cdcad2cf7de3b9e510efc58856086406004718")
+
+	status := releaseStatus()
+
+	if status["releaseTag"] != "v0.0.8" {
+		t.Fatalf("releaseTag = %q, want release tag", status["releaseTag"])
+	}
+	if status["deployedAt"] != "2026-04-23T22:30:00Z" {
+		t.Fatalf("deployedAt = %q, want deploy timestamp", status["deployedAt"])
+	}
+	if status["sourceCommit"] != "e3cdcad2cf7de3b9e510efc58856086406004718" {
+		t.Fatalf("sourceCommit = %q, want deployed source commit", status["sourceCommit"])
+	}
+	if status["sourceRef"] != "refs/tags/v0.0.8" {
+		t.Fatalf("sourceRef = %q, want deployed source ref", status["sourceRef"])
+	}
+	if status["backendImage"] != "ghcr.io/umple/umpleonline/backend:sha-e3cdcad2cf7de3b9e510efc58856086406004718" {
+		t.Fatalf("backendImage = %q, want backend image", status["backendImage"])
+	}
+}
+
+func clearBuildStatusEnv(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{
+		"GIT_COMMIT",
+		"GIT_BRANCH",
+		"GITHUB_SHA",
+		"GITHUB_REF",
+		"GITHUB_REF_NAME",
+		"BUILD_TIME",
+		"SOURCE_COMMIT",
+		"SOURCE_REF",
+		"SOURCE_REF_NAME",
+		"SOURCE_REF_TYPE",
+		"DEPLOYED_AT",
+		"DEPLOYED_SOURCE_COMMIT",
+		"DEPLOYED_SOURCE_REF",
+		"RELEASE_TAG",
+		"IMAGE_TAG",
+		"BACKEND_IMAGE_REF",
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,10 @@ services:
       - LSP_PORT=${LSP_PORT:-9999}
       - PORT=${BACKEND_PORT:-3001}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
+      - DEPLOYED_AT=${DEPLOYED_AT:-}
+      - DEPLOYED_SOURCE_COMMIT=${DEPLOYED_SOURCE_COMMIT:-}
+      - DEPLOYED_SOURCE_REF=${DEPLOYED_SOURCE_REF:-}
+      - RELEASE_TAG=${RELEASE_TAG:-}
     depends_on:
       code-exec:
         condition: service_healthy

--- a/docs/operations/prof-server-migration.md
+++ b/docs/operations/prof-server-migration.md
@@ -121,7 +121,7 @@ EOF
 Notes:
 
 - `ALLOWED_ORIGINS` must be the real production origin, not localhost.
-- Leave image variables out. The release script writes `BACKEND_IMAGE`, `FRONTEND_IMAGE`, `CODE_EXEC_IMAGE`, `CODE_RUNNER_IMAGE`, `COLLAB_IMAGE`, `LSP_PROXY_IMAGE`, and `DOCKER_GID` automatically during deploy.
+- Leave image and release metadata variables out. The release script writes `BACKEND_IMAGE`, `FRONTEND_IMAGE`, `CODE_EXEC_IMAGE`, `CODE_RUNNER_IMAGE`, `COLLAB_IMAGE`, `LSP_PROXY_IMAGE`, `DEPLOYED_AT`, `DEPLOYED_SOURCE_COMMIT`, `DEPLOYED_SOURCE_REF`, `RELEASE_TAG`, and `DOCKER_GID` automatically during deploy.
 - Keep `FRONTEND_BIND_HOST=127.0.0.1` unless you intentionally want the container bound publicly.
 
 ### 6. Configure the public entry point

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -291,6 +291,7 @@ export interface StatusResponse {
   generatedAt: string;
   uptimeSeconds: number;
   build: Record<string, unknown>;
+  release?: Record<string, unknown>;
   process: Record<string, unknown>;
   config: Record<string, unknown>;
   dependencies: Array<Record<string, unknown>>;

--- a/frontend/src/pages/status/StatusPage.tsx
+++ b/frontend/src/pages/status/StatusPage.tsx
@@ -111,18 +111,25 @@ function StatusContent({ status }: { status: StatusResponse }) {
   const services = Object.entries(status.services ?? {});
   const legacy = status.legacy ?? {};
   const legacyDocker = asRecord(legacy.docker);
+  const release = status.release ?? {};
+  const releaseLabel = formatValue(release.releaseTag) || shortCommit(status.build?.sourceCommit) || "unknown";
+  const releaseDetail = shortCommit(release.sourceCommit) || shortCommit(status.build?.sourceCommit) || formatValue(status.build?.sourceRefName);
 
   return (
     <div className="flex flex-col gap-4">
       <div className="grid gap-4 lg:grid-cols-3">
         <SummaryCard title="Backend uptime" value={formatDuration(status.uptimeSeconds)} description="Since this backend process started" />
-        <SummaryCard title="Commit" value={formatValue(status.build?.commit)} description={formatValue(status.build?.branch)} />
+        <SummaryCard title="Release" value={releaseLabel} description={releaseDetail} />
         <SummaryCard title="Compiler" value={formatValue(status.umplesync?.alive) === "true" ? "Running" : "Not running"} description={`Port ${formatValue(status.umplesync?.port)}`} />
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-2">
-        <DataCard title="Build" description="Source revision and image metadata">
+      <div className="grid gap-4 xl:grid-cols-3">
+        <DataCard title="Build" description="Source revision baked into the backend image">
           <KeyValueTable data={status.build} />
+        </DataCard>
+
+        <DataCard title="Release" description="Deployment metadata written by the production release flow">
+          <KeyValueTable data={status.release} />
         </DataCard>
 
         <DataCard title="Runtime" description="Backend process and configured service targets">
@@ -358,6 +365,12 @@ function formatValue(value: unknown): string {
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean") return String(value);
   return JSON.stringify(value);
+}
+
+function shortCommit(value: unknown): string {
+  const commit = formatValue(value);
+  if (!commit || commit === "unknown") return "";
+  return commit.length > 12 ? commit.slice(0, 12) : commit;
 }
 
 function formatDate(value: string): string {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-DEPLOY_PATH="${1:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
-BACKEND_IMAGE="${2:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
-FRONTEND_IMAGE="${3:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
-CODE_EXEC_IMAGE="${4:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
-CODE_RUNNER_IMAGE="${5:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
-COLLAB_IMAGE="${6:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
-LSP_PROXY_IMAGE="${7:?Usage: release.sh <deploy-path> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>}"
+USAGE="Usage: release.sh <deploy-path> <release-tag> <source-sha> <backend-image> <frontend-image> <code-exec-image> <code-runner-image> <collab-image> <lsp-proxy-image>"
+
+DEPLOY_PATH="${1:?$USAGE}"
+RELEASE_TAG="${2:?$USAGE}"
+SOURCE_SHA="${3:?$USAGE}"
+BACKEND_IMAGE="${4:?$USAGE}"
+FRONTEND_IMAGE="${5:?$USAGE}"
+CODE_EXEC_IMAGE="${6:?$USAGE}"
+CODE_RUNNER_IMAGE="${7:?$USAGE}"
+COLLAB_IMAGE="${8:?$USAGE}"
+LSP_PROXY_IMAGE="${9:?$USAGE}"
 
 compose() {
   if docker compose version >/dev/null 2>&1; then
@@ -84,6 +88,10 @@ rollback_release() {
   upsert_env "CODE_RUNNER_IMAGE" "$PREVIOUS_CODE_RUNNER_IMAGE" .env
   upsert_env "COLLAB_IMAGE" "$PREVIOUS_COLLAB_IMAGE" .env
   upsert_env "LSP_PROXY_IMAGE" "$PREVIOUS_LSP_PROXY_IMAGE" .env
+  upsert_env "DEPLOYED_AT" "$PREVIOUS_DEPLOYED_AT" .env
+  upsert_env "DEPLOYED_SOURCE_COMMIT" "$PREVIOUS_DEPLOYED_SOURCE_COMMIT" .env
+  upsert_env "DEPLOYED_SOURCE_REF" "$PREVIOUS_DEPLOYED_SOURCE_REF" .env
+  upsert_env "RELEASE_TAG" "$PREVIOUS_RELEASE_TAG" .env
   upsert_env "DOCKER_GID" "$DOCKER_GID" .env
 
   compose -f docker-compose.prod.yml pull || true
@@ -197,6 +205,11 @@ PREVIOUS_CODE_EXEC_IMAGE="$(read_env_value "CODE_EXEC_IMAGE" .env || true)"
 PREVIOUS_CODE_RUNNER_IMAGE="$(read_env_value "CODE_RUNNER_IMAGE" .env || true)"
 PREVIOUS_COLLAB_IMAGE="$(read_env_value "COLLAB_IMAGE" .env || true)"
 PREVIOUS_LSP_PROXY_IMAGE="$(read_env_value "LSP_PROXY_IMAGE" .env || true)"
+PREVIOUS_DEPLOYED_AT="$(read_env_value "DEPLOYED_AT" .env || true)"
+PREVIOUS_DEPLOYED_SOURCE_COMMIT="$(read_env_value "DEPLOYED_SOURCE_COMMIT" .env || true)"
+PREVIOUS_DEPLOYED_SOURCE_REF="$(read_env_value "DEPLOYED_SOURCE_REF" .env || true)"
+PREVIOUS_RELEASE_TAG="$(read_env_value "RELEASE_TAG" .env || true)"
+DEPLOYED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 upsert_env "BACKEND_IMAGE" "$BACKEND_IMAGE" .env
 upsert_env "FRONTEND_IMAGE" "$FRONTEND_IMAGE" .env
@@ -204,9 +217,15 @@ upsert_env "CODE_EXEC_IMAGE" "$CODE_EXEC_IMAGE" .env
 upsert_env "CODE_RUNNER_IMAGE" "$CODE_RUNNER_IMAGE" .env
 upsert_env "COLLAB_IMAGE" "$COLLAB_IMAGE" .env
 upsert_env "LSP_PROXY_IMAGE" "$LSP_PROXY_IMAGE" .env
+upsert_env "DEPLOYED_AT" "$DEPLOYED_AT" .env
+upsert_env "DEPLOYED_SOURCE_COMMIT" "$SOURCE_SHA" .env
+upsert_env "DEPLOYED_SOURCE_REF" "refs/tags/$RELEASE_TAG" .env
+upsert_env "RELEASE_TAG" "$RELEASE_TAG" .env
 upsert_env "DOCKER_GID" "$DOCKER_GID" .env
 
 echo "==> Releasing images:"
+echo "    RELEASE_TAG=$RELEASE_TAG"
+echo "    SOURCE_SHA=$SOURCE_SHA"
 echo "    BACKEND_IMAGE=$BACKEND_IMAGE"
 echo "    FRONTEND_IMAGE=$FRONTEND_IMAGE"
 echo "    CODE_EXEC_IMAGE=$CODE_EXEC_IMAGE"
@@ -214,6 +233,7 @@ echo "    CODE_RUNNER_IMAGE=$CODE_RUNNER_IMAGE"
 echo "    COLLAB_IMAGE=$COLLAB_IMAGE"
 echo "    LSP_PROXY_IMAGE=$LSP_PROXY_IMAGE"
 echo "    DOCKER_GID=$DOCKER_GID"
+echo "    DEPLOYED_AT=$DEPLOYED_AT"
 echo "    BACKEND_PORT=$BACKEND_PORT"
 echo "    FRONTEND_BIND_HOST=$FRONTEND_BIND_HOST"
 echo "    FRONTEND_HOST_PORT=$FRONTEND_HOST_PORT"


### PR DESCRIPTION
## Summary
- bake backend source metadata into published images
- persist release tag, deployed commit, and deploy time during production release
- surface build and release metadata on the status page

## Test plan
- git diff --check
- cd backend && go test ./internal/api/handlers (sandbox blocked Go build cache write)