### PR TITLE
fix(ci): refresh frontend alpine packages

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -124,6 +124,8 @@ jobs:
             org.opencontainers.image.created=${{ steps.meta.outputs.created }}
             org.opencontainers.image.vendor=University of Ottawa
             org.opencontainers.image.description=UmpleOnline frontend
+          build-args: |
+            APK_SECURITY_REFRESH=${{ steps.meta.outputs.created }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
           sbom: true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,8 @@ COPY . .
 RUN bun run build
 
 FROM nginx:1.29.6-alpine
-RUN apk upgrade --no-cache
+ARG APK_SECURITY_REFRESH
+RUN echo "Refreshing Alpine packages at ${APK_SECURITY_REFRESH}" && apk upgrade --no-cache
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 EXPOSE 80


### PR DESCRIPTION
## Summary
- Add a frontend image build arg that changes each publish run to refresh the Alpine package-upgrade layer
- Use that arg in the nginx Alpine stage so fixed OpenSSL packages are pulled instead of stale cached packages

## Test plan
- git diff --check
- Publish Images should rebuild the frontend package refresh layer and rerun Trivy