### PR TITLE
fix(status): restore dashboard ci expectations

### DIFF
--- a/frontend/src/pages/status/StatusPage.tsx
+++ b/frontend/src/pages/status/StatusPage.tsx
@@ -91,7 +91,7 @@ export function StatusPage() {
             </div>
             <div className="flex min-w-0 flex-col gap-1">
               <div className="flex flex-wrap items-center gap-3">
-                <h1 className="text-2xl font-bold tracking-tight text-ink">System Status</h1>
+                <h1 className="text-2xl font-bold tracking-tight text-ink">UmpleOnline Status</h1>
                 {status ? <StatusBadge value={status.status} /> : null}
               </div>
               <p className="text-sm font-medium text-ink-muted">

--- a/frontend/tests/e2e/status.spec.ts
+++ b/frontend/tests/e2e/status.spec.ts
@@ -70,7 +70,7 @@ test.describe('Status dashboard', () => {
     await expect(page.getByTestId('status-release-runtime')).toContainText('http://code-exec:3000')
     await expect(page.getByTestId('status-umplesync')).toContainText('Umple compiler listener ready')
     await expect(page.getByTestId('status-diagnostics')).toContainText('Legacy software')
-    await expect(page.getByTestId('status-diagnostics')).toContainText('umpleonline-backend')
+    await expect(page.getByTestId('status-system-resources')).toContainText('Umpleonline backend')
     await expect(page.locator('.react-resizable-handle')).toHaveCount(0)
     await expect(page.locator('.status-widget-drag-handle')).toHaveCount(0)
   })


### PR DESCRIPTION
## Summary
- Restore the status page accessible heading expected by the smoke test
- Update the Docker stats assertion to follow the new System resources section

## Test plan
- git diff --check
- cd frontend && PATH=/Users/elwin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/elwin/.codex/tmp/arg0/codex-arg0T4LHb5:/Users/elwin/Downloads/google-cloud-sdk/bin:/Users/elwin/.jenv/shims:/Users/elwin/.jenv/shims:/Users/elwin/.jenv/bin:/opt/anaconda3/condabin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.8/bin:/Users/elwin/.npm-global/bin:/Users/elwin/dev/apache-maven-3.9.9/bin:/Library/TeX/texbin:/Users/elwin/.cargo/bin:/Users/elwin/.local/bin:/Applications/Zed.app/Contents/SharedSupport/bin:/Users/elwin/umple/dev-tools:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/Codex.app/Contents/Resources bun run test:e2e tests/e2e/status.spec.ts
- cd frontend && PATH=/Users/elwin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/elwin/.codex/tmp/arg0/codex-arg0T4LHb5:/Users/elwin/Downloads/google-cloud-sdk/bin:/Users/elwin/.jenv/shims:/Users/elwin/.jenv/shims:/Users/elwin/.jenv/bin:/opt/anaconda3/condabin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.8/bin:/Users/elwin/.npm-global/bin:/Users/elwin/dev/apache-maven-3.9.9/bin:/Library/TeX/texbin:/Users/elwin/.cargo/bin:/Users/elwin/.local/bin:/Applications/Zed.app/Contents/SharedSupport/bin:/Users/elwin/umple/dev-tools:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/Codex.app/Contents/Resources bun run build